### PR TITLE
Fix Sonatype stuff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,6 @@ val sonatypeReleaseSettings = releaseSettings ++ sonatypeSettings ++ Seq(
       action = { state =>
         val extracted = Project.extract(state)
         val ref = extracted.get(Keys.thisProjectRef)
-
         extracted.runAggregated(PgpKeys.publishSigned in Global in ref, state)
       },
       enableCrossBuild = true

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15"
+version in ThisBuild := "0.16-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15-SNAPSHOT"
+version in ThisBuild := "0.15"


### PR DESCRIPTION
Makes it so you can release either client ... 

Although I'm not sure of the best way to manage the version upping and tagging (as it does it for each subproject, when really you want to do a release for each, but only up the version once). I've copied @steppenwells for this, maybe he has an idea ... 