### PR TITLE
Add previously to CollectionJson

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -103,31 +103,7 @@ case class Trail(
 }
 
 object CollectionJson {
-  implicit val jsonFormatWrites = Json.writes[CollectionJson]
-
-  implicit val jsonFormatReads: Reads[CollectionJson] = (
-    (__ \ 'live).read[List[Trail]] and
-    (__ \ 'draft).readNullable[List[Trail]] and
-    (__ \ 'lastUpdated).read[DateTime](jodaDateTimeFormats) and
-    (__ \ 'updatedBy).read[String] and
-    (__ \ 'updatedEmail).read[String] and
-    (__ \ 'displayName).readNullable[String] and
-    (__ \ 'href).readNullable[String] and
-    Reads.pure[Option[JsValue]](None) and
-    Reads.pure[Option[List[Trail]]](None)
-    )(CollectionJson.apply _)
-
-  val jsonFormatReadsWithDiff: Reads[CollectionJson] = (
-    (__ \ 'live).read[List[Trail]] and
-    (__ \ 'draft).readNullable[List[Trail]] and
-    (__ \ 'lastUpdated).read[DateTime](jodaDateTimeFormats) and
-    (__ \ 'updatedBy).read[String] and
-    (__ \ 'updatedEmail).read[String] and
-    (__ \ 'displayName).readNullable[String] and
-    (__ \ 'href).readNullable[String] and
-    (__ \ 'diff).readNullable[JsValue] and
-    (__ \ 'previously).readNullable[List[Trail]]
-    )(CollectionJson.apply _)
+  implicit val jsonFormatFormat = Json.format[CollectionJson]
 }
 
 case class CollectionJson(
@@ -138,6 +114,5 @@ case class CollectionJson(
   updatedEmail: String,
   displayName: Option[String],
   href: Option[String],
-  diff: Option[JsValue],
   previously: Option[List[Trail]]
 )

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -3,9 +3,6 @@ package com.gu.facia.client.models
 import play.api.libs.json._
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
-import play.api.libs.json._
-import play.api.libs.json.Reads._
-import play.api.libs.functional.syntax._
 
 sealed trait MetaDataCommonFields {
   val json: Map[String, JsValue]
@@ -103,7 +100,7 @@ case class Trail(
 }
 
 object CollectionJson {
-  implicit val jsonFormatFormat = Json.format[CollectionJson]
+  implicit val jsonFormat = Json.format[CollectionJson]
 }
 
 case class CollectionJson(

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -3,6 +3,9 @@ package com.gu.facia.client.models
 import play.api.libs.json._
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
 
 sealed trait MetaDataCommonFields {
   val json: Map[String, JsValue]
@@ -100,7 +103,31 @@ case class Trail(
 }
 
 object CollectionJson {
-  implicit val jsonFormat = Json.format[CollectionJson]
+  implicit val jsonFormatWrites = Json.writes[CollectionJson]
+
+  implicit val jsonFormatReads: Reads[CollectionJson] = (
+    (__ \ 'live).read[List[Trail]] and
+    (__ \ 'draft).readNullable[List[Trail]] and
+    (__ \ 'lastUpdated).read[DateTime](jodaDateTimeFormats) and
+    (__ \ 'updatedBy).read[String] and
+    (__ \ 'updatedEmail).read[String] and
+    (__ \ 'displayName).readNullable[String] and
+    (__ \ 'href).readNullable[String] and
+    Reads.pure[Option[JsValue]](None) and
+    Reads.pure[Option[List[Trail]]](None)
+    )(CollectionJson.apply _)
+
+  val jsonFormatReadsWithDiff: Reads[CollectionJson] = (
+    (__ \ 'live).read[List[Trail]] and
+    (__ \ 'draft).readNullable[List[Trail]] and
+    (__ \ 'lastUpdated).read[DateTime](jodaDateTimeFormats) and
+    (__ \ 'updatedBy).read[String] and
+    (__ \ 'updatedEmail).read[String] and
+    (__ \ 'displayName).readNullable[String] and
+    (__ \ 'href).readNullable[String] and
+    (__ \ 'diff).readNullable[JsValue] and
+    (__ \ 'previously).readNullable[List[Trail]]
+    )(CollectionJson.apply _)
 }
 
 case class CollectionJson(
@@ -110,5 +137,7 @@ case class CollectionJson(
   updatedBy: String,
   updatedEmail: String,
   displayName: Option[String],
-  href: Option[String]
+  href: Option[String],
+  diff: Option[JsValue],
+  previously: Option[List[Trail]]
 )

--- a/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
@@ -78,7 +78,7 @@ class CollectionSpec extends Specification with ResourcesHelper {
           updatedBy = "A test",
           updatedEmail = "a test email",
           displayName = None,
-          href = None)
+          href = None, None, None)
 
         val collectionJsonAsString = Json.stringify(Json.toJson(collectionJson))
         val newCollectionJson = Json.parse(collectionJsonAsString).as[CollectionJson]

--- a/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
@@ -78,7 +78,7 @@ class CollectionSpec extends Specification with ResourcesHelper {
           updatedBy = "A test",
           updatedEmail = "a test email",
           displayName = None,
-          href = None, None, None)
+          href = None, None)
 
         val collectionJsonAsString = Json.stringify(Json.toJson(collectionJson))
         val newCollectionJson = Json.parse(collectionJsonAsString).as[CollectionJson]

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -20,7 +20,6 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     updatedEmail = "test@example.com",
     displayName = Some("displayName"),
     href = Some("href"),
-    None,
     None
   )
   val content = Content(
@@ -82,7 +81,6 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
         updatedEmail = "test@example.com",
         displayName = Some("displayName"),
         href = Some("href"),
-        None,
         None
       )
       val curatedContent = Collection.liveContent(collection, contents)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -19,7 +19,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     updatedBy = "test",
     updatedEmail = "test@example.com",
     displayName = Some("displayName"),
-    href = Some("href")
+    href = Some("href"),
+    None,
+    None
   )
   val content = Content(
     "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
@@ -79,7 +81,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
         updatedBy = "test",
         updatedEmail = "test@example.com",
         displayName = Some("displayName"),
-        href = Some("href")
+        href = Some("href"),
+        None,
+        None
       )
       val curatedContent = Collection.liveContent(collection, contents)
       curatedContent.map(_.content.id) should equal(List("content-id"))


### PR DESCRIPTION
`previously` is used to show what has been removed and previously existed in the collection.

It is generally capped to `20`.

@robertberry @adamnfish 