### PR TITLE
Sorry I need to do this inside MAPI instead

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -113,7 +113,7 @@ object ContentApi {
   def latestContentFromLatestSnaps(capiClient: GuardianContentClient, latestSnapsRequest: LatestSnapsRequest, adjustItemQuery: AdjustItemQuery)
                                   (implicit ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
     def itemQueryFromSnapUri(uri: String): ItemQuery =
-      adjustItemQuery(capiClient.item(uri).pageSize(1).showFields("internalContentCode,shortUrl"))
+      adjustItemQuery(capiClient.item(uri).pageSize(1).showFields("internalContentCode"))
 
     Response.Async.Right(
       Future.traverse(latestSnapsRequest.snaps) { case (id, uri) =>


### PR DESCRIPTION
Hi @robertberry,
Today I realize that only MAPI needs this field and therefore it shouldn't be polluting the library.
No rush, but we should merge this PR before the next release of the facia-client.

Cheers
