### PR TITLE
Added a proper recover fn - old recover was mis-named and has been fixed

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
@@ -19,8 +19,12 @@ case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
     asFuture.map(_.fold(failure, success))
   }
 
-  def recover(pf: ApiError => ApiError)(implicit ec: ExecutionContext): Response[A] = Response {
+  def mapError(pf: ApiError => ApiError)(implicit ec: ExecutionContext): Response[A] = Response {
     fold(err => Left(pf(err)), Right(_))
+  }
+
+  def recover(pf: ApiError => A)(implicit ec: ExecutionContext): Response[A] = Response {
+    fold(err => Right(pf(err)), Right(_))
   }
 
   def asFuture(implicit ec: ExecutionContext) = {

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -32,7 +32,7 @@ object ContentApi {
   }
 
   def getHydrateResponse(client: ContentApiClientLogic, searchQueries: Seq[SearchQuery])(implicit ec: ExecutionContext): Response[Seq[SearchResponse]] = {
-    Response.Async.Right(Future.traverse(searchQueries)(client.getResponse)) recover { err =>
+    Response.Async.Right(Future.traverse(searchQueries)(client.getResponse)) mapError { err =>
       CapiError(s"Failed to hydrate content ${err.message}", err.cause)
     }
   }
@@ -71,11 +71,11 @@ object ContentApi {
   def getBackfillResponse(client: ContentApiClientLogic, query: Either[ItemQuery, SearchQuery])
                          (implicit ec: ExecutionContext): Either[Response[ItemResponse], Response[SearchResponse]] = {
     query.right.map { itemQuery =>
-      Response.Async.Right(client.getResponse(itemQuery)) recover { err =>
+      Response.Async.Right(client.getResponse(itemQuery)) mapError { err =>
         CapiError(s"Failed to get backfill response ${err.message}", err.cause)
       }
     }.left.map { searchQuery =>
-      Response.Async.Right(client.getResponse(searchQuery)) recover { err =>
+      Response.Async.Right(client.getResponse(searchQuery)) mapError { err =>
         CapiError(s"Failed to get backfill response ${err.message}", err.cause)
       }
     }


### PR DESCRIPTION
Recover now exists to provide an alternative to a failure. The old recover has been named mapError, since that's actually what it does (it's actually analogous to Either's `.left.map`).