### PR TITLE
Editors picks index

### DIFF
--- a/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -48,7 +48,8 @@ case class Front(
   imageHeight: Option[Int],
   isImageDisplayed: Option[Boolean],
   priority: Option[String],
-  isHidden: Option[Boolean]
+  isHidden: Option[Boolean],
+  editorsPicksIndex: Option[List[Int]]
 )
 
 object Config {

--- a/src/test/resources/DEV/frontsapi/config/config.json
+++ b/src/test/resources/DEV/frontsapi/config/config.json
@@ -26,10 +26,12 @@
     "lifeandstyle" : {
       "collections" : [ "5011-3940-8793-33a9", "7d2c-a2a3-f7a9-e361", "f09a-00ea-81c0-6a01", "9ff3-334c-b065-e792", "05d7-f9f9-c7f9-1a0b", "c671-9122-a336-f9ed" ],
       "title" : "Food, homes and lifestyle news, video and pictures",
-      "description" : "Food, homes and lifestyle news, video and pictures from the Guardian"
+      "description" : "Food, homes and lifestyle news, video and pictures from the Guardian",
+      "editorsPicksIndex": [0, 1]
     },
     "football/germany" : {
-      "collections" : [ "1faa-2704-ed58-6138", "edfa-ba2d-4867-33f0", "e756-9130-93b0-ee2b", "4ecb-4615-76ed-de57" ]
+      "collections" : [ "1faa-2704-ed58-6138", "edfa-ba2d-4867-33f0", "e756-9130-93b0-ee2b", "4ecb-4615-76ed-de57" ],
+        "editorsPicksIndex": [0]
     },
     "football/croatia" : {
       "collections" : [ "2bc1-6217-97ea-9103", "41ef-7d3d-717f-5d0a", "b1d0-502c-c640-f49a", "4ecb-4615-76ed-de57" ]

--- a/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
+++ b/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
@@ -23,6 +23,14 @@ class ConfigSpec extends Specification with ResourcesHelper {
           (front.description must beSome.which(_ == "Latest news, comment and advice on homes, interior design, " +
           "decorating and gardening from the Guardian, the world's leading liberal voice"))
       })
+
+      config.fronts.get("lifeandstyle") must beSome.which({ front =>
+        front.editorsPicksIndex must beSome.which (_ == List(0, 1))
+      })
+
+      config.fronts.get("football/germany") must beSome.which({ front =>
+        front.editorsPicksIndex must beSome.which (_ == List(0))
+      })
     }
   }
 }


### PR DESCRIPTION
We want a front to say what `collection` on itself is considered `editorsPicks`.

We are going to use an `index` instead of a `collectionId` to avoid for when a collection falls out of the path, it would continue to be used.

In the case of a non-existent index, or no value, we will default to the top collection, which is the current behaviour. (This is all going to be in `frontend`)

@stephanfowler @robertberry 