### PR TITLE
Change logic around itemKicker for SupportingCuratedContent

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -329,7 +329,7 @@ object SupportingCuratedContent {
       resolvedMetaData.showKickerTag,
       trailMetaData.byline.orElse(contentFields.get("byline")),
       resolvedMetaData.showByline,
-      ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
+      ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, None),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
       resolvedMetaData.showBoostedHeadline,
       resolvedMetaData.showQuotedHeadline)}

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -1,9 +1,11 @@
 package com.gu.facia.api.models
 
-import com.gu.contentapi.client.model.Content
+import com.gu.contentapi.client.model.{Tag, Content}
+import com.gu.facia.api.utils.{TagKicker, SectionKicker}
 import com.gu.facia.client.models.{CollectionConfigJson, TrailMetaData}
 import org.scalatest.{FreeSpec, Matchers}
-import play.api.libs.json.JsString
+import play.api.libs.json.{JsBoolean, JsString}
+import org.scalatest.OptionValues._
 
 class CuratedContentTest extends FreeSpec with Matchers {
 
@@ -35,6 +37,83 @@ class CuratedContentTest extends FreeSpec with Matchers {
     "should resolve the headline from Content webTitle" in {
       val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
       curatedContent.headline should be ("contentWithoutFieldHeadlineHeadline")
+    }
+  }
+
+  "CuratedContent itemKicker" - {
+    val emptyContent = Content(
+      "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+      fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None)
+    val emptyTrailMetaData = TrailMetaData(Map.empty)
+    val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
+    val collectionConfigShowSections = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showSections = Option(true)))
+    val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
+
+    "should resolve to None" in {
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfig)
+      curatedContent.kicker should be (None)
+    }
+
+    "should resolve to SectionKicker with config showSections true" in {
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowSections)
+      curatedContent.kicker.value shouldBe a [SectionKicker]
+    }
+
+    "should resolve to TagKicker with config showTags true" in {
+      //This test requires content to have tags
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowTags)
+      curatedContent.kicker.value shouldBe a [TagKicker]
+    }
+
+    "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
+      val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, collectionConfigShowTags)
+      curatedContent.kicker.value shouldBe a [SectionKicker]
+    }
+
+    "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
+      val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, collectionConfigShowTags)
+      curatedContent.kicker.value shouldBe a [TagKicker]
+    }
+  }
+
+  "SupportingCuratedContent itemKicker" - {
+    val emptyContent = Content(
+      "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
+      fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
+      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None)
+    val emptyTrailMetaData = TrailMetaData(Map.empty)
+    val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
+    val collectionConfigShowSections = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showSections = Option(true)))
+    val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
+
+    "should resolve to None" in {
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfig)
+      supportingCuratedContent.kicker should be (None)
+    }
+
+    "should resolve to None with config showSections true" in {
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowSections)
+      supportingCuratedContent.kicker should be (None)
+    }
+
+    "should resolve to None with config showTags true" in {
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowTags)
+      supportingCuratedContent.kicker should be (None)
+    }
+
+    "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
+      val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, collectionConfigShowTags)
+      supportingCuratedContent.kicker.value shouldBe a [SectionKicker]
+    }
+
+    "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
+      val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, collectionConfigShowTags)
+      supportingCuratedContent.kicker.value shouldBe a [TagKicker]
     }
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -10,12 +10,12 @@ import org.mockito.Mockito._
 
 
 class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with OptionValues with OneInstancePerTest {
-  "fromContentAndTrail" - {
-    val trailMetadata = Mockito.spy(TrailMetaData.empty)
-    val content = mock[Content]
-    val collectionConfig = Mockito.spy(CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
-    val metaDataDefaults = ResolvedMetaData.Default
+  val trailMetadata = Mockito.spy(TrailMetaData.empty)
+  val content = mock[Content]
+  val collectionConfig = Mockito.spy(CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+  val metaDataDefaults = ResolvedMetaData.Default
 
+  "fromContentAndTrail" - {
     "should prefer item level custom kicker to collection level section kicker" in {
       when(trailMetadata.customKicker).thenReturn(Some("custom kicker"))
       when(trailMetadata.showKickerCustom).thenReturn(Some(true))
@@ -84,5 +84,19 @@ class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       ItemKicker.kickerText(FreeHtmlKicker("<b>Something</b>")) shouldBe None
       ItemKicker.kickerText(FreeHtmlKickerWithLink("<b>Something</b>", "http://www.theguardian.com/football")) shouldBe None
     }
+  }
+
+  "section kicker" - {
+    "should not appear for supporting" in {
+      when(trailMetadata.showKickerSection).thenReturn(Some(false))
+      val metaDataDefaultsWithShowKickerSection = metaDataDefaults.copy(showKickerSection = false)
+      when(content.sectionId).thenReturn(Some("section"))
+      when(content.sectionName).thenReturn(Some("Section"))
+      when(content.tags).thenReturn(Nil)
+      when(content.safeFields).thenReturn(Map.empty[String, String])
+
+      ItemKicker.fromContentAndTrail(content, trailMetadata, metaDataDefaultsWithShowKickerSection, None) should be (None)
+    }
+
   }
 }


### PR DESCRIPTION
In the past, the `config` was ignored when resolving the `ItemKicker` for a `SupportingCuratedContent` by passing a `None`.

This puts that behaviour back in.

@adamnfish @robertberry 