### PR TITLE
Add filter to response

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
@@ -15,7 +15,7 @@ case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
     }
   }
 
-  def filter(f: A => Boolean, orLeft: ApiError = FilteredOut())(implicit ex: ExecutionContext): Response[A] = flatMap { a =>
+  def filter(f: A => Boolean, orLeft: ApiError = FilteredOut)(implicit ex: ExecutionContext): Response[A] = flatMap { a =>
     if(f(a))
       Response.Right(a)
     else
@@ -88,4 +88,7 @@ case class DataError(message: String, cause: Option[Throwable] = None) extends A
 case class CapiError(message: String, cause: Option[Throwable] = None) extends ApiError
 case class HttpError(message: String, cause: Option[Throwable] = None) extends ApiError
 case class UrlConstructError(message: String, cause: Option[Throwable] = None) extends ApiError
-case class FilteredOut(message: String = "Filtered out", cause: Option[Throwable] = None) extends ApiError
+case object FilteredOut extends ApiError {
+  def message = "Filtered out"
+  def cause = None
+}

--- a/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
@@ -15,7 +15,7 @@ case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
     }
   }
 
-  def filter(f: A => Boolean, orLeft: ApiError = FilteredOut)(implicit ex: ExecutionContext): Response[A] = flatMap { a =>
+  def filter(f: A => Boolean, orLeft: ApiError = FilteredOut())(implicit ex: ExecutionContext): Response[A] = flatMap { a =>
     if(f(a))
       Response.Right(a)
     else

--- a/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
@@ -15,6 +15,13 @@ case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
     }
   }
 
+  def filter(f: A => Boolean, orLeft: ApiError = FilteredOut)(implicit ex: ExecutionContext): Response[A] = flatMap { a =>
+    if(f(a))
+      Response.Right(a)
+    else
+      Response.Left(orLeft)
+  }
+
   def fold[B](failure: ApiError => B, success: A => B)(implicit ec: ExecutionContext): Future[B] = {
     asFuture.map(_.fold(failure, success))
   }
@@ -81,3 +88,4 @@ case class DataError(message: String, cause: Option[Throwable] = None) extends A
 case class CapiError(message: String, cause: Option[Throwable] = None) extends ApiError
 case class HttpError(message: String, cause: Option[Throwable] = None) extends ApiError
 case class UrlConstructError(message: String, cause: Option[Throwable] = None) extends ApiError
+case class FilteredOut(message: String = "Filtered out", cause: Option[Throwable] = None) extends ApiError

--- a/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
@@ -1,0 +1,22 @@
+package com.gu.facia.api
+
+import com.gu.facia.api.Response
+import lib.ExecutionContext
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
+import org.scalatest._
+import org.mockito.Mockito._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ResponseTest extends FreeSpec with ShouldMatchers with ScalaFutures {
+
+  "Response.filter" - {
+    "should return the same result if the filter function returns true" in {
+      Response.Right[Int](4).filter(_ == 4).asFuture.futureValue should equal(Right(4))
+    }
+
+    "should return a Left(FilteredOut) if the filter function returns false" in {
+      Response.Right[Int](4).filter(_ == 3).asFuture.futureValue should equal(Left(FilteredOut()))
+    }
+  }
+}

--- a/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
@@ -1,11 +1,7 @@
 package com.gu.facia.api
 
-import com.gu.facia.api.Response
-import lib.ExecutionContext
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
 import org.scalatest._
-import org.mockito.Mockito._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ResponseTest extends FreeSpec with ShouldMatchers with ScalaFutures {

--- a/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
@@ -12,7 +12,7 @@ class ResponseTest extends FreeSpec with ShouldMatchers with ScalaFutures {
     }
 
     "should return a Left(FilteredOut) if the filter function returns false" in {
-      Response.Right[Int](4).filter(_ == 3).asFuture.futureValue should equal(Left(FilteredOut()))
+      Response.Right[Int](4).filter(_ == 3).asFuture.futureValue should equal(Left(FilteredOut))
     }
   }
 }


### PR DESCRIPTION
This adds a filter method which, if unsuccessful, returns a response whose Left is a new ApiError subclass named FilteredOut.