### PR TITLE
Add TestContentApiClient

### DIFF
--- a/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
+++ b/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
@@ -4,8 +4,17 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
 
+private case class TestContentApiClient(override val apiKey: String, override val targetUrl: String) extends GuardianContentClient(apiKey)
+
 trait IntegrationTestConfig extends ExecutionContext {
-  implicit val capiClient = new GuardianContentClient(apiKey = scala.sys.env.getOrElse("CONTENT_API_KEY", ""))
+  val apiKey: String = scala.sys.env.getOrElse("CONTENT_API_KEY", "")
+  val targetUrl: Option[String] = scala.sys.env.get("FACIA_CLIENT_TARGET_URL")
+
+  implicit val capiClient: GuardianContentClient =
+    targetUrl.fold(ifEmpty = new GuardianContentClient(apiKey)){ targetUrl =>
+      new TestContentApiClient(
+        apiKey,
+        targetUrl)}
 
   private val amazonS3Client = new AmazonS3Client()
   implicit val apiClient: ApiClient = ApiClient("aws-frontend-store", "DEV", AmazonSdkS3Client(amazonS3Client))


### PR DESCRIPTION
This is to allow overriding of targetUrl from environment variables.

It's only for `IntegrationTestConfig`.

@robertberry @adamnfish 