### PR TITLE
Make debugging backfill results simpler

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -96,7 +96,9 @@ object ContentApi {
       _.map { itemResponse =>
           itemResponse.editorsPicks ++ itemResponse.mostViewed ++ itemResponse.results
         },
-      _.map(_.results)
+      _.map { searchResponse =>
+          searchResponse.results
+        }
     )
   }
 


### PR DESCRIPTION
It's now possible to drop a debug statement on the results in IntelliJ, which makes debugging backfill issues *MUCH MUCH* easier. I've been using this in a publish-local all the time, so it's worth having in the real world as well.