### PR TITLE
Supporting Items

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -63,6 +63,7 @@ case class SupportingItem(
   meta: Option[SupportingItemMetaData]
 ) {
   val isSnap: Boolean = id.startsWith("snap/")
+  lazy val safeMeta = meta.getOrElse(TrailMetaData.empty)
 }
 
 object TrailMetaData {

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -113,7 +113,7 @@ object FAPI {
       backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
       collectionConfig = CollectionConfig.fromCollection(collection)
     } yield {
-      backfillContent.map(FaciaContent.fromTrailAndContent(_, TrailMetaData.empty, collectionConfig))
+      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, collectionConfig))
     }
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -68,7 +68,7 @@ object FAPI {
   private def getContentForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
                                    (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[Set[Content]] = {
     val itemIdsForRequest = Collection.liveIdsWithoutSnaps(collection)
-    val supportingIdsForRequest = Collection.liveSublinkIdsWithoutSnaps(collection)
+    val supportingIdsForRequest = Collection.liveSupportingIdsWithoutSnaps(collection)
     val allItemIdsForRequest = itemIdsForRequest ::: supportingIdsForRequest
     ContentApi.buildHydrateQueries(capiClient, allItemIdsForRequest, adjustSearchQuery) match {
       case Success(hydrateQueries) =>
@@ -82,8 +82,8 @@ object FAPI {
   private def getLatestSnapContentForCollection(collection: Collection, adjustItemQuery: AdjustItemQuery)
                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
     val latestSnapsRequest: LatestSnapsRequest = Collection.latestSnapsRequestFor(collection)
-    val latestSublinkSnaps: LatestSnapsRequest = Collection.liveSublinkSnaps(collection)
-    val allSnaps = latestSnapsRequest.join(latestSublinkSnaps)
+    val latestSupportingSnaps: LatestSnapsRequest = Collection.liveSupportingSnaps(collection)
+    val allSnaps = latestSnapsRequest.join(latestSupportingSnaps)
     for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, allSnaps, adjustItemQuery))
       yield snapContent}
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -82,8 +82,8 @@ object FAPI {
                       (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
     val latestSnapsRequest: LatestSnapsRequest = Collection.latestSnapsRequestFor(collection)
     val latestSublinkSnaps: LatestSnapsRequest = Collection.liveSublinkSnaps(collection)
-    val snaps = LatestSnapsRequest(latestSnapsRequest.snaps ++ latestSublinkSnaps.snaps)
-    for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, snaps, adjustItemQuery))
+    val allSnaps = latestSnapsRequest.join(latestSublinkSnaps)
+    for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, allSnaps, adjustItemQuery))
       yield snapContent}
 
   def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -69,7 +69,8 @@ object FAPI {
                                    (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[Set[Content]] = {
     val itemIdsForRequest = Collection.liveIdsWithoutSnaps(collection)
     val supportingIdsForRequest = Collection.liveSublinkIdsWithoutSnaps(collection)
-    ContentApi.buildHydrateQueries(capiClient, itemIdsForRequest ::: supportingIdsForRequest, adjustSearchQuery) match {
+    val allItemIdsForRequest = itemIdsForRequest ::: supportingIdsForRequest
+    ContentApi.buildHydrateQueries(capiClient, allItemIdsForRequest, adjustSearchQuery) match {
       case Success(hydrateQueries) =>
         for {
           hydrateResponses <- ContentApi.getHydrateResponse(capiClient, hydrateQueries)

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -9,7 +9,9 @@ import com.gu.facia.api.{CapiError, Response}
 import scala.concurrent.{Future, ExecutionContext}
 import scala.util.Try
 
-case class LatestSnapsRequest(snaps: Map[String, String])
+case class LatestSnapsRequest(snaps: Map[String, String]) {
+  def join(other: LatestSnapsRequest): LatestSnapsRequest = this.copy(snaps = this.snaps ++ other.snaps)
+}
 
 object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -55,25 +55,27 @@ object Collection {
     val collectionConfig = CollectionConfig.fromCollection(collection)
 
     def resolveTrail(trail: Trail): Option[FaciaContent] = {
-      content.find(c => trail.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code")))).map { content =>
+      content.find(c => trail.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code"))))
+        .map { content =>
         trail.safeMeta.supporting
           .map(_.flatMap(resolveSupportingContent))
           .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, supportingItems, collectionConfig))
-          .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig))
-      }.orElse{
-        snapContent.find{case (id, _) => trail.id == id}
-          .map(c => LatestSnap(trail.id, trail.safeMeta.snapUri, trail.safeMeta.snapCss, c._2))
-      }.orElse{ Snap.maybeFromTrail(trail) }
-    }
+          .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig))}
+        .orElse {
+          snapContent
+            .find{case (id, _) => trail.id == id}
+            .map(c => LatestSnap(trail.id, trail.safeMeta.snapUri, trail.safeMeta.snapCss, c._2))}
+        .orElse{ Snap.maybeFromTrail(trail)}}
 
     def resolveSupportingContent(supportingItem: SupportingItem): Option[FaciaContent] = {
-      content.find(c => supportingItem.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code")))).map { content =>
-        SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, collectionConfig)
-      }.orElse{
-        snapContent.find{case (id, _) => supportingItem.id == id}
-          .map(c => LatestSnap(supportingItem.id, supportingItem.safeMeta.snapUri, supportingItem.safeMeta.snapCss, c._2))
-      }.orElse{ Snap.maybeFromSupportingItem(supportingItem) }
-    }
+      content
+        .find(c => supportingItem.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code"))))
+        .map { content => SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, collectionConfig)}
+        .orElse {
+          snapContent
+            .find{case (id, _) => supportingItem.id == id}
+            .map(c => LatestSnap(supportingItem.id, supportingItem.safeMeta.snapUri, supportingItem.safeMeta.snapCss, c._2))}
+        .orElse{ Snap.maybeFromSupportingItem(supportingItem)}}
 
     collection.live.flatMap(resolveTrail)
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -3,7 +3,7 @@ package com.gu.facia.api.models
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.contentapi.LatestSnapsRequest
 import com.gu.facia.api.utils.IntegerString
-import com.gu.facia.client.models.{Trail, CollectionJson}
+import com.gu.facia.client.models.{SupportingItem, Trail, CollectionJson}
 import org.joda.time.DateTime
 
 case class Collection(
@@ -65,6 +65,20 @@ object Collection {
 
   def liveIdsWithoutSnaps(collection: Collection): List[String] =
     collection.live.filterNot(_.isSnap).map(_.id)
+
+  private def allSublinks(collection: Collection): List[SupportingItem] =
+    collection.live.flatMap(_.meta).flatMap(_.supporting).flatten
+
+  def liveSublinkIdsWithoutSnaps(collection: Collection): List[String] =
+    allSublinks(collection).filterNot(_.isSnap).map(_.id)
+
+  def liveSublinkSnaps(collection: Collection): LatestSnapsRequest =
+    LatestSnapsRequest(
+      allSublinks(collection)
+      .filter(_.isSnap)
+      .filter(_.safeMeta.snapType == Some("latest"))
+      .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
+      .toMap)
 
   def latestSnapsRequestFor(collection: Collection): LatestSnapsRequest =
     LatestSnapsRequest(

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -83,15 +83,15 @@ object Collection {
   def liveIdsWithoutSnaps(collection: Collection): List[String] =
     collection.live.filterNot(_.isSnap).map(_.id)
 
-  private def allSublinks(collection: Collection): List[SupportingItem] =
+  private def allSupportingItems(collection: Collection): List[SupportingItem] =
     collection.live.flatMap(_.meta).flatMap(_.supporting).flatten
 
-  def liveSublinkIdsWithoutSnaps(collection: Collection): List[String] =
-    allSublinks(collection).filterNot(_.isSnap).map(_.id)
+  def liveSupportingIdsWithoutSnaps(collection: Collection): List[String] =
+    allSupportingItems(collection).filterNot(_.isSnap).map(_.id)
 
-  def liveSublinkSnaps(collection: Collection): LatestSnapsRequest =
+  def liveSupportingSnaps(collection: Collection): LatestSnapsRequest =
     LatestSnapsRequest(
-      allSublinks(collection)
+      allSupportingItems(collection)
       .filter(_.isSnap)
       .filter(_.safeMeta.snapType == Some("latest"))
       .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -55,7 +55,7 @@ object Collection {
     val collectionConfig = CollectionConfig.fromCollection(collection)
     collection.live.flatMap { trail =>
       content.find(c => trail.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code")))).map { content =>
-        FaciaContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig)
+        CuratedContent.fromTrailAndContent(content, trail.safeMeta, collectionConfig)
       }.orElse{
         snapContent.find{case (id, _) => trail.id == id}
         .map(c => LatestSnap(trail.id, trail.safeMeta.snapUri, trail.safeMeta.snapCss, c._2))

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -49,6 +49,22 @@ object Snap {
       ))
     case _ => None
   }
+
+  def maybeFromSupportingItem(supportingItem: SupportingItem): Option[Snap] = supportingItem.safeMeta.snapType match {
+    case Some("link") =>
+      Option(LinkSnap(
+        supportingItem.id,
+        supportingItem.safeMeta.snapUri,
+        supportingItem.safeMeta.snapCss))
+    case Some("latest") =>
+      Option(LatestSnap(
+        supportingItem.id,
+        supportingItem.safeMeta.snapUri,
+        supportingItem.safeMeta.snapCss,
+        None
+      ))
+    case _ => None
+  }
 }
 
 sealed trait Snap extends FaciaContent
@@ -65,7 +81,7 @@ case class LatestSnap(
 
 case class CuratedContent(
   content: Content,
-  supportingContent: List[SupportingCuratedContent],
+  supportingContent: List[FaciaContent],
   headline: String,
   href: Option[String],
   trailText: Option[String],
@@ -107,7 +123,7 @@ case class SupportingCuratedContent(
 object CuratedContent {
 
   def fromTrailAndContentWithSupporting(content: Content, trailMetaData: TrailMetaData,
-                                        supportingContent: List[SupportingCuratedContent],
+                                        supportingContent: List[FaciaContent],
                                         collectionConfig: CollectionConfig) = {
     val contentFields: Map[String, String] = content.safeFields
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -65,6 +65,7 @@ case class LatestSnap(
 
 case class CuratedContent(
   content: Content,
+  supportingContent: List[SupportingCuratedContent],
   headline: String,
   href: Option[String],
   trailText: Option[String],
@@ -83,13 +84,60 @@ case class CuratedContent(
   showBoostedHeadline: Boolean,
   showQuotedHeadline: Boolean) extends FaciaContent
 
-object FaciaContent {
+case class SupportingCuratedContent(
+  content: Content,
+  headline: String,
+  href: Option[String],
+  trailText: Option[String],
+  group: String,
+  image: Option[Image],
+  isBreaking: Boolean,
+  isBoosted: Boolean,
+  imageHide: Boolean,
+  imageReplace: Boolean,
+  showMainVideo: Boolean,
+  showKickerTag: Boolean,
+  byline: Option[String],
+  showByLine: Boolean,
+  kicker: Option[ItemKicker],
+  imageCutout: Option[ImageCutout],
+  showBoostedHeadline: Boolean,
+  showQuotedHeadline: Boolean) extends FaciaContent
+
+object CuratedContent {
+
+  def fromTrailAndContentWithSupporting(content: Content, trailMetaData: TrailMetaData,
+                                        supportingContent: List[SupportingCuratedContent],
+                                        collectionConfig: CollectionConfig) = {
+    val contentFields: Map[String, String] = content.safeFields
+
+    CuratedContent(
+      content,
+      supportingContent,
+      trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
+      trailMetaData.href.orElse(contentFields.get("href")),
+      trailMetaData.trailText.orElse(contentFields.get("trailText")),
+      trailMetaData.group.getOrElse("0"),
+      Image.fromTrail(trailMetaData),
+      trailMetaData.isBreaking.getOrElse(false),
+      trailMetaData.isBoosted.getOrElse(false),
+      trailMetaData.imageHide.getOrElse(false),
+      trailMetaData.imageReplace.getOrElse(false),
+      trailMetaData.showMainVideo.getOrElse(false),
+      trailMetaData.showKickerTag.getOrElse(false),
+      trailMetaData.byline.orElse(contentFields.get("byline")),
+      trailMetaData.showByline.getOrElse(false),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
+      ImageCutout.fromTrail(trailMetaData),
+      trailMetaData.showBoostedHeadline.getOrElse(false),
+      trailMetaData.showQuotedHeadline.getOrElse(false))}
 
   def fromTrailAndContent(content: Content, trailMetaData: TrailMetaData, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
 
     CuratedContent(
       content,
+      supportingContent = Nil,
       trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
       trailMetaData.href.orElse(contentFields.get("href")),
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
@@ -107,6 +155,30 @@ object FaciaContent {
       ImageCutout.fromTrail(trailMetaData),
       trailMetaData.showBoostedHeadline.getOrElse(false),
       trailMetaData.showQuotedHeadline.getOrElse(false)
-    )
-  }
+    )}
+}
+
+object SupportingCuratedContent {
+  def fromTrailAndContent(content: Content, trailMetaData: TrailMetaData, collectionConfig: CollectionConfig): SupportingCuratedContent = {
+    val contentFields: Map[String, String] = content.safeFields
+
+    SupportingCuratedContent(
+      content,
+      trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
+      trailMetaData.href.orElse(contentFields.get("href")),
+      trailMetaData.trailText.orElse(contentFields.get("trailText")),
+      trailMetaData.group.getOrElse("0"),
+      Image.fromTrail(trailMetaData),
+      trailMetaData.isBreaking.getOrElse(false),
+      trailMetaData.isBoosted.getOrElse(false),
+      trailMetaData.imageHide.getOrElse(false),
+      trailMetaData.imageReplace.getOrElse(false),
+      trailMetaData.showMainVideo.getOrElse(false),
+      trailMetaData.showKickerTag.getOrElse(false),
+      trailMetaData.byline.orElse(contentFields.get("byline")),
+      trailMetaData.showByline.getOrElse(false),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
+      ImageCutout.fromTrail(trailMetaData),
+      trailMetaData.showBoostedHeadline.getOrElse(false),
+      trailMetaData.showQuotedHeadline.getOrElse(false))}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -2,12 +2,12 @@ package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.utils.ItemKicker
-import com.gu.facia.client.models.{Trail, TrailMetaData}
+import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, TrailMetaData}
 
 case class Image(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String)
 
 object Image {
-  def fromTrail(trailMeta: TrailMetaData): Option[Image] =
+  def fromTrail(trailMeta: MetaDataCommonFields): Option[Image] =
     for {
       imageSrc <- trailMeta.imageSrc
       imageSrcWidth <- trailMeta.imageSrcWidth
@@ -22,7 +22,7 @@ case class ImageCutout(
   imageCutoutSrcHeight: String)
 
 object ImageCutout {
-  def fromTrail(trailMeta: TrailMetaData): Option[ImageCutout] =
+  def fromTrail(trailMeta: MetaDataCommonFields): Option[ImageCutout] =
     for {
       imageCutoutSrc <- trailMeta.imageCutoutSrc
       imageCutoutSrcWidth <- trailMeta.imageCutoutSrcWidth
@@ -132,7 +132,7 @@ object CuratedContent {
       trailMetaData.showBoostedHeadline.getOrElse(false),
       trailMetaData.showQuotedHeadline.getOrElse(false))}
 
-  def fromTrailAndContent(content: Content, trailMetaData: TrailMetaData, collectionConfig: CollectionConfig): CuratedContent = {
+  def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
 
     CuratedContent(
@@ -159,7 +159,7 @@ object CuratedContent {
 }
 
 object SupportingCuratedContent {
-  def fromTrailAndContent(content: Content, trailMetaData: TrailMetaData, collectionConfig: CollectionConfig): SupportingCuratedContent = {
+  def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): SupportingCuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
 
     SupportingCuratedContent(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -2,10 +2,10 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.{Content, Tag}
 import com.gu.facia.api.models.CollectionConfig
-import com.gu.facia.client.models.TrailMetaData
+import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 
 object ItemKicker {
-  def fromContentAndTrail(content: Content, trailMeta: TrailMetaData, config: Option[CollectionConfig]): Option[ItemKicker] = {
+  def fromContentAndTrail(content: Content, trailMeta: MetaDataCommonFields, config: Option[CollectionConfig]): Option[ItemKicker] = {
     lazy val maybeTag = content.tags.headOption
     lazy val tagKicker = maybeTag.map(TagKicker.fromTag)
     lazy val sectionKicker = for {
@@ -35,7 +35,7 @@ object ItemKicker {
     }
   }
 
-  private[utils] def tonalKicker(content: Content, trailMeta: TrailMetaData): Option[ItemKicker] = {
+  private[utils] def tonalKicker(content: Content, trailMeta: MetaDataCommonFields): Option[ItemKicker] = {
     def tagsOfType(tagType: String): Seq[Tag] = content.tags.filter(_.`type` == tagType)
     val types: Seq[Tag] = tagsOfType("type")
     val tones: Seq[Tag] = tagsOfType("tone")

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -231,7 +231,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     def makeTrail(id: String) =
       Trail(id, 0, None)
     def makeTrailWithSupporting(id: String, supporting: Trail*) =
-      Trail(id, 0, Some(TrailMetaData(Map("supporting" -> JsArray(Seq(Json.toJson(supporting)))))))
+      Trail(id, 0, Some(TrailMetaData(Map("supporting" -> JsArray(supporting.map(Json.toJson(_)))))))
 
     val supportingTrailOne = makeTrail("internal-code/content/445034105")
     val supportingTrailTwo = makeTrail("internal-code/content/445529464")

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -227,7 +227,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     }
   }
 
-  "SupportingContent" - {
+  "Supporting Items" - {
     def makeTrail(id: String) =
       Trail(id, 0, None)
     def makeTrailWithSupporting(id: String, supporting: Trail*) =
@@ -264,7 +264,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       })
     }
 
-    "should not fill in dream snaps in sublinks" in {
+    "should not fill in dream snaps in supporting items" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJsonSupportingWithDreamSnaps), collectionConfig)
       val faciaContent = FAPI.collectionContentWithoutSnaps(collection)
 
@@ -286,7 +286,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       })
     }
 
-    "should fill in dream snaps in sublinks" in {
+    "should fill in dream snaps in supporting items" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJsonSupportingWithDreamSnaps), collectionConfig)
       val faciaContent = FAPI.collectionContentWithSnaps(collection)
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -276,6 +276,11 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
             c.supportingContent.length should be (5)
+            c.supportingContent.collect{case s: SupportingCuratedContent => s}.length should be (2)
+            val latestSnaps = c.supportingContent.collect{case l: LatestSnap => l}
+            latestSnaps.length should be (2)
+            latestSnaps.forall(_.latestContent.isDefined == false) should be (true)
+            c.supportingContent.collect{case l: LinkSnap => l}.length should be (1)
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })
@@ -283,7 +288,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "should fill in dream snaps in sublinks" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJsonSupportingWithDreamSnaps), collectionConfig)
-      val faciaContent = FAPI.collectionContentWithoutSnaps(collection)
+      val faciaContent = FAPI.collectionContentWithSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
       err => fail(s"expected to get one item with supporting and dream snaps, got $err", err.cause),
@@ -293,6 +298,11 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
             c.supportingContent.length should be (5)
+            c.supportingContent.collect{case s: SupportingCuratedContent => s}.length should be (2)
+            val latestSnaps = c.supportingContent.collect{case l: LatestSnap => l}
+            latestSnaps.length should be (2)
+            latestSnaps.forall(_.latestContent.isDefined) should be (true)
+            c.supportingContent.collect{case l: LinkSnap => l}.length should be (1)
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -258,7 +258,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
-            c.supportingContent should be (2)
+            c.supportingContent.length should be (2)
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })
@@ -275,7 +275,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
-            c.supportingContent should be (2)
+            c.supportingContent.length should be (5)
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })
@@ -292,7 +292,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
-            c.supportingContent should be (5)
+            c.supportingContent.length should be (5)
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -298,11 +298,20 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         listOfFaciaContent.apply(0) match {
           case c: CuratedContent =>
             c.supportingContent.length should be (5)
-            c.supportingContent.collect{case s: SupportingCuratedContent => s}.length should be (2)
+            val supportingContent = c.supportingContent.collect{case s: SupportingCuratedContent => s}
+            supportingContent.length should be (2)
             val latestSnaps = c.supportingContent.collect{case l: LatestSnap => l}
             latestSnaps.length should be (2)
             latestSnaps.forall(_.latestContent.isDefined) should be (true)
-            c.supportingContent.collect{case l: LinkSnap => l}.length should be (1)
+            val linkSnaps = c.supportingContent.collect{case l: LinkSnap => l}
+            linkSnaps.length should be (1)
+
+            c.supportingContent(0).asInstanceOf[SupportingCuratedContent].headline should be ("PM returns from holiday after video shows US reporter beheaded by Briton")
+            c.supportingContent(1).asInstanceOf[LatestSnap].latestContent.get.sectionId should be (Some("culture"))
+            c.supportingContent(2).asInstanceOf[LatestSnap].latestContent.get.sectionId should be (Some("technology"))
+            c.supportingContent(3).asInstanceOf[SupportingCuratedContent].headline should be ("Inside the 29 August edition")
+            c.supportingContent(4).asInstanceOf[LinkSnap].id should be ("snap/347234723")
+
           case somethingElse => fail(s"expected only CuratedContent, got ${somethingElse.getClass.getName}")
         }
       })

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -24,16 +24,16 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val trailMetaDataWithoutHeadline = TrailMetaData(Map.empty)
 
     "should resolve the headline from TrailMetaData" in {
-      val curatedContent = FaciaContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, collectionConfig)
       curatedContent.headline should be ("trailMetaDataHeadline")
     }
 
     "should resolve the headline from Content fields.headline" in {
-      val curatedContent = FaciaContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
       curatedContent.headline should be ("Content headline")
     }
     "should resolve the headline from Content webTitle" in {
-      val curatedContent = FaciaContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
       curatedContent.headline should be ("contentWithoutFieldHeadlineHeadline")
     }
   }


### PR DESCRIPTION
This adds the requesting of `supporting` items.

When requesting `snaps`, it fills out `dreamsnaps` inside `supporting` items.

@robertberry 