### PR TITLE
Add most-viewed results to the backfill query

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -91,7 +91,9 @@ object ContentApi {
   def backfillContentFromResponse(response: Either[Response[ItemResponse], Response[SearchResponse]])
                                  (implicit ec: ExecutionContext): Response[List[Content]] = {
     response.fold(
-      _.map(itemResponse => itemResponse.editorsPicks ++ itemResponse.results),
+      _.map { itemResponse =>
+          itemResponse.editorsPicks ++ itemResponse.mostViewed ++ itemResponse.results
+        },
       _.map(_.results)
     )
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -103,6 +103,31 @@ class ContentApiTest extends FreeSpec
       val itemResponse = mock[ItemResponse]
       when(itemResponse.results) thenReturn contents
       when(itemResponse.editorsPicks) thenReturn Nil
+      when(itemResponse.mostViewed) thenReturn Nil
+      val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
+      ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
+        err => fail(s"expected contents result, got error $err"),
+        result => result should be(contents)
+      )
+    }
+
+    "includes editors picks in item query backfill" in {
+      val itemResponse = mock[ItemResponse]
+      when(itemResponse.results) thenReturn Nil
+      when(itemResponse.editorsPicks) thenReturn contents
+      when(itemResponse.mostViewed) thenReturn Nil
+      val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
+      ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
+        err => fail(s"expected contents result, got error $err"),
+        result => result should be(contents)
+      )
+    }
+
+    "includes most viewed in item query backfill" in {
+      val itemResponse = mock[ItemResponse]
+      when(itemResponse.results) thenReturn Nil
+      when(itemResponse.editorsPicks) thenReturn Nil
+      when(itemResponse.mostViewed) thenReturn contents
       val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
       ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
         err => fail(s"expected contents result, got error $err"),


### PR DESCRIPTION
This fixes backfill queries for the "most popular" collections.

cc @janua 