### PR TITLE
Use ResolvedMetaData when creating ImageCutout

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -43,12 +43,14 @@ object ImageCutout {
         None)
   }
 
-  def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] =
-    if (trailMeta.imageCutoutReplace.exists(identity))
+  def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] = {
+    val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMeta)
+    if (resolvedMetaData.imageCutoutReplace)
       fromTrailMeta(trailMeta)
         .orElse(fromContentTags(content, trailMeta))
     else
       None
+  }
 }
 
 sealed trait FaciaContent


### PR DESCRIPTION
Depending on the type of content, `imageCutoutReplace` should default to `true` when not set.

@robertberry @adamnfish 