### PR TITLE
Remove Duplication between CollectionConfig and Collection

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -115,9 +115,8 @@ object FAPI {
     val backfillResponse = ContentApi.getBackfillResponse(capiClient, query)
     for {
       backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
-      collectionConfig = CollectionConfig.fromCollection(collection)
     } yield {
-      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, collectionConfig))
+      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, collection.collectionConfig))
     }
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTime
 case class Collection(
   id: String,
   displayName: String,
+  href: Option[String],
   live: List[Trail],
   draft: Option[List[Trail]],
   lastUpdated: Option[DateTime],
@@ -22,6 +23,7 @@ object Collection {
     Collection(
       collectionId,
       collectionJson.flatMap(_.displayName).orElse(collectionConfig.displayName).getOrElse("untitled"),
+      collectionJson.flatMap(_.href).orElse(collectionConfig.href),
       collectionJson.map(_.live).getOrElse(Nil),
       collectionJson.flatMap(_.draft),
       collectionJson.map(_.lastUpdated),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -40,20 +40,4 @@ object CollectionConfig {
       collectionJson.showTimestamps.exists(identity),
       Importance.fromCollectionConfigJson(collectionJson)
     )
-
-  def fromCollection(collection: Collection): CollectionConfig =
-    CollectionConfig(
-      Some(collection.displayName),
-      collection.apiQuery,
-      collection.collectionType,
-      collection.href,
-      collection.groups.map(Group.toGroups),
-      collection.uneditable,
-      collection.showTags,
-      collection.showSections,
-      collection.hideKickers,
-      collection.showDateHeader,
-      collection.showLatestUpdate,
-      collection.importance
-    )
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -16,6 +16,8 @@ case class CollectionConfig(
     hideKickers: Boolean,
     showDateHeader: Boolean,
     showLatestUpdate: Boolean,
+    excludeFromRss: Boolean,
+    showTimestamps: Boolean,
     importance: Importance)
 
 object CollectionConfig {
@@ -34,6 +36,8 @@ object CollectionConfig {
       collectionJson.hideKickers.getOrElse(false),
       collectionJson.showDateHeader.getOrElse(false),
       collectionJson.showLatestUpdate.getOrElse(false),
+      collectionJson.excludeFromRss.exists(identity),
+      collectionJson.showTimestamps.exists(identity),
       Importance.fromCollectionConfigJson(collectionJson)
     )
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -23,6 +23,22 @@ case class CollectionConfig(
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-VI"
 
+  val empty = CollectionConfig(
+    displayName = None,
+    apiQuery = None,
+    collectionType = DefaultCollectionType,
+    href = None,
+    groups = None,
+    uneditable = false,
+    showTags = false,
+    showSections = false,
+    hideKickers = false,
+    showDateHeader = false,
+    showLatestUpdate = false,
+    excludeFromRss = false,
+    showTimestamps = false,
+    importance = DefaultImportance)
+
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
       collectionJson.displayName,
@@ -38,6 +54,5 @@ object CollectionConfig {
       collectionJson.showLatestUpdate.getOrElse(false),
       collectionJson.excludeFromRss.exists(identity),
       collectionJson.showTimestamps.exists(identity),
-      Importance.fromCollectionConfigJson(collectionJson)
-    )
+      Importance.fromCollectionConfigJson(collectionJson))
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -180,17 +180,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       Some(new DateTime(1)),
       Some("updatedBy"),
       Some("updatedBy@example.com"),
-      None,
-      Some("business?edition=uk"),
-      "news/most-popular",
-      None,
-      false,
-      false,
-      false,
-      false,
-      false,
-      false,
-      DefaultImportance
+      CollectionConfig.empty
     )
 
     "can get the backfill for a collection" in {
@@ -203,7 +193,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "collection metadata is resolved on backfill content" in {
       val query = "business?edition=uk"
-      FAPI.backfill(query, collection.copy(showSections = true)).asFuture.futureValue.fold(
+      FAPI.backfill(query, collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true))).asFuture.futureValue.fold(
         err => fail(s"expected backfill results, got $err", err.cause),
         backfillContents => backfillContents.head.kicker.value shouldBe a [SectionKicker]
       )
@@ -212,7 +202,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     "item query can be adjusted" in {
       val query = "business?edition=uk"
       val adjust: AdjustItemQuery = q => q.showTags("all")
-      FAPI.backfill(query, collection.copy(showSections = true), adjustItemQuery = adjust).asFuture.futureValue.fold(
+      FAPI.backfill(query, collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true)), adjustItemQuery = adjust).asFuture.futureValue.fold(
         err => fail(s"expected backfill results, got $err", err.cause),
         backfillContents => backfillContents.head.content.tags.exists(_.id.contains("business")) should equal(true)
       )
@@ -221,7 +211,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     "search query can be adjusted" in {
       val query = "search?tag=sustainable-business/series/finance&use-date=published"
       val adjust: AdjustSearchQuery = q => q.showTags("series")
-      FAPI.backfill(query, collection.copy(showSections = true), adjustSearchQuery = adjust).asFuture.futureValue.fold(
+      FAPI.backfill(query, collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true)), adjustSearchQuery = adjust).asFuture.futureValue.fold(
         err => fail(s"expected backfill results, got $err", err.cause),
         backfillContents => backfillContents.head.content.tags.exists(_.id.contains("sustainable-business/series/finance")) should equal(true)
       )

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -175,6 +175,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     val collection = Collection(
       "uk/business/regular-stories",
       "economy",
+      None,
       Nil,
       None,
       Some(new DateTime(1)),

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -39,6 +39,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       collection should have(
         'id("id"),
         'draft(None),
+        'href(Some("collectionHref")),
         'lastUpdated(Some(new DateTime(1))),
         'updatedBy(Some("test")),
         'updatedEmail(Some("test@example.com")),

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -21,7 +21,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     updatedBy = "test",
     updatedEmail = "test@example.com",
     displayName = Some("displayName"),
-    href = Some("href"),
+    href = Some("collectionHref"),
     None
   )
   val content = Content(
@@ -30,7 +30,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     Nil, None, Nil, None
   )
   val contents = Set(content)
-  val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
+  val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(href = Some("collectionConfigHref")))
 
 
   "fromCollectionJson" - {
@@ -42,8 +42,11 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
         'lastUpdated(Some(new DateTime(1))),
         'updatedBy(Some("test")),
         'updatedEmail(Some("test@example.com")),
-        'displayName("displayName"),
-        'href(Some("href"))
+        'displayName("displayName")
+      )
+
+      collection.collectionConfig should have (
+        'href(Some("collectionConfigHref"))
       )
     }
   }
@@ -160,7 +163,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
 
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfigWithImportance)
 
-      collection.importance should be (Critical)
+      collection.collectionConfig.importance should be (Critical)
     }
   }
 }


### PR DESCRIPTION
#### What
This removes some of the repetition between `CollectionConfig` and `Collection`.

Instead, `Collection` now carries a `CollectionConfig`.

I have left the duplication for `href` and `displayName` until we completely remove these fields out of the `CollectionJson` and `Collection`.

#### Why
Duplication is too confusing and new fields don't get naturally carried unless explicit.

@robertberry @adamnfish 