### PR TITLE
Add covariance on Response

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/Response.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 
 
-case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
+case class Response[+A] protected (underlying: Future[Either[ApiError, A]]) {
   def map[B](f: A => B)(implicit ec: ExecutionContext): Response[B] =
     flatMap(a => Response.Right(f(a)))
 
@@ -30,7 +30,7 @@ case class Response[A] protected (underlying: Future[Either[ApiError, A]]) {
     fold(err => Left(pf(err)), Right(_))
   }
 
-  def recover(pf: ApiError => A)(implicit ec: ExecutionContext): Response[A] = Response {
+  def recover[A1 >: A](pf: ApiError => A1)(implicit ec: ExecutionContext): Response[A1] = Response {
     fold(err => Right(pf(err)), Right(_))
   }
 


### PR DESCRIPTION
`Response.Right(Nil)` is not compatible with the type `Response[List[T]]`. This fixes that.

@adamnfish 