### PR TITLE
Image Cutout Logic

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -25,11 +25,16 @@ object ImageCutout {
   val empty = ImageCutout(imageCutoutReplace = false, None, None, None)
 
   def fromTrail(trailMeta: MetaDataCommonFields): ImageCutout =
-    ImageCutout(
-      trailMeta.imageCutoutReplace.getOrElse(false),
-      trailMeta.imageCutoutSrc,
-      trailMeta.imageCutoutSrcWidth,
-      trailMeta.imageCutoutSrcHeight)
+    (for {
+      src <- trailMeta.imageCutoutSrc
+      width <- trailMeta.imageCutoutSrcWidth
+      height <- trailMeta.imageCutoutSrcHeight
+    } yield ImageCutout(
+              trailMeta.imageCutoutReplace.getOrElse(false),
+              Option(src),
+              Option(width),
+              Option(height)))
+    .getOrElse(ImageCutout.empty.copy(imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity)))
 }
 
 sealed trait FaciaContent

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -17,18 +17,17 @@ object Image {
 
 case class ImageCutout(
   imageCutoutReplace: Boolean,
-  imageCutoutSrc: String,
-  imageCutoutSrcWidth: String,
-  imageCutoutSrcHeight: String)
+  imageCutoutSrc: Option[String],
+  imageCutoutSrcWidth: Option[String],
+  imageCutoutSrcHeight: Option[String])
 
 object ImageCutout {
-  def fromTrail(trailMeta: MetaDataCommonFields): Option[ImageCutout] =
-    for {
-      imageCutoutSrc <- trailMeta.imageCutoutSrc
-      imageCutoutSrcWidth <- trailMeta.imageCutoutSrcWidth
-      imageCutoutSrcHeight <- trailMeta.imageCutoutSrcHeight
-    } yield ImageCutout(trailMeta.imageCutoutReplace.getOrElse(false),
-      imageCutoutSrc, imageCutoutSrcWidth, imageCutoutSrcHeight)
+  def fromTrail(trailMeta: MetaDataCommonFields): ImageCutout =
+    ImageCutout(
+      trailMeta.imageCutoutReplace.getOrElse(false),
+      trailMeta.imageCutoutSrc,
+      trailMeta.imageCutoutSrcWidth,
+      trailMeta.imageCutoutSrcHeight)
 }
 
 sealed trait FaciaContent
@@ -96,7 +95,7 @@ case class CuratedContent(
   byline: Option[String],
   showByLine: Boolean,
   kicker: Option[ItemKicker],
-  imageCutout: Option[ImageCutout],
+  imageCutout: ImageCutout,
   showBoostedHeadline: Boolean,
   showQuotedHeadline: Boolean) extends FaciaContent
 
@@ -116,7 +115,7 @@ case class SupportingCuratedContent(
   byline: Option[String],
   showByLine: Boolean,
   kicker: Option[ItemKicker],
-  imageCutout: Option[ImageCutout],
+  imageCutout: ImageCutout,
   showBoostedHeadline: Boolean,
   showQuotedHeadline: Boolean) extends FaciaContent
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -7,7 +7,7 @@ import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, 
 case class Image(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String)
 
 object Image {
-  def fromTrail(trailMeta: MetaDataCommonFields): Option[Image] =
+  def fromTrailMeta(trailMeta: MetaDataCommonFields): Option[Image] =
     for {
       imageSrc <- trailMeta.imageSrc
       imageSrcWidth <- trailMeta.imageSrcWidth
@@ -21,7 +21,7 @@ case class ImageCutout(
   imageCutoutSrcHeight: Option[String])
 
 object ImageCutout {
-  def fromTrail(trailMeta: MetaDataCommonFields): Option[ImageCutout] =
+  def fromTrailMeta(trailMeta: MetaDataCommonFields): Option[ImageCutout] =
     for {
       src <- trailMeta.imageCutoutSrc
       width <- trailMeta.imageCutoutSrcWidth
@@ -44,7 +44,7 @@ object ImageCutout {
 
   def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] =
     if (trailMeta.imageCutoutReplace.exists(identity))
-      fromTrail(trailMeta)
+      fromTrailMeta(trailMeta)
         .orElse(fromContentTags(content, trailMeta))
     else
       None
@@ -153,7 +153,7 @@ object CuratedContent {
       trailMetaData.href.orElse(contentFields.get("href")),
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
-      Image.fromTrail(trailMetaData),
+      Image.fromTrailMeta(trailMetaData),
       trailMetaData.isBreaking.getOrElse(false),
       trailMetaData.isBoosted.getOrElse(false),
       trailMetaData.imageHide.getOrElse(false),
@@ -177,7 +177,7 @@ object CuratedContent {
       trailMetaData.href.orElse(contentFields.get("href")),
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
-      Image.fromTrail(trailMetaData),
+      Image.fromTrailMeta(trailMetaData),
       trailMetaData.isBreaking.getOrElse(false),
       trailMetaData.isBoosted.getOrElse(false),
       trailMetaData.imageHide.getOrElse(false),
@@ -203,7 +203,7 @@ object SupportingCuratedContent {
       trailMetaData.href.orElse(contentFields.get("href")),
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
-      Image.fromTrail(trailMetaData),
+      Image.fromTrailMeta(trailMetaData),
       trailMetaData.isBreaking.getOrElse(false),
       trailMetaData.isBoosted.getOrElse(false),
       trailMetaData.imageHide.getOrElse(false),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -37,7 +37,6 @@ object ImageCutout {
 
   def fromContentTags(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] = {
     val contributorTags = content.tags.filter(_.`type` == "contributor")
-    if (contributorTags.length == 1)
       for {
         tag <- contributorTags.find(_.bylineLargeImageUrl.isDefined)
         path <- tag.bylineLargeImageUrl
@@ -46,13 +45,11 @@ object ImageCutout {
         Option(path),
         None,
         None)
-    else
-      None
   }
 
   def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): ImageCutout =
     fromTrail(trailMeta)
-      .orElse(fromContentTags(content, trailMeta))
+      .orElse(if (trailMeta.imageCutoutReplace.exists(identity)) fromContentTags(content, trailMeta) else None)
       .getOrElse(ImageCutout.empty.copy(imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity)))
 }
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -22,6 +22,8 @@ case class ImageCutout(
   imageCutoutSrcHeight: Option[String])
 
 object ImageCutout {
+  val empty = ImageCutout(imageCutoutReplace = false, None, None, None)
+
   def fromTrail(trailMeta: MetaDataCommonFields): ImageCutout =
     ImageCutout(
       trailMeta.imageCutoutReplace.getOrElse(false),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -16,22 +16,18 @@ object Image {
 }
 
 case class ImageCutout(
-  imageCutoutReplace: Boolean,
-  imageCutoutSrc: Option[String],
+  imageCutoutSrc: String,
   imageCutoutSrcWidth: Option[String],
   imageCutoutSrcHeight: Option[String])
 
 object ImageCutout {
-  val empty = ImageCutout(imageCutoutReplace = false, None, None, None)
-
   def fromTrail(trailMeta: MetaDataCommonFields): Option[ImageCutout] =
     for {
       src <- trailMeta.imageCutoutSrc
       width <- trailMeta.imageCutoutSrcWidth
       height <- trailMeta.imageCutoutSrcHeight
     } yield ImageCutout(
-              trailMeta.imageCutoutReplace.getOrElse(false),
-              Option(src),
+              src,
               Option(width),
               Option(height))
 
@@ -41,16 +37,17 @@ object ImageCutout {
         tag <- contributorTags.find(_.bylineLargeImageUrl.isDefined)
         path <- tag.bylineLargeImageUrl
       } yield ImageCutout(
-        trailMeta.imageCutoutReplace.exists(identity),
-        Option(path),
+        path,
         None,
         None)
   }
 
-  def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): ImageCutout =
-    fromTrail(trailMeta)
-      .orElse(if (trailMeta.imageCutoutReplace.exists(identity)) fromContentTags(content, trailMeta) else None)
-      .getOrElse(ImageCutout.empty.copy(imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity)))
+  def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] =
+    if (trailMeta.imageCutoutReplace.exists(identity))
+      fromTrail(trailMeta)
+        .orElse(fromContentTags(content, trailMeta))
+    else
+      None
 }
 
 sealed trait FaciaContent
@@ -118,7 +115,7 @@ case class CuratedContent(
   byline: Option[String],
   showByLine: Boolean,
   kicker: Option[ItemKicker],
-  imageCutout: ImageCutout,
+  imageCutout: Option[ImageCutout],
   showBoostedHeadline: Boolean,
   showQuotedHeadline: Boolean) extends FaciaContent
 
@@ -138,7 +135,7 @@ case class SupportingCuratedContent(
   byline: Option[String],
   showByLine: Boolean,
   kicker: Option[ItemKicker],
-  imageCutout: ImageCutout,
+  imageCutout: Option[ImageCutout],
   showBoostedHeadline: Boolean,
   showQuotedHeadline: Boolean) extends FaciaContent
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
@@ -34,65 +34,50 @@ class ImageCutoutTest extends FreeSpec with Matchers {
 
   "ImageCutout" - {
 
-    "should return empty ImageCutout" in {
-      ImageCutout.empty should be (ImageCutout(false, None, None, None))
-    }
-
-    "should return true for standalone true" in {
+    "should return None for imageCutoutReplace=true but nothing to replace with" in {
       val trailMeta = trailMetaDataWithImageCutout(true)
       val imageCutout = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMeta)
-      imageCutout.imageCutoutReplace should be (true)
+      imageCutout should be (None)
     }
 
     "should return src with replace true or false" in {
-      val src = Option("src")
-      val width = Option("width")
+      val src    = "src"
+      val width  = Option("width")
       val height = Option("height")
 
-      val trailMetaTrue = trailMetaDataWithImageCutout(true, src, width, height)
+      val trailMetaTrue = trailMetaDataWithImageCutout(true, Option(src), width, height)
       val imageCutoutTrue = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMetaTrue)
-      imageCutoutTrue.imageCutoutReplace should be (true)
-      imageCutoutTrue.imageCutoutSrc should be (src)
-      imageCutoutTrue.imageCutoutSrcWidth should be (width)
-      imageCutoutTrue.imageCutoutSrcHeight should be (height)
+      imageCutoutTrue.isDefined should be (true)
+      imageCutoutTrue.get.imageCutoutSrc should be (src)
+      imageCutoutTrue.get.imageCutoutSrcWidth should be (width)
+      imageCutoutTrue.get.imageCutoutSrcHeight should be (height)
 
-      val trailMetaFalse = trailMetaDataWithImageCutout(false, src, width, height)
+      val trailMetaFalse = trailMetaDataWithImageCutout(false, Option(src), width, height)
       val imageCutoutFalse = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMetaFalse)
-      imageCutoutFalse.imageCutoutReplace should be (false)
-      imageCutoutFalse.imageCutoutSrc should be (src)
-      imageCutoutFalse.imageCutoutSrcWidth should be (width)
-      imageCutoutFalse.imageCutoutSrcHeight should be (height)
+      imageCutoutFalse should be (None)
     }
 
-    "should return None for src, width, height if any are empty" in {
+    "should return None for src, width, height if all are empty" in {
       val src = Option("src")
       val widthNone: Option[String] = None
       val height = Option("height")
 
       val trailMeta = trailMetaDataWithImageCutout(true, src, widthNone, height)
       val imageCutout = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMeta)
-      imageCutout.imageCutoutReplace should be (true)
-      imageCutout.imageCutoutSrc should be (None)
-      imageCutout.imageCutoutSrcWidth should be (None)
-      imageCutout.imageCutoutSrcHeight should be (None)
+      imageCutout should be (None)
     }
 
     "should return an ImageCutout from content tags" in {
       val trailMeta = trailMetaDataWithImageCutout(true, None, None, None)
       val imageCutout = ImageCutout.fromContentAndTrailMeta(contentWithContributor, trailMeta)
-      imageCutout.imageCutoutReplace should be (true)
-      imageCutout.imageCutoutSrc should be (Some(bylineImageUrl))
-      imageCutout.imageCutoutSrcWidth should be (None)
-      imageCutout.imageCutoutSrcHeight should be (None)
+      imageCutout.isDefined should be (true)
+      imageCutout should be (Some(ImageCutout(bylineImageUrl, None, None)))
     }
 
     "should not return an ImageCutout from content tags if imageCutoutReplace is false" in {
       val trailMeta = trailMetaDataWithImageCutout(false, None, None, None)
       val imageCutout = ImageCutout.fromContentAndTrailMeta(contentWithContributor, trailMeta)
-      imageCutout.imageCutoutReplace should be (false)
-      imageCutout.imageCutoutSrc should be (None)
-      imageCutout.imageCutoutSrcWidth should be (None)
-      imageCutout.imageCutoutSrcHeight should be (None)
+      imageCutout should be (None)
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
@@ -1,5 +1,6 @@
 package com.gu.facia.api.models
 
+import com.gu.contentapi.client.model.{Tag, Content}
 import com.gu.facia.client.models.TrailMetaData
 import org.scalatest.{Matchers, FreeSpec}
 import play.api.libs.json.{JsString, JsBoolean}
@@ -16,6 +17,20 @@ class ImageCutoutTest extends FreeSpec with Matchers {
     ++ imageCutoutSrcWidth.map("imageCutoutSrcWidth" -> JsString(_))
     ++ imageCutoutSrcHeight.map("imageCutoutSrcHeight" -> JsString(_)))
 
+  val emptyContent =
+    Content(
+      "id", None, None, None,
+      "webTitle", "webUrl", "apiUrl", None,
+      Nil, None, Nil, None)
+
+  def contentWithContributorTag(bylineLargeImageUrl: String): Content =
+    emptyContent.copy(tags = List(Tag(
+      "tagid", "contributor", None, None, "webTitle",
+      "webUrl", "apiUrl", Nil, None, None, bylineImageUrl = None,
+      Option(bylineLargeImageUrl), None, None, None, None)))
+
+  val contentWithContributor = contentWithContributorTag("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/3/13/1394733744420/MichaelWhite.png")
+
   "ImageCutout" - {
 
     "should return empty ImageCutout" in {
@@ -24,7 +39,7 @@ class ImageCutoutTest extends FreeSpec with Matchers {
 
     "should return true for standalone true" in {
       val trailMeta = trailMetaDataWithImageCutout(true)
-      val imageCutout = ImageCutout.fromTrail(trailMeta)
+      val imageCutout = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMeta)
       imageCutout.imageCutoutReplace should be (true)
     }
 
@@ -34,14 +49,14 @@ class ImageCutoutTest extends FreeSpec with Matchers {
       val height = Option("height")
 
       val trailMetaTrue = trailMetaDataWithImageCutout(true, src, width, height)
-      val imageCutoutTrue = ImageCutout.fromTrail(trailMetaTrue)
+      val imageCutoutTrue = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMetaTrue)
       imageCutoutTrue.imageCutoutReplace should be (true)
       imageCutoutTrue.imageCutoutSrc should be (src)
       imageCutoutTrue.imageCutoutSrcWidth should be (width)
       imageCutoutTrue.imageCutoutSrcHeight should be (height)
 
       val trailMetaFalse = trailMetaDataWithImageCutout(false, src, width, height)
-      val imageCutoutFalse = ImageCutout.fromTrail(trailMetaFalse)
+      val imageCutoutFalse = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMetaFalse)
       imageCutoutFalse.imageCutoutReplace should be (false)
       imageCutoutFalse.imageCutoutSrc should be (src)
       imageCutoutFalse.imageCutoutSrcWidth should be (width)
@@ -54,7 +69,7 @@ class ImageCutoutTest extends FreeSpec with Matchers {
       val height = Option("height")
 
       val trailMeta = trailMetaDataWithImageCutout(true, src, widthNone, height)
-      val imageCutout = ImageCutout.fromTrail(trailMeta)
+      val imageCutout = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMeta)
       imageCutout.imageCutoutReplace should be (true)
       imageCutout.imageCutoutSrc should be (None)
       imageCutout.imageCutoutSrcWidth should be (None)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
@@ -29,7 +29,8 @@ class ImageCutoutTest extends FreeSpec with Matchers {
       "webUrl", "apiUrl", Nil, None, None, bylineImageUrl = None,
       Option(bylineLargeImageUrl), None, None, None, None)))
 
-  val contentWithContributor = contentWithContributorTag("http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/3/13/1394733744420/MichaelWhite.png")
+  val bylineImageUrl = "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/3/13/1394733744420/MichaelWhite.png"
+  val contentWithContributor = contentWithContributorTag(bylineImageUrl)
 
   "ImageCutout" - {
 
@@ -71,6 +72,24 @@ class ImageCutoutTest extends FreeSpec with Matchers {
       val trailMeta = trailMetaDataWithImageCutout(true, src, widthNone, height)
       val imageCutout = ImageCutout.fromContentAndTrailMeta(emptyContent, trailMeta)
       imageCutout.imageCutoutReplace should be (true)
+      imageCutout.imageCutoutSrc should be (None)
+      imageCutout.imageCutoutSrcWidth should be (None)
+      imageCutout.imageCutoutSrcHeight should be (None)
+    }
+
+    "should return an ImageCutout from content tags" in {
+      val trailMeta = trailMetaDataWithImageCutout(true, None, None, None)
+      val imageCutout = ImageCutout.fromContentAndTrailMeta(contentWithContributor, trailMeta)
+      imageCutout.imageCutoutReplace should be (true)
+      imageCutout.imageCutoutSrc should be (Some(bylineImageUrl))
+      imageCutout.imageCutoutSrcWidth should be (None)
+      imageCutout.imageCutoutSrcHeight should be (None)
+    }
+
+    "should not return an ImageCutout from content tags if imageCutoutReplace is false" in {
+      val trailMeta = trailMetaDataWithImageCutout(false, None, None, None)
+      val imageCutout = ImageCutout.fromContentAndTrailMeta(contentWithContributor, trailMeta)
+      imageCutout.imageCutoutReplace should be (false)
       imageCutout.imageCutoutSrc should be (None)
       imageCutout.imageCutoutSrcWidth should be (None)
       imageCutout.imageCutoutSrcHeight should be (None)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/ImageCutoutTest.scala
@@ -1,0 +1,65 @@
+package com.gu.facia.api.models
+
+import com.gu.facia.client.models.TrailMetaData
+import org.scalatest.{Matchers, FreeSpec}
+import play.api.libs.json.{JsString, JsBoolean}
+
+class ImageCutoutTest extends FreeSpec with Matchers {
+
+  def trailMetaDataWithImageCutout(
+    imageCutoutReplace: Boolean = false,
+    imageCutoutSrc: Option[String] = None,
+    imageCutoutSrcWidth: Option[String] = None,
+    imageCutoutSrcHeight: Option[String] = None) = TrailMetaData(Map(
+    "imageCutoutReplace" -> JsBoolean(imageCutoutReplace))
+    ++ imageCutoutSrc.map("imageCutoutSrc" -> JsString(_))
+    ++ imageCutoutSrcWidth.map("imageCutoutSrcWidth" -> JsString(_))
+    ++ imageCutoutSrcHeight.map("imageCutoutSrcHeight" -> JsString(_)))
+
+  "ImageCutout" - {
+
+    "should return empty ImageCutout" in {
+      ImageCutout.empty should be (ImageCutout(false, None, None, None))
+    }
+
+    "should return true for standalone true" in {
+      val trailMeta = trailMetaDataWithImageCutout(true)
+      val imageCutout = ImageCutout.fromTrail(trailMeta)
+      imageCutout.imageCutoutReplace should be (true)
+    }
+
+    "should return src with replace true or false" in {
+      val src = Option("src")
+      val width = Option("width")
+      val height = Option("height")
+
+      val trailMetaTrue = trailMetaDataWithImageCutout(true, src, width, height)
+      val imageCutoutTrue = ImageCutout.fromTrail(trailMetaTrue)
+      imageCutoutTrue.imageCutoutReplace should be (true)
+      imageCutoutTrue.imageCutoutSrc should be (src)
+      imageCutoutTrue.imageCutoutSrcWidth should be (width)
+      imageCutoutTrue.imageCutoutSrcHeight should be (height)
+
+      val trailMetaFalse = trailMetaDataWithImageCutout(false, src, width, height)
+      val imageCutoutFalse = ImageCutout.fromTrail(trailMetaFalse)
+      imageCutoutFalse.imageCutoutReplace should be (false)
+      imageCutoutFalse.imageCutoutSrc should be (src)
+      imageCutoutFalse.imageCutoutSrcWidth should be (width)
+      imageCutoutFalse.imageCutoutSrcHeight should be (height)
+    }
+
+    "should return None for src, width, height if any are empty" in {
+      val src = Option("src")
+      val widthNone: Option[String] = None
+      val height = Option("height")
+
+      val trailMeta = trailMetaDataWithImageCutout(true, src, widthNone, height)
+      val imageCutout = ImageCutout.fromTrail(trailMeta)
+      imageCutout.imageCutoutReplace should be (true)
+      imageCutout.imageCutoutSrc should be (None)
+      imageCutout.imageCutoutSrcWidth should be (None)
+      imageCutout.imageCutoutSrcHeight should be (None)
+    }
+  }
+
+}


### PR DESCRIPTION
This changes `ImageCutout` on `CuratedContent` and `SupportingCuratedContent` to non-optional, and instead changes the fields to optional.

`ImageCutout.imageCutoutReplace` can be set to `true`, without there being an `ImageCutout` provided; this would mean that there should be an `ImageCutout` coming entirely from the tags of the content.

This copies some of the behaviour from `frontend`, but it is not as black and white there and I haven't completely taken everything across.

@adamnfish @robertberry 