### PR TITLE
Extract some Front logic that was embedded in the FAPI file

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -15,11 +15,7 @@ object FAPI {
   def getFronts()(implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[Set[Front]] = {
     for {
       config <- Response.Async.Right(faciaClient.config)
-    } yield {
-      config.fronts
-        .map { case (id, json) => Front.fromFrontJson(id, json)}
-        .toSet
-    }
+    } yield Front.frontsFromConfig(config)
   }
 
   def frontForPath(path: String)(implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[Front] = {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.models
 
-import com.gu.facia.client.models.FrontJson
+import com.gu.facia.client.models.{ConfigJson, FrontJson}
 
 sealed trait FrontPriority
 object EditorialPriority extends FrontPriority
@@ -55,4 +55,10 @@ object Front {
       getFrontPriority(frontJson),
       frontJson.isHidden.getOrElse(false)
     )
+
+  def frontsFromConfig(configJson: ConfigJson): Set[Front] = {
+    configJson.fronts
+      .map { case (id, json) => Front.fromFrontJson(id, json)}
+      .toSet
+  }
 }


### PR DESCRIPTION
This allows Mobile to use the logic without duplicating it and improves testability.