### PR TITLE
Snaps

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -1,8 +1,9 @@
 package com.gu.facia.api
 
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.facia.api.contentapi.{LatestSnapsRequest, ContentApi}
+import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
+import com.gu.facia.api.contentapi.{ContentApi, LatestSnapsRequest}
 import com.gu.facia.api.models._
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.TrailMetaData
@@ -64,26 +65,36 @@ object FAPI {
     }
   }
 
-  def collectionContent(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+  private def getContentForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+                                   (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[Set[Content]] = {
     val itemIdsForRequest = Collection.liveIdsWithoutSnaps(collection)
-
-    val latestSnapsRequest: LatestSnapsRequest = Collection.latestSnapsRequestFor(collection)
-
     ContentApi.buildHydrateQueries(capiClient, itemIdsForRequest, adjustSearchQuery) match {
       case Success(hydrateQueries) =>
         for {
           hydrateResponses <- ContentApi.getHydrateResponse(capiClient, hydrateQueries)
-          snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsRequest)
-          content = ContentApi.itemsFromSearchResponses(hydrateResponses)
-        } yield {
-          Collection.liveContent(collection, content, snapContent)
-        }
-
+          content = ContentApi.itemsFromSearchResponses(hydrateResponses)}
+        yield content
       case Failure(error) =>
-        Response.Left(UrlConstructError(error.getMessage, Some(error)))
-    }
+        Response.Left(UrlConstructError(error.getMessage, Some(error)))}}
+
+  private def getLatestSnapContentForCollection(collection: Collection)
+                      (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
+    val latestSnapsRequest: LatestSnapsRequest = Collection.latestSnapsRequestFor(collection)
+    for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsRequest))
+      yield snapContent}
+
+  def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+                                (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    for(setOfContent <- getContentForCollection(collection, adjustSearchQuery))
+      yield Collection.liveContent(collection, setOfContent)
   }
+
+  def collectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+                                   (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    for {
+      setOfContent <- getContentForCollection(collection, adjustSearchQuery)
+      snapContent <- getLatestSnapContentForCollection(collection)}
+    yield Collection.liveContent(collection, setOfContent, snapContent)}
 
   /**
    * Fetches content for the given backfill query. The query can be manipulated for different

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -65,7 +65,7 @@ object FAPI {
   }
 
   def collectionContent(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[CuratedContent]] = {
+                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     val itemIdsForRequest = collection.live.filterNot(_.isSnap).map(_.id)
 
     ContentApi.buildHydrateQueries(capiClient, itemIdsForRequest, adjustSearchQuery) match {

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -77,10 +77,10 @@ object FAPI {
       case Failure(error) =>
         Response.Left(UrlConstructError(error.getMessage, Some(error)))}}
 
-  private def getLatestSnapContentForCollection(collection: Collection)
+  private def getLatestSnapContentForCollection(collection: Collection, adjustItemQuery: AdjustItemQuery)
                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
     val latestSnapsRequest: LatestSnapsRequest = Collection.latestSnapsRequestFor(collection)
-    for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsRequest))
+    for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsRequest, adjustItemQuery))
       yield snapContent}
 
   def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
@@ -89,11 +89,11 @@ object FAPI {
       yield Collection.liveContent(collection, setOfContent)
   }
 
-  def collectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+  def collectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
                                    (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     for {
       setOfContent <- getContentForCollection(collection, adjustSearchQuery)
-      snapContent <- getLatestSnapContentForCollection(collection)}
+      snapContent <- getLatestSnapContentForCollection(collection, adjustSnapItemQuery)}
     yield Collection.liveContent(collection, setOfContent, snapContent)}
 
   /**

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -78,10 +78,10 @@ object FAPI {
       case Success(hydrateQueries) =>
         for {
           hydrateResponses <- ContentApi.getHydrateResponse(capiClient, hydrateQueries)
-          snapResponses <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsForRequest)
-          content = ContentApi.itemsFromSearchResponses(hydrateResponses) ++ snapResponses
+          snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, latestSnapsForRequest)
+          content = ContentApi.itemsFromSearchResponses(hydrateResponses)
         } yield {
-          Collection.liveContent(collection, content)
+          Collection.liveContent(collection, content, snapContent)
         }
 
       case Failure(error) =>

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -99,10 +99,10 @@ object ContentApi {
     }
   }
 
-  def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnapsRequest: LatestSnapsRequest)
+  def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnapsRequest: LatestSnapsRequest, adjustItemQuery: AdjustItemQuery)
                                   (implicit ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
     def itemQueryFromSnapUri(uri: String): ItemQuery =
-      capiClient.item(uri).pageSize(1).showFields("internalContentCode")
+      adjustItemQuery(capiClient.item(uri).pageSize(1).showFields("internalContentCode"))
 
     Response.Async.Right(
       Future.traverse(latestSnapsRequest.snaps) { case (id, uri) =>

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -9,6 +9,8 @@ import com.gu.facia.api.{CapiError, Response}
 import scala.concurrent.{Future, ExecutionContext}
 import scala.util.Try
 
+case class LatestSnapsRequest(snaps: Map[String, String])
+
 object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery
   type AdjustItemQuery = ItemQuery => ItemQuery
@@ -97,13 +99,13 @@ object ContentApi {
     }
   }
 
-  def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnaps: Map[String, String])
+  def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnapsRequest: LatestSnapsRequest)
                                   (implicit ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
     def itemQueryFromSnapUri(uri: String): ItemQuery =
       capiClient.item(uri).pageSize(1).showFields("internalContentCode")
 
     Response.Async.Right(
-      Future.traverse(latestSnaps) { case (id, uri) =>
+      Future.traverse(latestSnapsRequest.snaps) { case (id, uri) =>
         capiClient.getResponse(itemQueryFromSnapUri(uri))
           .map(_.results.headOption).map(id -> _)
       }.map(_.toMap))

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -98,14 +98,14 @@ object ContentApi {
   }
 
   def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnaps: Map[String, String])
-                                  (implicit ec: ExecutionContext): Response[Set[Content]] = {
+                                  (implicit ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
     def itemQueryFromSnapUri(uri: String): ItemQuery =
-      capiClient.item(uri).pageSize(1)
+      capiClient.item(uri).pageSize(1).showFields("internalContentCode")
 
     Response.Async.Right(
       Future.traverse(latestSnaps) { case (id, uri) =>
         capiClient.getResponse(itemQueryFromSnapUri(uri))
-          .map(_.results.headOption)
-      }.map(_.toList.flatten.toSet))
+          .map(_.results.headOption).map(id -> _)
+      }.map(_.toMap))
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -50,7 +50,6 @@ object Collection {
     // note that this does not currently deal with e.g. snaps
     val collectionConfig = CollectionConfig.fromCollection(collection)
     collection.live.flatMap { trail =>
-      val contentCodeUrl = trail.id
       content.find(c => trail.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code")))).map { content =>
         FaciaContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig)
       }.orElse{ Snap.maybeFromTrail(trail) }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -45,7 +45,7 @@ object Collection {
     )
   }
 
-  def liveContent(collection: Collection, content: Set[Content]): List[CuratedContent] = {
+  def liveContent(collection: Collection, content: Set[Content]): List[FaciaContent] = {
     // if content is not in the set it was most likely filtered out by the CAPI query, so exclude it
     // note that this does not currently deal with e.g. snaps
     val collectionConfig = CollectionConfig.fromCollection(collection)
@@ -53,7 +53,7 @@ object Collection {
       val contentCodeUrl = trail.id
       content.find(c => trail.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code")))).map { content =>
         FaciaContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig)
-      }
+      }.orElse{ Snap.maybeFromTrail(trail) }
     }
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -1,6 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
+import com.gu.facia.api.contentapi.LatestSnapsRequest
 import com.gu.facia.api.utils.IntegerString
 import com.gu.facia.client.models.{Trail, CollectionJson}
 import org.joda.time.DateTime
@@ -64,6 +65,13 @@ object Collection {
 
   def liveIdsWithoutSnaps(collection: Collection): List[String] =
     collection.live.filterNot(_.isSnap).map(_.id)
+
+  def latestSnapsRequestFor(collection: Collection): LatestSnapsRequest =
+    LatestSnapsRequest(
+      collection.live
+      .filter(_.isSnap)
+      .filter(_.safeMeta.snapType == Some("latest"))
+      .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri)).toMap)
 }
 
 case class Group(get: Int)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -38,7 +38,8 @@ object Snap {
     case Some("link") =>
       Option(LinkSnap(
         trail.id,
-        trail.safeMeta.snapUri))
+        trail.safeMeta.snapUri,
+        trail.safeMeta.snapCss))
     case Some("latest") =>
       Option(LatestSnap)
     case _ => None
@@ -48,7 +49,8 @@ object Snap {
 sealed trait Snap extends FaciaContent
 case class LinkSnap(
   id: String,
-  snapUri: Option[String]) extends Snap
+  snapUri: Option[String],
+  snapCss: Option[String]) extends Snap
 
 object LatestSnap extends Snap
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -57,32 +57,6 @@ case class LinkSnap(
   snapUri: Option[String],
   snapCss: Option[String]) extends Snap
 
-object LinkSnap {
-  def unapply(trail: Trail): Option[LinkSnap] =
-    trail.safeMeta.snapType match {
-      case Some("link") =>
-        Option(LinkSnap(
-          trail.id,
-          trail.safeMeta.snapUri,
-          trail.safeMeta.snapCss))
-      case _ => None
-    }
-}
-
-object LatestSnap {
-  //def contentFromSnapUri(uri: String): Content =
-
-  def unapply(trail: Trail): Option[LinkSnap] =
-    trail.safeMeta.snapType match {
-      case Some("link") =>
-        Option(LinkSnap(
-          trail.id,
-          trail.safeMeta.snapUri,
-          trail.safeMeta.snapCss))
-      case _ => None
-    }
-}
-
 case class LatestSnap(
   id: String,
   snapUri: Option[String],

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -32,8 +32,26 @@ object ImageCutout {
 }
 
 sealed trait FaciaContent
-object Snap extends FaciaContent
-object SnapLatest extends FaciaContent
+
+object Snap {
+  def maybeFromTrail(trail: Trail): Option[Snap] = trail.safeMeta.snapType match {
+    case Some("link") =>
+      Option(LinkSnap(
+        trail.id,
+        trail.safeMeta.snapUri))
+    case Some("latest") =>
+      Option(LatestSnap)
+    case _ => None
+  }
+}
+
+sealed trait Snap extends FaciaContent
+case class LinkSnap(
+  id: String,
+  snapUri: Option[String]) extends Snap
+
+object LatestSnap extends Snap
+
 case class CuratedContent(
   content: Content,
   headline: Option[String],

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -41,7 +41,12 @@ object Snap {
         trail.safeMeta.snapUri,
         trail.safeMeta.snapCss))
     case Some("latest") =>
-      Option(LatestSnap)
+      Option(LatestSnap(
+        trail.id,
+        trail.safeMeta.snapUri,
+        trail.safeMeta.snapCss,
+        None
+      ))
     case _ => None
   }
 }
@@ -52,7 +57,16 @@ case class LinkSnap(
   snapUri: Option[String],
   snapCss: Option[String]) extends Snap
 
-object LatestSnap extends Snap
+object LatestSnap {
+  //def contentFromSnapUri(uri: String): Content =
+
+}
+
+case class LatestSnap(
+  id: String,
+  snapUri: Option[String],
+  snapCss: Option[String],
+  latestContent: Option[Content]) extends Snap
 
 case class CuratedContent(
   content: Content,

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -57,9 +57,30 @@ case class LinkSnap(
   snapUri: Option[String],
   snapCss: Option[String]) extends Snap
 
+object LinkSnap {
+  def unapply(trail: Trail): Option[LinkSnap] =
+    trail.safeMeta.snapType match {
+      case Some("link") =>
+        Option(LinkSnap(
+          trail.id,
+          trail.safeMeta.snapUri,
+          trail.safeMeta.snapCss))
+      case _ => None
+    }
+}
+
 object LatestSnap {
   //def contentFromSnapUri(uri: String): Content =
 
+  def unapply(trail: Trail): Option[LinkSnap] =
+    trail.safeMeta.snapType match {
+      case Some("link") =>
+        Option(LinkSnap(
+          trail.id,
+          trail.safeMeta.snapUri,
+          trail.safeMeta.snapCss))
+      case _ => None
+    }
 }
 
 case class LatestSnap(

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -2,13 +2,15 @@ package com.gu.facia.api.integration
 
 import com.gu.facia.api.FAPI
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
-import com.gu.facia.api.models.{CuratedContent, Collection}
+import com.gu.facia.api.models.{LatestSnap, CollectionConfig, CuratedContent, Collection}
 import com.gu.facia.api.utils.SectionKicker
+import com.gu.facia.client.models.{CollectionConfigJson, CollectionJson, TrailMetaData, Trail}
 import lib.IntegrationTestConfig
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FreeSpec, OptionValues, ShouldMatchers}
+import play.api.libs.json.JsString
 
 class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures with OptionValues with IntegrationTestConfig {
   implicit val patience = PatienceConfig(Span(2, Seconds), Span(50, Millis))
@@ -72,6 +74,64 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
           case _ => None
         }.head.content.tags.exists(_.`type` == "tone") should equal(true)
       )
+    }
+
+    "for snaps" - {
+      def makeLatestTrailFor(id: String, href: String) =
+        Trail(id, 0, Some(TrailMetaData(Map("snapUri" -> JsString(href), "snapType" -> JsString("latest")))))
+      val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
+      val dreamSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
+
+      val normalTrail = Trail("internal-code/content/445034105", 0, None)
+
+      def makeCollectionJson(trails: Trail*) = CollectionJson(
+        live = trails.toList,
+        draft = None,
+        lastUpdated = new DateTime(1),
+        updatedBy = "test",
+        updatedEmail = "test@example.com",
+        displayName = Some("displayName"),
+        href = Some("href"))
+      val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
+
+      "should turn dream snaps into content" in {
+        val collectionJson = makeCollectionJson(dreamSnapOne, dreamSnapTwo)
+        val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
+        val faciaContent = FAPI.collectionContent(collection)
+
+        faciaContent.asFuture.futureValue.fold(
+          err => fail(s"expected to get two dream snaps, got $err", err.cause),
+          {listOfFaciaContent =>
+            val dreamSnaps = listOfFaciaContent.collect{ case ls: LatestSnap => ls}
+            dreamSnaps.length should be (2)
+            dreamSnaps(0).latestContent.fold(fail("dream snap 0 content was empty")){ c =>
+              c.tags.exists(_.id.contains("culture"))
+            }
+            dreamSnaps(1).latestContent.fold(fail("dream snap 1 content was empty")){ c =>
+              c.tags.exists(_.id.contains("technology"))
+            }
+          }
+        )
+      }
+
+      "work with normal content" in {
+        val collectionJson = makeCollectionJson(dreamSnapOne, normalTrail, dreamSnapTwo)
+        val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
+        val faciaContent = FAPI.collectionContent(collection)
+
+        faciaContent.asFuture.futureValue.fold(
+          err => fail(s"expected to get three items, got $err", err.cause),
+          { listOfFaciaContent =>
+            listOfFaciaContent.length should be (3)
+
+            val normalContent = listOfFaciaContent.collect{ case cc: CuratedContent => cc}
+            normalContent.length should be (1)
+            normalContent.apply(0).headline should be ("PM returns from holiday after video shows US reporter beheaded by Briton")
+
+          }
+        )
+      }
+
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -2,7 +2,7 @@ package com.gu.facia.api.integration
 
 import com.gu.facia.api.FAPI
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
-import com.gu.facia.api.models.{Collection, CollectionId}
+import com.gu.facia.api.models.{CuratedContent, Collection, CollectionId}
 import com.gu.facia.api.utils.SectionKicker
 import lib.IntegrationTestConfig
 import org.scalatest.concurrent.ScalaFutures
@@ -66,7 +66,10 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val adjust: AdjustSearchQuery = q => q.showTags("tone")
       FAPI.collectionContent(collection, adjust).asFuture.futureValue.fold(
         err => fail(s"expected collection, got $err", err.cause),
-        curatedContent => curatedContent.head.content.tags.exists(_.`type` == "tone") should equal(true)
+        curatedContent => curatedContent.flatMap{
+          case c: CuratedContent => Some(c)
+          case _ => None
+        }.head.content.tags.exists(_.`type` == "tone") should equal(true)
       )
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -81,7 +81,10 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
         href = Some("href")
       )
       val curatedContent = Collection.liveContent(collection, contents)
-      curatedContent.map(_.content.id) should equal(List("content-id"))
+      curatedContent.flatMap{
+        case c: CuratedContent => Some(c)
+        case _ => None
+      }.map(_.content.id) should equal(List("content-id"))
     }
   }
 }


### PR DESCRIPTION
This introduces Snaps to the Fapi client.

In the ADT, `Snap` hangs off `FaciaContent`, while `LinkSnap` and `LatestSnap` hand off `Snap.

The small changeset:
 - Ability to request content with or without snaps through `collectionContentWithSnaps` and `collectionContentWithoutSnaps`
 - Can adjust the default `LatestSnap` query

The behaviour is that if a `LatestSnap` gets no results from the `ContentAPI`, it will just stay as a `LatestSnap` with its `latestContent` set to `None`.
The same behaviour applies to requesting content for a `Collection` via `...withoutSnaps`; they stay as `LatestSnap` with an empty `latestContent`.

@robertberry
