### PR TITLE
Reduce parallelism to prevent AWS SDK failures

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -52,7 +52,7 @@ object FAPI {
       configJson <- Response.Async.Right(faciaClient.config)
       frontJson <- Response.fromOption(configJson.fronts.get(frontId), NotFound(s"No front found for $frontId"))
       collectionIds = frontJson.collections
-      collectionsJsons <- Response.Async.Right(Future.traverse(collectionIds)(faciaClient.collection))
+      collectionsJsons <- Response.Async.Right(Future.sequence(collectionIds.map(faciaClient.collection)))
       collectionConfigJsons <- Response.traverse(
         collectionIds.map(id => Response.fromOption(configJson.collections.get(id), NotFound(s"Collection config not found for $id")))
       )


### PR DESCRIPTION
This fixes failures in our integration tests. With these calls made in parallel we consistently (ish) get 404s from the S3 calls. By swapping the concurrent (traversed) calls over to serial ones (sequence), these problems go away. The downside is that calls to retrieve collections will take much longer.

@robertberry, @janua is there a better way you can think of with some batching / configuration of the AWS SDK?
