### PR TITLE
Fix requesting without Snaps

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -89,8 +89,9 @@ object FAPI {
 
   def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
                                 (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    val collectionWithoutSnaps = Collection.withoutSnaps(collection)
     for(setOfContent <- getContentForCollection(collection, adjustSearchQuery))
-      yield Collection.liveContent(collection, setOfContent)
+      yield Collection.liveContent(collectionWithoutSnaps, setOfContent)
   }
 
   def collectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -84,6 +84,11 @@ object Collection {
       .filter(_.isSnap)
       .filter(_.safeMeta.snapType == Some("latest"))
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri)).toMap)
+
+  def withoutSnaps(collection: Collection): Collection = {
+    collection.copy(
+      live = collection.live.filterNot(_.isSnap),
+      draft = collection.draft.map(_.filterNot(_.isSnap)))}
 }
 
 case class Group(get: Int)

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -156,14 +156,10 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         faciaContent.asFuture.futureValue.fold(
         err => fail(s"expected to get three items, got $err", err.cause),
         { listOfFaciaContent =>
-          listOfFaciaContent.length should be (3)
+          listOfFaciaContent.length should be (1)
 
           val normalContent = listOfFaciaContent.collect{ case cc: CuratedContent => cc}
           normalContent.apply(0).headline should be ("PM returns from holiday after video shows US reporter beheaded by Briton")
-
-          val latestSnapContent = listOfFaciaContent.collect{ case ls: LatestSnap => ls}
-          latestSnapContent.length should be (2)
-          latestSnapContent.forall(_.latestContent == None) should be (true)
         })
       }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -257,4 +257,66 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       collection.collectionConfig.importance should be (Critical)
     }
   }
+
+  "Collection" - {
+    "filter out the snaps in live" in {
+        val trailOne = Trail("internal-code/content/1", 1, Some(trailMetadata))
+        val trailTwo = Trail("internal-code/content/2", 1, Some(trailMetadata))
+        val snapOne = Trail("snap/1415985080061", 1, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))))
+        val snapTwo = Trail("snap/5345345215342", 1, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))))
+        val snapLatestOne = Trail("snap/8474745745660", 1, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))))
+        val snapLatestTwo = Trail("snap/4324234234234", 1, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))))
+
+        val snapContentOne = Content(
+          "content-id-one", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+          fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+          Nil, None, Nil, None)
+        val snapContentTwo = Content(
+          "content-id-two", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+          fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+          Nil, None, Nil, None)
+
+        val snapContent = Map("snap/8474745745660" -> Some(snapContentOne), "snap/4324234234234" -> Some(snapContentTwo))
+
+        val collectionJsonTwo = collectionJson.copy(live = List(snapOne, snapTwo, trailOne, snapLatestOne, snapLatestTwo, trailTwo))
+
+        val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJsonTwo), collectionConfig)
+
+        val collectionWithoutSnaps = Collection.withoutSnaps(collection)
+
+        collectionWithoutSnaps.live.length should be (2)
+        collectionWithoutSnaps.live(0).id should be ("internal-code/content/1")
+        collectionWithoutSnaps.live(1).id should be ("internal-code/content/2")
+      }
+
+    "filter out the snaps in draft" in {
+      val trailOne = Trail("internal-code/content/1", 1, Some(trailMetadata))
+      val trailTwo = Trail("internal-code/content/2", 1, Some(trailMetadata))
+      val snapOne = Trail("snap/1415985080061", 1, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))))
+      val snapTwo = Trail("snap/5345345215342", 1, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))))
+      val snapLatestOne = Trail("snap/8474745745660", 1, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))))
+      val snapLatestTwo = Trail("snap/4324234234234", 1, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))))
+
+      val snapContentOne = Content(
+        "content-id-one", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+        fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+        Nil, None, Nil, None)
+      val snapContentTwo = Content(
+        "content-id-two", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+        fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+        Nil, None, Nil, None)
+
+      val snapContent = Map("snap/8474745745660" -> Some(snapContentOne), "snap/4324234234234" -> Some(snapContentTwo))
+
+      val collectionJsonTwo = collectionJson.copy(draft = Option(List(snapOne, snapTwo, trailTwo, snapLatestOne, snapLatestTwo, trailOne)))
+
+      val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJsonTwo), collectionConfig)
+
+      val collectionWithoutSnaps = Collection.withoutSnaps(collection)
+
+      collectionWithoutSnaps.draft.map(_.length) should be (Some(2))
+      collectionWithoutSnaps.draft.map(_.apply(0).id) should be (Some("internal-code/content/2"))
+      collectionWithoutSnaps.draft.map(_.apply(1).id) should be (Some("internal-code/content/1"))
+    }
+    }
 }


### PR DESCRIPTION
This fixes requesting with `FAPI` via `collectionContentWithoutSnaps`.

Snaps were still getting through, and the test was wrong.

@adamnfish @robertberry 