### PR TITLE
kickerText(FreeHtmlKicker* ) now returns text of plain-text kickers

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -91,7 +91,7 @@ object ItemKicker {
   }
 
   def stringIfPlainText(string: String) : Option[String] = {
-    val StringWithHtml = "<\\w+>".r.unanchored
+    val StringWithHtml = "<\\w+.*>".r.unanchored
     string match {
       case StringWithHtml() => None
       case _ => Some(string)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -90,14 +90,22 @@ object ItemKicker {
     case _ => None
   }
 
+  def stringIfPlainText(string: String) : Option[String] = {
+    val StringWithHtml = "<\\w+>".r.unanchored
+    string match {
+      case StringWithHtml() => None
+      case _ => Some(string)
+    }
+  }
+
   /** Return a plain-text representation of a kicker */
   def kickerText(itemKicker: ItemKicker): Option[String] = itemKicker match {
     case BreakingNewsKicker => Some("Breaking")
     case AnalysisKicker => Some("Analysis")
     case ReviewKicker => Some("Review")
     case CartoonKicker => Some("Cartoon")
-    case FreeHtmlKicker(_) => None
-    case FreeHtmlKickerWithLink(_, _) => None
+    case FreeHtmlKicker(text) => stringIfPlainText(text)
+    case FreeHtmlKickerWithLink(text, _) => stringIfPlainText(text)
     case _ => kickerContents(itemKicker)
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -79,6 +79,7 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     "should return nothing for free HTML kickers containing HTML" in {
       ItemKicker.kickerText(FreeHtmlKicker("<b>Something</b>")) shouldBe None
       ItemKicker.kickerText(FreeHtmlKickerWithLink("<b>Something</b>", "http://www.theguardian.com/football")) shouldBe None
+      ItemKicker.kickerText(FreeHtmlKickerWithLink("<a href=\"foo\">Something</b>", "http://www.theguardian.com/football")) shouldBe None
     }
 
     "should return the text of free HTML kickers not actually containing HTML" in {

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -78,6 +78,7 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
 
     "should return nothing for free HTML kickers containing HTML" in {
       ItemKicker.kickerText(FreeHtmlKicker("<b>Something</b>")) shouldBe None
+      ItemKicker.kickerText(FreeHtmlKicker("Look at <a href=\"http://example.com\">this</a> link")) shouldBe None
       ItemKicker.kickerText(FreeHtmlKickerWithLink("<b>Something</b>", "http://www.theguardian.com/football")) shouldBe None
       ItemKicker.kickerText(FreeHtmlKickerWithLink("<a href=\"foo\">Something</b>", "http://www.theguardian.com/football")) shouldBe None
     }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -49,7 +49,6 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     "should return the contents of free HTML kickers (with links)" in {
       ItemKicker.kickerContents(FreeHtmlKickerWithLink("<b>Something</b>", "http://www.theguardian.com/football")) shouldBe Some("<b>Something</b>")
     }
-
   }
 
   "kickerText" - {
@@ -77,9 +76,14 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       ItemKicker.kickerText(SectionKicker("Football", "")) shouldBe Some("Football")
     }
 
-    "should return nothing for free HTML kickers" in {
+    "should return nothing for free HTML kickers containing HTML" in {
       ItemKicker.kickerText(FreeHtmlKicker("<b>Something</b>")) shouldBe None
       ItemKicker.kickerText(FreeHtmlKickerWithLink("<b>Something</b>", "http://www.theguardian.com/football")) shouldBe None
+    }
+
+    "should return the text of free HTML kickers not actually containing HTML" in {
+      ItemKicker.kickerText(FreeHtmlKicker("Something")) shouldBe Some("Something")
+      ItemKicker.kickerText(FreeHtmlKickerWithLink("Something", "http://www.theguardian.com/football")) shouldBe Some("Something")
     }
   }
 }


### PR DESCRIPTION
This is a workaround for the current tendency to use `FreeHtmlKicker` for plain-text keyword kickers; once there is a `FreeTextKicker` or similar, it will hopefully be obsolete.