### PR TITLE
MetadataDefaults

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -296,6 +296,7 @@ object CuratedContent {
 object SupportingCuratedContent {
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): SupportingCuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
+    val metaDataDefaults = MetadataDefaults.fromContent(content)
 
     SupportingCuratedContent(
       content,
@@ -304,16 +305,16 @@ object SupportingCuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       Image.fromTrail(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(false),
-      trailMetaData.isBoosted.getOrElse(false),
-      trailMetaData.imageHide.getOrElse(false),
-      trailMetaData.imageReplace.getOrElse(false),
-      trailMetaData.showMainVideo.getOrElse(false),
-      trailMetaData.showKickerTag.getOrElse(false),
+      trailMetaData.isBreaking.getOrElse(metaDataDefaults.isBreaking),
+      trailMetaData.isBoosted.getOrElse(metaDataDefaults.isBoosted),
+      trailMetaData.imageHide.getOrElse(metaDataDefaults.imageHide),
+      trailMetaData.imageReplace.getOrElse(metaDataDefaults.imageReplace),
+      trailMetaData.showMainVideo.getOrElse(metaDataDefaults.showMainVideo),
+      trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(false),
+      trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
       ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(false),
-      trailMetaData.showQuotedHeadline.getOrElse(false))}
+      trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
+      trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline))}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -244,6 +244,7 @@ object CuratedContent {
                                         supportingContent: List[FaciaContent],
                                         collectionConfig: CollectionConfig) = {
     val contentFields: Map[String, String] = content.safeFields
+    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
 
     CuratedContent(
       content,
@@ -261,7 +262,7 @@ object CuratedContent {
       trailMetaData.showKickerTag.getOrElse(false),
       trailMetaData.byline.orElse(contentFields.get("byline")),
       trailMetaData.showByline.getOrElse(false),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
       trailMetaData.showBoostedHeadline.getOrElse(false),
       trailMetaData.showQuotedHeadline.getOrElse(false))}
@@ -286,7 +287,7 @@ object CuratedContent {
       trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
       trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
       trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
       trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline)
@@ -313,7 +314,7 @@ object SupportingCuratedContent {
       trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
       trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
       trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
       trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline))}

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -1,7 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
-import com.gu.facia.api.utils.ItemKicker
+import com.gu.facia.api.utils.{MetadataDefaults, ItemKicker}
 import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, TrailMetaData}
 
 case class Image(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String)
@@ -268,6 +268,7 @@ object CuratedContent {
 
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
+    val metaDataDefaults = MetadataDefaults.fromContent(content)
 
     CuratedContent(
       content,
@@ -277,18 +278,18 @@ object CuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       Image.fromTrail(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(false),
-      trailMetaData.isBoosted.getOrElse(false),
-      trailMetaData.imageHide.getOrElse(false),
-      trailMetaData.imageReplace.getOrElse(false),
-      trailMetaData.showMainVideo.getOrElse(false),
-      trailMetaData.showKickerTag.getOrElse(false),
+      trailMetaData.isBreaking.getOrElse(metaDataDefaults.isBreaking),
+      trailMetaData.isBoosted.getOrElse(metaDataDefaults.isBoosted),
+      trailMetaData.imageHide.getOrElse(metaDataDefaults.imageHide),
+      trailMetaData.imageReplace.getOrElse(metaDataDefaults.imageReplace),
+      trailMetaData.showMainVideo.getOrElse(metaDataDefaults.showMainVideo),
+      trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(false),
+      trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
       ItemKicker.fromContentAndTrail(content, trailMetaData, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(false),
-      trailMetaData.showQuotedHeadline.getOrElse(false)
+      trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
+      trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline)
     )}
 }
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -272,17 +272,17 @@ object CuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       ImageReplace.fromTrailMeta(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(false),
-      trailMetaData.isBoosted.getOrElse(false),
-      trailMetaData.imageHide.getOrElse(false),
-      trailMetaData.showMainVideo.getOrElse(false),
-      trailMetaData.showKickerTag.getOrElse(false),
+      resolvedMetaData.isBreaking,
+      resolvedMetaData.isBoosted,
+      resolvedMetaData.imageHide,
+      resolvedMetaData.showMainVideo,
+      resolvedMetaData.showKickerTag,
       trailMetaData.byline.orElse(contentFields.get("byline")),
       trailMetaData.showByline.getOrElse(false),
       ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(false),
-      trailMetaData.showQuotedHeadline.getOrElse(false))}
+      resolvedMetaData.showBoostedHeadline,
+      resolvedMetaData.showQuotedHeadline)}
 
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
@@ -296,17 +296,17 @@ object CuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       ImageReplace.fromTrailMeta(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(resolvedMetaData.isBreaking),
-      trailMetaData.isBoosted.getOrElse(resolvedMetaData.isBoosted),
-      trailMetaData.imageHide.getOrElse(resolvedMetaData.imageHide),
-      trailMetaData.showMainVideo.getOrElse(resolvedMetaData.showMainVideo),
-      trailMetaData.showKickerTag.getOrElse(resolvedMetaData.showKickerTag),
+      resolvedMetaData.isBreaking,
+      resolvedMetaData.isBoosted,
+      resolvedMetaData.imageHide,
+      resolvedMetaData.showMainVideo,
+      resolvedMetaData.showKickerTag,
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(resolvedMetaData.showByline),
+      resolvedMetaData.showByline,
       ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(resolvedMetaData.showBoostedHeadline),
-      trailMetaData.showQuotedHeadline.getOrElse(resolvedMetaData.showQuotedHeadline)
+      resolvedMetaData.showBoostedHeadline,
+      resolvedMetaData.showQuotedHeadline
     )}
 }
 
@@ -322,15 +322,15 @@ object SupportingCuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       ImageReplace.fromTrailMeta(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(resolvedMetaData.isBreaking),
-      trailMetaData.isBoosted.getOrElse(resolvedMetaData.isBoosted),
-      trailMetaData.imageHide.getOrElse(resolvedMetaData.imageHide),
-      trailMetaData.showMainVideo.getOrElse(resolvedMetaData.showMainVideo),
-      trailMetaData.showKickerTag.getOrElse(resolvedMetaData.showKickerTag),
+      resolvedMetaData.isBreaking,
+      resolvedMetaData.isBoosted,
+      resolvedMetaData.imageHide,
+      resolvedMetaData.showMainVideo,
+      resolvedMetaData.showKickerTag,
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(resolvedMetaData.showByline),
+      resolvedMetaData.showByline,
       ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(resolvedMetaData.showBoostedHeadline),
-      trailMetaData.showQuotedHeadline.getOrElse(resolvedMetaData.showQuotedHeadline))}
+      resolvedMetaData.showBoostedHeadline,
+      resolvedMetaData.showQuotedHeadline)}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -1,7 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
-import com.gu.facia.api.utils.{MetadataDefaults, ItemKicker}
+import com.gu.facia.api.utils.{ResolvedMetaData, ItemKicker}
 import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, TrailMetaData}
 
 case class Image(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String)
@@ -244,7 +244,7 @@ object CuratedContent {
                                         supportingContent: List[FaciaContent],
                                         collectionConfig: CollectionConfig) = {
     val contentFields: Map[String, String] = content.safeFields
-    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
+    val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData)
 
     CuratedContent(
       content,
@@ -262,14 +262,14 @@ object CuratedContent {
       trailMetaData.showKickerTag.getOrElse(false),
       trailMetaData.byline.orElse(contentFields.get("byline")),
       trailMetaData.showByline.getOrElse(false),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
       trailMetaData.showBoostedHeadline.getOrElse(false),
       trailMetaData.showQuotedHeadline.getOrElse(false))}
 
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
-    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
+    val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData)
 
     CuratedContent(
       content,
@@ -279,25 +279,25 @@ object CuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       Image.fromTrail(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(metaDataDefaults.isBreaking),
-      trailMetaData.isBoosted.getOrElse(metaDataDefaults.isBoosted),
-      trailMetaData.imageHide.getOrElse(metaDataDefaults.imageHide),
-      trailMetaData.imageReplace.getOrElse(metaDataDefaults.imageReplace),
-      trailMetaData.showMainVideo.getOrElse(metaDataDefaults.showMainVideo),
-      trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
+      trailMetaData.isBreaking.getOrElse(resolvedMetaData.isBreaking),
+      trailMetaData.isBoosted.getOrElse(resolvedMetaData.isBoosted),
+      trailMetaData.imageHide.getOrElse(resolvedMetaData.imageHide),
+      trailMetaData.imageReplace.getOrElse(resolvedMetaData.imageReplace),
+      trailMetaData.showMainVideo.getOrElse(resolvedMetaData.showMainVideo),
+      trailMetaData.showKickerTag.getOrElse(resolvedMetaData.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
+      trailMetaData.showByline.getOrElse(resolvedMetaData.showByline),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
-      trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline)
+      trailMetaData.showBoostedHeadline.getOrElse(resolvedMetaData.showBoostedHeadline),
+      trailMetaData.showQuotedHeadline.getOrElse(resolvedMetaData.showQuotedHeadline)
     )}
 }
 
 object SupportingCuratedContent {
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): SupportingCuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
-    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
+    val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData)
 
     SupportingCuratedContent(
       content,
@@ -306,16 +306,16 @@ object SupportingCuratedContent {
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),
       Image.fromTrail(trailMetaData),
-      trailMetaData.isBreaking.getOrElse(metaDataDefaults.isBreaking),
-      trailMetaData.isBoosted.getOrElse(metaDataDefaults.isBoosted),
-      trailMetaData.imageHide.getOrElse(metaDataDefaults.imageHide),
-      trailMetaData.imageReplace.getOrElse(metaDataDefaults.imageReplace),
-      trailMetaData.showMainVideo.getOrElse(metaDataDefaults.showMainVideo),
-      trailMetaData.showKickerTag.getOrElse(metaDataDefaults.showKickerTag),
+      trailMetaData.isBreaking.getOrElse(resolvedMetaData.isBreaking),
+      trailMetaData.isBoosted.getOrElse(resolvedMetaData.isBoosted),
+      trailMetaData.imageHide.getOrElse(resolvedMetaData.imageHide),
+      trailMetaData.imageReplace.getOrElse(resolvedMetaData.imageReplace),
+      trailMetaData.showMainVideo.getOrElse(resolvedMetaData.showMainVideo),
+      trailMetaData.showKickerTag.getOrElse(resolvedMetaData.showKickerTag),
       trailMetaData.byline.orElse(contentFields.get("byline")),
-      trailMetaData.showByline.getOrElse(metaDataDefaults.showByline),
-      ItemKicker.fromContentAndTrail(content, trailMetaData, metaDataDefaults, Some(collectionConfig)),
+      trailMetaData.showByline.getOrElse(resolvedMetaData.showByline),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromTrail(trailMetaData),
-      trailMetaData.showBoostedHeadline.getOrElse(metaDataDefaults.showBoostedHeadline),
-      trailMetaData.showQuotedHeadline.getOrElse(metaDataDefaults.showQuotedHeadline))}
+      trailMetaData.showBoostedHeadline.getOrElse(resolvedMetaData.showBoostedHeadline),
+      trailMetaData.showQuotedHeadline.getOrElse(resolvedMetaData.showQuotedHeadline))}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -268,7 +268,7 @@ object CuratedContent {
 
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
-    val metaDataDefaults = MetadataDefaults.fromContent(content)
+    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
 
     CuratedContent(
       content,
@@ -296,7 +296,7 @@ object CuratedContent {
 object SupportingCuratedContent {
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): SupportingCuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
-    val metaDataDefaults = MetadataDefaults.fromContent(content)
+    val metaDataDefaults = MetadataDefaults.fromContentAndTrailMetaData(content, trailMetaData)
 
     SupportingCuratedContent(
       content,

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -272,7 +272,7 @@ object CuratedContent {
     CuratedContent(
       content,
       supportingContent = Nil,
-        trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
+      trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
       trailMetaData.href.orElse(contentFields.get("href")),
       trailMetaData.trailText.orElse(contentFields.get("trailText")),
       trailMetaData.group.getOrElse("0"),

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -8,7 +8,7 @@ object ItemKicker {
   def fromContentAndTrail(
       maybeContent: Option[Content],
       trailMeta: MetaDataCommonFields,
-      metaDefaults: MetadataDefaults,
+      metaDefaults: ResolvedMetaData,
       config: Option[CollectionConfig]): Option[ItemKicker] = {
 
     lazy val maybeTag = maybeContent.flatMap(_.tags.headOption)
@@ -41,9 +41,9 @@ object ItemKicker {
     }
   }
 
-  def fromTrailMetaData(trailMeta: MetaDataCommonFields): Option[ItemKicker] = fromContentAndTrail(None, trailMeta, MetadataDefaults.Default, None)
+  def fromTrailMetaData(trailMeta: MetaDataCommonFields): Option[ItemKicker] = fromContentAndTrail(None, trailMeta, ResolvedMetaData.Default, None)
 
-  def fromContentAndTrail(content: Content, trailMeta: MetaDataCommonFields, metaDataDefaults: MetadataDefaults, config: Option[CollectionConfig]): Option[ItemKicker]
+  def fromContentAndTrail(content: Content, trailMeta: MetaDataCommonFields, metaDataDefaults: ResolvedMetaData, config: Option[CollectionConfig]): Option[ItemKicker]
     = fromContentAndTrail(Option(content), trailMeta, metaDataDefaults, config)
 
   private[utils] def tonalKicker(content: Content, trailMeta: MetaDataCommonFields): Option[ItemKicker] = {

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
@@ -92,7 +92,7 @@ object MetadataDefaults {
     else
       mutatingMetaDataDefaults}
 
-  def fromContentAndTrailMetaData(content: Content, trailMeta: TrailMetaData): MetadataDefaults = {
+  def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): MetadataDefaults = {
     val metaDataDefaultsForTrailMeta = fromTrailMetaData(trailMeta)
     fromContent(content, metaDataDefaultsForTrailMeta)}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
@@ -1,0 +1,92 @@
+package com.gu.facia.api.utils
+
+import com.gu.contentapi.client.model.Content
+import com.gu.facia.api.models._
+
+
+object MetadataDefaults {
+  val Cartoon = "type/cartoon"
+  val Video = "type/video"
+  val Comment = "tone/comment"
+
+  private def fold[T](faciaContent: FaciaContent)(c: (CuratedContent) => T, scc: (SupportingCuratedContent) => T,
+    ls: (LinkSnap) => T, las: (LatestSnap) => T): T = faciaContent match {
+    case curatedContent: CuratedContent => c(curatedContent)
+    case supportingCuratedContent: SupportingCuratedContent => scc(supportingCuratedContent)
+    case linkSnap: LinkSnap => ls(linkSnap)
+    case latestSnap: LatestSnap => las(latestSnap)}
+
+  def isCartoonForContent(content: Content): Boolean =
+    content.tags.exists(_.id == Cartoon)
+
+  def isCartoon(faciaContent: FaciaContent): Boolean = {
+
+    fold(faciaContent)(
+      curatedContent => isCartoonForContent(curatedContent.content),
+      supportingCuratedContent => isCartoonForContent(supportingCuratedContent.content),
+      _ => false,
+      latestSnap => latestSnap.latestContent.exists(isCartoonForContent))}
+
+  def isCommentForContent(content: Content): Boolean =
+    content.tags.exists(_.id == Comment)
+
+  def isComment(faciaContent: FaciaContent): Boolean = {
+    fold(faciaContent)(
+      curatedContent => isCommentForContent(curatedContent.content),
+      supportingCuratedContent => isCommentForContent(supportingCuratedContent.content),
+      _ => false,
+      latestSnap => latestSnap.latestContent.exists(isCommentForContent))}
+
+  def isVideoForContent(content: Content): Boolean =
+    content.tags.exists(_.id == Video)
+
+  def isVideo(faciaContent: FaciaContent): Boolean = {
+
+    fold(faciaContent)(
+      curatedContent => isVideoForContent(curatedContent.content),
+      supportingCuratedContent => isVideoForContent(supportingCuratedContent.content),
+      _ => false,
+      latestSnap => latestSnap.latestContent.exists(isVideoForContent))
+  }
+
+  val Default = MetadataDefaults(
+    isBreaking = false,
+    isBoosted = false,
+    imageHide = false,
+    imageReplace = false,
+    showKickerSection = false,
+    showKickerCustom = false,
+    showBoostedHeadline = false,
+    showMainVideo = false,
+    showKickerTag = false,
+    showByline = false,
+    imageCutoutReplace = false,
+    showQuotedHeadline = false)
+
+  def apply(content: Content): MetadataDefaults = {
+    if (isCartoonForContent(content))
+      Default.copy(showByline = true)
+    else if (isCommentForContent(content))
+      Default.copy(
+        showByline = true,
+        showQuotedHeadline = true,
+        imageCutoutReplace = true)
+    else if (isVideoForContent(content))
+      Default.copy(showMainVideo = true)
+    else
+      Default}
+}
+
+case class MetadataDefaults(
+    isBreaking: Boolean,
+    isBoosted: Boolean,
+    imageHide: Boolean,
+    imageReplace: Boolean,
+    showKickerSection: Boolean,
+    showKickerCustom: Boolean,
+    showBoostedHeadline: Boolean,
+    showMainVideo: Boolean,
+    showKickerTag: Boolean,
+    showByline: Boolean,
+    imageCutoutReplace: Boolean,
+    showQuotedHeadline: Boolean)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
@@ -63,7 +63,7 @@ object MetadataDefaults {
     imageCutoutReplace = false,
     showQuotedHeadline = false)
 
-  def apply(content: Content): MetadataDefaults = {
+  def fromContent(content: Content): MetadataDefaults = {
     if (isCartoonForContent(content))
       Default.copy(showByline = true)
     else if (isCommentForContent(content))

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/MetadataDefaults.scala
@@ -2,6 +2,7 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.models._
+import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 
 
 object MetadataDefaults {
@@ -63,18 +64,37 @@ object MetadataDefaults {
     imageCutoutReplace = false,
     showQuotedHeadline = false)
 
-  def fromContent(content: Content): MetadataDefaults = {
+  def fromTrailMetaData(trailMeta: MetaDataCommonFields): MetadataDefaults =
+    MetadataDefaults(
+      isBreaking = trailMeta.isBreaking.exists(identity),
+      isBoosted = trailMeta.isBoosted.exists(identity),
+      imageHide = trailMeta.imageHide.exists(identity),
+      imageReplace = trailMeta.imageReplace.exists(identity),
+      showKickerSection = trailMeta.showKickerSection.exists(identity),
+      showKickerCustom = trailMeta.showKickerCustom.exists(identity),
+      showBoostedHeadline = trailMeta.showBoostedHeadline.exists(identity),
+      showMainVideo = trailMeta.showMainVideo.exists(identity),
+      showKickerTag = trailMeta.showKickerTag.exists(identity),
+      showByline = trailMeta.showByline.exists(identity),
+      imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
+      showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
+
+  def fromContent(content: Content, mutatingMetaDataDefaults: MetadataDefaults = Default): MetadataDefaults = {
     if (isCartoonForContent(content))
-      Default.copy(showByline = true)
+      mutatingMetaDataDefaults.copy(showByline = true)
     else if (isCommentForContent(content))
-      Default.copy(
+      mutatingMetaDataDefaults.copy(
         showByline = true,
         showQuotedHeadline = true,
         imageCutoutReplace = true)
     else if (isVideoForContent(content))
-      Default.copy(showMainVideo = true)
+      mutatingMetaDataDefaults.copy(showMainVideo = true)
     else
-      Default}
+      mutatingMetaDataDefaults}
+
+  def fromContentAndTrailMetaData(content: Content, trailMeta: TrailMetaData): MetadataDefaults = {
+    val metaDataDefaultsForTrailMeta = fromTrailMetaData(trailMeta)
+    fromContent(content, metaDataDefaultsForTrailMeta)}
 }
 
 case class MetadataDefaults(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -49,39 +49,33 @@ object ResolvedMetaData {
       showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
 
   private[utils] def fromContent(content: Content): ResolvedMetaData = {
-    val mutatingMetaDataDefaults = Default
     if (isCartoonForContent(content))
-      mutatingMetaDataDefaults.copy(showByline = true)
+      Default.copy(showByline = true)
     else if (isCommentForContent(content))
-      mutatingMetaDataDefaults.copy(
+      Default.copy(
         showByline = true,
         showQuotedHeadline = true,
         imageCutoutReplace = true)
     else if (isVideoForContent(content))
-      mutatingMetaDataDefaults.copy(showMainVideo = true)
+      Default.copy(showMainVideo = true)
     else
-      mutatingMetaDataDefaults}
-
-  private [utils] def joinResolvedMetaDataAndTrailMetaData(first: ResolvedMetaData, second: MetaDataCommonFields): ResolvedMetaData =
-    first.copy(
-      isBreaking = second.isBreaking.getOrElse(first.isBreaking),
-      isBoosted = second.isBoosted.getOrElse(first.isBoosted),
-      imageHide = second.imageHide.getOrElse(first.imageHide),
-      imageReplace = second.imageReplace.getOrElse(first.imageReplace),
-      showKickerSection = second.showKickerSection.getOrElse(first.showKickerSection),
-      showKickerCustom = second.showKickerCustom.getOrElse(first.showKickerCustom),
-      showBoostedHeadline = second.showBoostedHeadline.getOrElse(first.showBoostedHeadline),
-      showMainVideo = second.showMainVideo.getOrElse(first.showMainVideo),
-      showKickerTag = second.showKickerTag.getOrElse(first.showKickerTag),
-      showByline = second.showByline.getOrElse(first.showByline),
-      imageCutoutReplace = second.imageCutoutReplace.getOrElse(first.imageCutoutReplace),
-      showQuotedHeadline = second.showQuotedHeadline.getOrElse(first.showQuotedHeadline)
-    )
+      Default}
 
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): ResolvedMetaData = {
     val metaDataFromContent = fromContent(content)
-    joinResolvedMetaDataAndTrailMetaData(metaDataFromContent, trailMeta)
-  }
+    metaDataFromContent.copy(
+      isBreaking = trailMeta.isBreaking.getOrElse(metaDataFromContent.isBreaking),
+      isBoosted = trailMeta.isBoosted.getOrElse(metaDataFromContent.isBoosted),
+      imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide),
+      imageReplace = trailMeta.imageReplace.getOrElse(metaDataFromContent.imageReplace),
+      showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
+      showKickerCustom = trailMeta.showKickerCustom.getOrElse(metaDataFromContent.showKickerCustom),
+      showBoostedHeadline = trailMeta.showBoostedHeadline.getOrElse(metaDataFromContent.showBoostedHeadline),
+      showMainVideo = trailMeta.showMainVideo.getOrElse(metaDataFromContent.showMainVideo),
+      showKickerTag = trailMeta.showKickerTag.getOrElse(metaDataFromContent.showKickerTag),
+      showByline = trailMeta.showByline.getOrElse(metaDataFromContent.showByline),
+      imageCutoutReplace = trailMeta.imageCutoutReplace.getOrElse(metaDataFromContent.imageCutoutReplace),
+      showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline))}
 }
 
 case class ResolvedMetaData(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -64,7 +64,7 @@ object ResolvedMetaData {
     imageCutoutReplace = false,
     showQuotedHeadline = false)
 
-  def fromTrailMetaData(trailMeta: MetaDataCommonFields): ResolvedMetaData =
+  private[utils] def fromTrailMetaData(trailMeta: MetaDataCommonFields): ResolvedMetaData =
     ResolvedMetaData(
       isBreaking = trailMeta.isBreaking.exists(identity),
       isBoosted = trailMeta.isBoosted.exists(identity),
@@ -79,7 +79,7 @@ object ResolvedMetaData {
       imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
       showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
 
-  def fromContent(content: Content, mutatingMetaDataDefaults: ResolvedMetaData = Default): ResolvedMetaData = {
+  private[utils] def fromContent(content: Content, mutatingMetaDataDefaults: ResolvedMetaData = Default): ResolvedMetaData = {
     if (isCartoonForContent(content))
       mutatingMetaDataDefaults.copy(showByline = true)
     else if (isCommentForContent(content))

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -10,45 +10,14 @@ object ResolvedMetaData {
   val Video = "type/video"
   val Comment = "tone/comment"
 
-  private def fold[T](faciaContent: FaciaContent)(c: (CuratedContent) => T, scc: (SupportingCuratedContent) => T,
-    ls: (LinkSnap) => T, las: (LatestSnap) => T): T = faciaContent match {
-    case curatedContent: CuratedContent => c(curatedContent)
-    case supportingCuratedContent: SupportingCuratedContent => scc(supportingCuratedContent)
-    case linkSnap: LinkSnap => ls(linkSnap)
-    case latestSnap: LatestSnap => las(latestSnap)}
-
   def isCartoonForContent(content: Content): Boolean =
     content.tags.exists(_.id == Cartoon)
-
-  def isCartoon(faciaContent: FaciaContent): Boolean = {
-
-    fold(faciaContent)(
-      curatedContent => isCartoonForContent(curatedContent.content),
-      supportingCuratedContent => isCartoonForContent(supportingCuratedContent.content),
-      _ => false,
-      latestSnap => latestSnap.latestContent.exists(isCartoonForContent))}
 
   def isCommentForContent(content: Content): Boolean =
     content.tags.exists(_.id == Comment)
 
-  def isComment(faciaContent: FaciaContent): Boolean = {
-    fold(faciaContent)(
-      curatedContent => isCommentForContent(curatedContent.content),
-      supportingCuratedContent => isCommentForContent(supportingCuratedContent.content),
-      _ => false,
-      latestSnap => latestSnap.latestContent.exists(isCommentForContent))}
-
   def isVideoForContent(content: Content): Boolean =
     content.tags.exists(_.id == Video)
-
-  def isVideo(faciaContent: FaciaContent): Boolean = {
-
-    fold(faciaContent)(
-      curatedContent => isVideoForContent(curatedContent.content),
-      supportingCuratedContent => isVideoForContent(supportingCuratedContent.content),
-      _ => false,
-      latestSnap => latestSnap.latestContent.exists(isVideoForContent))
-  }
 
   val Default = ResolvedMetaData(
     isBreaking = false,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -79,7 +79,8 @@ object ResolvedMetaData {
       imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
       showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
 
-  private[utils] def fromContent(content: Content, mutatingMetaDataDefaults: ResolvedMetaData = Default): ResolvedMetaData = {
+  private[utils] def fromContent(content: Content): ResolvedMetaData = {
+    val mutatingMetaDataDefaults = Default
     if (isCartoonForContent(content))
       mutatingMetaDataDefaults.copy(showByline = true)
     else if (isCommentForContent(content))
@@ -109,8 +110,9 @@ object ResolvedMetaData {
     )
 
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): ResolvedMetaData = {
-    val metaDataDefaultsForTrailMeta = fromTrailMetaData(trailMeta)
-    fromContent(content, metaDataDefaultsForTrailMeta)}
+    val metaDataFromContent = fromContent(content)
+    joinResolvedMetaDataAndTrailMetaData(metaDataFromContent, trailMeta)
+  }
 }
 
 case class ResolvedMetaData(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -2,10 +2,10 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.models._
-import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
+import com.gu.facia.client.models.MetaDataCommonFields
 
 
-object MetadataDefaults {
+object ResolvedMetaData {
   val Cartoon = "type/cartoon"
   val Video = "type/video"
   val Comment = "tone/comment"
@@ -50,7 +50,7 @@ object MetadataDefaults {
       latestSnap => latestSnap.latestContent.exists(isVideoForContent))
   }
 
-  val Default = MetadataDefaults(
+  val Default = ResolvedMetaData(
     isBreaking = false,
     isBoosted = false,
     imageHide = false,
@@ -64,8 +64,8 @@ object MetadataDefaults {
     imageCutoutReplace = false,
     showQuotedHeadline = false)
 
-  def fromTrailMetaData(trailMeta: MetaDataCommonFields): MetadataDefaults =
-    MetadataDefaults(
+  def fromTrailMetaData(trailMeta: MetaDataCommonFields): ResolvedMetaData =
+    ResolvedMetaData(
       isBreaking = trailMeta.isBreaking.exists(identity),
       isBoosted = trailMeta.isBoosted.exists(identity),
       imageHide = trailMeta.imageHide.exists(identity),
@@ -79,7 +79,7 @@ object MetadataDefaults {
       imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
       showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
 
-  def fromContent(content: Content, mutatingMetaDataDefaults: MetadataDefaults = Default): MetadataDefaults = {
+  def fromContent(content: Content, mutatingMetaDataDefaults: ResolvedMetaData = Default): ResolvedMetaData = {
     if (isCartoonForContent(content))
       mutatingMetaDataDefaults.copy(showByline = true)
     else if (isCommentForContent(content))
@@ -92,12 +92,12 @@ object MetadataDefaults {
     else
       mutatingMetaDataDefaults}
 
-  def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): MetadataDefaults = {
+  def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): ResolvedMetaData = {
     val metaDataDefaultsForTrailMeta = fromTrailMetaData(trailMeta)
     fromContent(content, metaDataDefaultsForTrailMeta)}
 }
 
-case class MetadataDefaults(
+case class ResolvedMetaData(
     isBreaking: Boolean,
     isBoosted: Boolean,
     imageHide: Boolean,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -2,7 +2,7 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.models._
-import com.gu.facia.client.models.MetaDataCommonFields
+import com.gu.facia.client.models.{TrailMetaData, MetaDataCommonFields}
 
 
 object ResolvedMetaData {
@@ -91,6 +91,22 @@ object ResolvedMetaData {
       mutatingMetaDataDefaults.copy(showMainVideo = true)
     else
       mutatingMetaDataDefaults}
+
+  private [utils] def joinResolvedMetaDataAndTrailMetaData(first: ResolvedMetaData, second: MetaDataCommonFields): ResolvedMetaData =
+    first.copy(
+      isBreaking = second.isBreaking.getOrElse(first.isBreaking),
+      isBoosted = second.isBoosted.getOrElse(first.isBoosted),
+      imageHide = second.imageHide.getOrElse(first.imageHide),
+      imageReplace = second.imageReplace.getOrElse(first.imageReplace),
+      showKickerSection = second.showKickerSection.getOrElse(first.showKickerSection),
+      showKickerCustom = second.showKickerCustom.getOrElse(first.showKickerCustom),
+      showBoostedHeadline = second.showBoostedHeadline.getOrElse(first.showBoostedHeadline),
+      showMainVideo = second.showMainVideo.getOrElse(first.showMainVideo),
+      showKickerTag = second.showKickerTag.getOrElse(first.showKickerTag),
+      showByline = second.showByline.getOrElse(first.showByline),
+      imageCutoutReplace = second.imageCutoutReplace.getOrElse(first.imageCutoutReplace),
+      showQuotedHeadline = second.showQuotedHeadline.getOrElse(first.showQuotedHeadline)
+    )
 
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields): ResolvedMetaData = {
     val metaDataDefaultsForTrailMeta = fromTrailMetaData(trailMeta)

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -14,22 +14,25 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     val trailMetadata = Mockito.spy(TrailMetaData.empty)
     val content = mock[Content]
     val collectionConfig = Mockito.spy(CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+    val metaDataDefaults = MetadataDefaults.Default
 
     "should prefer item level custom kicker to collection level section kicker" in {
       when(trailMetadata.customKicker).thenReturn(Some("custom kicker"))
       when(trailMetadata.showKickerCustom).thenReturn(Some(true))
+      val metaDataDefaultsWithShowKickerCustom = metaDataDefaults.copy(showKickerCustom = true)
       when(collectionConfig.showSections).thenReturn(true)
 
-      ItemKicker.fromContentAndTrail(content, trailMetadata, Some(collectionConfig)).value shouldBe a [FreeHtmlKicker]
+      ItemKicker.fromContentAndTrail(content, trailMetadata, metaDataDefaultsWithShowKickerCustom, Some(collectionConfig)).value shouldBe a [FreeHtmlKicker]
     }
 
     "should prefer item level section kicker to collection level tag kicker" in {
       when(collectionConfig.showTags).thenReturn(true)
       when(trailMetadata.showKickerSection).thenReturn(Some(true))
+      val metaDataDefaultsWithShowKickerSection = metaDataDefaults.copy(showKickerSection = true)
       when(content.sectionId).thenReturn(Some("section"))
       when(content.sectionName).thenReturn(Some("Section"))
 
-      ItemKicker.fromContentAndTrail(content, trailMetadata, Some(collectionConfig)).value shouldBe a [SectionKicker]
+      ItemKicker.fromContentAndTrail(content, trailMetadata, metaDataDefaultsWithShowKickerSection, Some(collectionConfig)).value shouldBe a [SectionKicker]
     }
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -14,7 +14,7 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     val trailMetadata = Mockito.spy(TrailMetaData.empty)
     val content = mock[Content]
     val collectionConfig = Mockito.spy(CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
-    val metaDataDefaults = MetadataDefaults.Default
+    val metaDataDefaults = ResolvedMetaData.Default
 
     "should prefer item level custom kicker to collection level section kicker" in {
       when(trailMetadata.customKicker).thenReturn(Some("custom kicker"))

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -39,33 +39,40 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers {
   "Resolving Metadata using fromContent" - {
 
     "Content with type cartoon should showByline" in {
-      ResolvedMetaData.fromContent(contentWithCartoon).showByline should be (true)
+      val resolvedMetaData = ResolvedMetaData.fromContent(contentWithCartoon)
+      resolvedMetaData should have (
+        'showByline (true))
     }
 
     "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
-      ResolvedMetaData.fromContent(contentWithComment).showByline should be (true)
-      ResolvedMetaData.fromContent(contentWithComment).showQuotedHeadline should be (true)
-      ResolvedMetaData.fromContent(contentWithComment).imageCutoutReplace should be (true)
+      val resolvedMetaData = ResolvedMetaData.fromContent(contentWithComment)
+      resolvedMetaData should have (
+        'showByline (true),
+        'showQuotedHeadline (true),
+        'imageCutoutReplace (true))
     }
 
     "Content with type video should showMainVideo" in {
-      ResolvedMetaData.fromContent(contentWithVideo).showMainVideo should be (true)
+      val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo)
+      resolvedMetaData should have (
+        'showMainVideo (true))
     }
 
     "Content with silly type should all false" in {
       val contentWithVideo = contentWithTags(tagWithId("sillyid"))
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo)
-     resolvedMetaData.showByline should be (false)
-     resolvedMetaData.showQuotedHeadline should be (false)
-     resolvedMetaData.imageCutoutReplace should be (false)
-     resolvedMetaData.showMainVideo should be (false)
-     resolvedMetaData.isBoosted should be (false)
-     resolvedMetaData.isBreaking should be (false)
-     resolvedMetaData.imageHide should be (false)
-     resolvedMetaData.imageReplace should be (false)
-     resolvedMetaData.showKickerCustom should be (false)
-     resolvedMetaData.showKickerSection should be (false)
-     resolvedMetaData.showKickerTag should be (false)
+      resolvedMetaData should have (
+        'showByline (false),
+        'showQuotedHeadline (false),
+        'imageCutoutReplace (false),
+        'showMainVideo (false),
+        'isBoosted (false),
+        'isBreaking (false),
+        'imageHide (false),
+        'imageReplace (false),
+        'showKickerCustom (false),
+        'showKickerSection (false),
+        'showKickerTag (false))
     }
   }
 
@@ -73,32 +80,35 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers {
 
     "Resolve all to false for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(emptyTrailMetaData)
-      resolvedMetaData.showByline should be (false)
-      resolvedMetaData.showQuotedHeadline should be (false)
-      resolvedMetaData.imageCutoutReplace should be (false)
-      resolvedMetaData.showMainVideo should be (false)
-      resolvedMetaData.isBoosted should be (false)
-      resolvedMetaData.isBreaking should be (false)
-      resolvedMetaData.imageHide should be (false)
-      resolvedMetaData.imageReplace should be (false)
-      resolvedMetaData.showKickerCustom should be (false)
-      resolvedMetaData.showKickerSection should be (false)
-      resolvedMetaData.showKickerTag should be (false)
+      resolvedMetaData should have (
+        'showByline (false),
+        'showQuotedHeadline (false),
+        'imageCutoutReplace (false),
+        'showMainVideo (false),
+        'isBoosted (false),
+        'isBreaking (false),
+        'imageHide (false),
+        'imageReplace (false),
+        'showKickerCustom (false),
+        'showKickerSection (false),
+        'showKickerTag (false))
     }
 
     "Resolve all to true for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMetaDataWithFieldsSetTrue)
-      resolvedMetaData.showByline should be (true)
-      resolvedMetaData.showQuotedHeadline should be (true)
-      resolvedMetaData.imageCutoutReplace should be (true)
-      resolvedMetaData.showMainVideo should be (true)
-      resolvedMetaData.isBoosted should be (false)
-      resolvedMetaData.isBreaking should be (false)
-      resolvedMetaData.imageHide should be (false)
-      resolvedMetaData.imageReplace should be (false)
-      resolvedMetaData.showKickerCustom should be (false)
-      resolvedMetaData.showKickerSection should be (false)
-      resolvedMetaData.showKickerTag should be (false)
+      resolvedMetaData should have (
+        'showByline (true),
+        'showQuotedHeadline (true),
+        'imageCutoutReplace (true),
+        'showMainVideo (true),
+        'isBoosted (false),
+        'isBreaking (false),
+        'imageHide (false),
+        'imageReplace (false),
+        'showKickerCustom (false),
+        'showKickerSection (false),
+        'showKickerTag (false)
+      )
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -1,0 +1,96 @@
+package com.gu.facia.api.utils
+
+import com.gu.contentapi.client.model.{Content, Tag}
+import com.gu.facia.client.models.TrailMetaData
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.libs.json.JsBoolean
+
+class ResolvedMetaDataTest extends FreeSpec with Matchers {
+
+  "Resolving Metadata using fromContent" - {
+    def tagWithId(id: String) = Tag(
+      id = id,
+      `type` = "",
+      webTitle = "",
+      webUrl = "",
+      apiUrl = "")
+
+    def contentWithTags(tags: Tag*): Content = Content(
+      "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+      fields = Option(Map.empty), tags.toList, None, Nil, None)
+
+    "Content with type cartoon should showByline" in {
+      val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
+      ResolvedMetaData.fromContent(contentWithCartoon).showByline should be (true)
+    }
+
+    "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
+      val contentWithComment = contentWithTags(tagWithId("tone/comment"))
+      ResolvedMetaData.fromContent(contentWithComment).showByline should be (true)
+      ResolvedMetaData.fromContent(contentWithComment).showQuotedHeadline should be (true)
+      ResolvedMetaData.fromContent(contentWithComment).imageCutoutReplace should be (true)
+    }
+
+    "Content with type video should showMainVideo" in {
+      val contentWithVideo = contentWithTags(tagWithId("type/video"))
+      ResolvedMetaData.fromContent(contentWithVideo).showMainVideo should be (true)
+    }
+
+    "Content with silly type should all false" in {
+      val contentWithVideo = contentWithTags(tagWithId("sillyid"))
+      val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo)
+     resolvedMetaData.showByline should be (false)
+     resolvedMetaData.showQuotedHeadline should be (false)
+     resolvedMetaData.imageCutoutReplace should be (false)
+     resolvedMetaData.showMainVideo should be (false)
+     resolvedMetaData.isBoosted should be (false)
+     resolvedMetaData.isBreaking should be (false)
+     resolvedMetaData.imageHide should be (false)
+     resolvedMetaData.imageReplace should be (false)
+     resolvedMetaData.showKickerCustom should be (false)
+     resolvedMetaData.showKickerSection should be (false)
+     resolvedMetaData.showKickerTag should be (false)
+    }
+  }
+
+  "Resolving Metadata using fromTrailMetaData" - {
+
+    "Resolve all to false for empty TrailMetaData" in {
+      val emptyTrailMetaData = TrailMetaData(Map.empty)
+      val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(emptyTrailMetaData)
+      resolvedMetaData.showByline should be (false)
+      resolvedMetaData.showQuotedHeadline should be (false)
+      resolvedMetaData.imageCutoutReplace should be (false)
+      resolvedMetaData.showMainVideo should be (false)
+      resolvedMetaData.isBoosted should be (false)
+      resolvedMetaData.isBreaking should be (false)
+      resolvedMetaData.imageHide should be (false)
+      resolvedMetaData.imageReplace should be (false)
+      resolvedMetaData.showKickerCustom should be (false)
+      resolvedMetaData.showKickerSection should be (false)
+      resolvedMetaData.showKickerTag should be (false)
+    }
+
+    "Resolve all to true for empty TrailMetaData" in {
+      val trailMetaData = TrailMetaData(
+        Map("showByline" -> JsBoolean(true),
+        "showMainVideo" -> JsBoolean(true),
+        "showQuotedHeadline" -> JsBoolean(true),
+        "imageCutoutReplace" -> JsBoolean(true)))
+      val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMetaData)
+      resolvedMetaData.showByline should be (true)
+      resolvedMetaData.showQuotedHeadline should be (true)
+      resolvedMetaData.imageCutoutReplace should be (true)
+      resolvedMetaData.showMainVideo should be (true)
+      resolvedMetaData.isBoosted should be (false)
+      resolvedMetaData.isBreaking should be (false)
+      resolvedMetaData.imageHide should be (false)
+      resolvedMetaData.imageReplace should be (false)
+      resolvedMetaData.showKickerCustom should be (false)
+      resolvedMetaData.showKickerSection should be (false)
+      resolvedMetaData.showKickerTag should be (false)
+    }
+
+  }
+
+}

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -114,30 +114,44 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers {
 
   "Resolving Metadata using fromContentAndTrailMetaData" - {
 
-    "should resolve correct for cartoon, comment and video when trailMetaData is not set" in {
+    "should resolve correct for cartoon when trailMetaData is not set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, emptyTrailMetaData)
-      resolvedCartoon.showByline should be(true)
-
-      val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData)
-      resolvedComment.showByline should be(true)
-      resolvedComment.showQuotedHeadline should be(true)
-      resolvedComment.imageCutoutReplace should be(true)
-
-      val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, emptyTrailMetaData)
-      resolvedVideo.showMainVideo should be(true)
+      resolvedCartoon should have (
+        'showByline (true))
     }
 
-    "should resolve correct for cartoon, comment and video when trailMetaData IS set" in {
+    "should resolve correct for comment when trailMetaData is not set" in {
+      val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData)
+      resolvedComment should have (
+        'showByline (true),
+        'showQuotedHeadline (true),
+        'imageCutoutReplace (true))
+    }
+
+    "should resolve correct for video when trailMetaData is not set" in {
+      val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, emptyTrailMetaData)
+      resolvedVideo should have (
+        'showMainVideo (true))
+    }
+
+    "should resolve correct for cartoon when trailMetaData IS set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, trailMetaDataWithFieldsSetFalse)
-      resolvedCartoon.showByline should be(false)
+      resolvedCartoon should have (
+        'showByline (false))
+    }
 
+    "should resolve correct for comment when trailMetaData IS set" in {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, trailMetaDataWithFieldsSetFalse)
-      resolvedComment.showByline should be(false)
-      resolvedComment.showQuotedHeadline should be(false)
-      resolvedComment.imageCutoutReplace should be(false)
+      resolvedComment should have (
+        'showByline (false),
+        'showQuotedHeadline (false),
+        'imageCutoutReplace (false))
+    }
 
+    "should resolve correct for video when trailMetaData IS set" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, trailMetaDataWithFieldsSetFalse)
-      resolvedVideo.showMainVideo should be(false)
+      resolvedVideo should have (
+        'showMainVideo (false))
     }
   }
 


### PR DESCRIPTION
This adds the same logic that exists in `frontend` around the resolving of metadata based on the type of a piece of content, and then overriding if the tool has set the metadata explicitly.

In `frontend` it is called `MetadataDefaults`, but I think I prefer the name `ResolvedMetaData`. It makes more sense to me.

@robertberry @adamnfish 