### PR TITLE
Canonical collections

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -76,7 +76,8 @@ case class FrontJson(
   imageHeight: Option[Int],
   isImageDisplayed: Option[Boolean],
   priority: Option[String],
-  isHidden: Option[Boolean]
+  isHidden: Option[Boolean],
+  canonical: Option[String]
 )
 
 object ConfigJson {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -40,7 +40,13 @@ object Front {
       imageWidth <- frontJson.imageWidth
     } yield FrontImage(imageUrl, imageHeight, imageWidth)
 
-  def fromFrontJson(id: String, frontJson: FrontJson): Front =
+  def fromFrontJson(id: String, frontJson: FrontJson): Front = {
+    val canonical = id match {
+      case "uk" => "uk-alpha/news/regular-stories"
+      case "us" => "us-alpha/news/regular-stories"
+      case "au" => "au-alpha/news/regular-stories"
+      case _ => frontJson.canonical.orElse(frontJson.collections.headOption).getOrElse("no collections")
+    }
     Front(
       id,
       frontJson.collections,
@@ -53,8 +59,9 @@ object Front {
       frontJson.isImageDisplayed.getOrElse(false),
       getFrontPriority(frontJson),
       frontJson.isHidden.getOrElse(false),
-      frontJson.canonical.orElse(frontJson.collections.headOption).getOrElse("no collections")
+      canonical
     )
+  }
 
   def frontsFromConfig(configJson: ConfigJson): Set[Front] = {
     configJson.fronts

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -23,7 +23,8 @@ case class Front(
                   frontImage: Option[FrontImage],
                   isImageDisplayed: Boolean,
                   priority: FrontPriority,
-                  isHidden: Boolean)
+                  isHidden: Boolean,
+                  canonicalCollection: String)
 
 object Front {
   private def getFrontPriority(frontJson: FrontJson): FrontPriority =
@@ -51,7 +52,8 @@ object Front {
       getImageUrl(frontJson),
       frontJson.isImageDisplayed.getOrElse(false),
       getFrontPriority(frontJson),
-      frontJson.isHidden.getOrElse(false)
+      frontJson.isHidden.getOrElse(false),
+      frontJson.canonical.orElse(frontJson.collections.headOption).getOrElse("no collections")
     )
 
   def frontsFromConfig(configJson: ConfigJson): Set[Front] = {

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -21,16 +21,31 @@ class FrontTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneI
         Front.fromFrontJson("frontId", frontJson).canonicalCollection should equal("collection1")
       }
 
-      "on the uk front, always takes the uk headlines container even if it is not at the top" in {
-        Front.fromFrontJson("uk", frontJson).canonicalCollection should equal("uk-alpha/news/regular-stories")
+      "on the uk front, takes the editorially-chosen PROD uk headlines collection if it is present" in {
+        val ukFrontJson = frontJson.copy(collections = frontJson.collections :+ "uk-alpha/news/regular-stories")
+        Front.fromFrontJson("uk", ukFrontJson).canonicalCollection should equal("uk-alpha/news/regular-stories")
       }
 
-      "on the us front, takes the uk headlines container even if it is not at the top" in {
-        Front.fromFrontJson("us", frontJson).canonicalCollection should equal("us-alpha/news/regular-stories")
+      "on the uk front, takes the first collection if the editorially-chosen uk headlines collection is not present" in {
+        Front.fromFrontJson("uk", frontJson).canonicalCollection should equal("collection1")
       }
 
-      "on the au front, takes the uk headlines container even if it is not at the top" in {
-        Front.fromFrontJson("au", frontJson).canonicalCollection should equal("au-alpha/news/regular-stories")
+      "on the us front, takes the editorially-chosen PROD us headlines collection if it is present" in {
+        val usFrontJson = frontJson.copy(collections = frontJson.collections :+ "us-alpha/news/regular-stories")
+        Front.fromFrontJson("us", usFrontJson).canonicalCollection should equal("us-alpha/news/regular-stories")
+      }
+
+      "on the us front, takes the first collection if the editorially-chosen us headlines collection is not present" in {
+        Front.fromFrontJson("us", frontJson).canonicalCollection should equal("collection1")
+      }
+
+      "on the au front, takes the editorially-chosen PROD au headlines collection if it is present" in {
+        val auFrontJson = frontJson.copy(collections = frontJson.collections :+ "au-alpha/news/regular-stories")
+        Front.fromFrontJson("au", auFrontJson).canonicalCollection should equal("au-alpha/news/regular-stories")
+      }
+
+      "on the au front, takes the first collection if the editorially-chosen au headlines collection is not present" in {
+        Front.fromFrontJson("au", frontJson).canonicalCollection should equal("collection1")
       }
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -1,0 +1,25 @@
+package com.gu.facia.api.models
+
+import com.gu.facia.client.models.FrontJson
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+
+class FrontTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneInstancePerTest {
+  "fromFrontJson" - {
+    "when generating the canonical field" - {
+      val frontJson = FrontJson(
+        collections = List("collection1", "collection2", "collection3", "collection4"),
+        None, None, None, None, None, None, None, None, None, None, None, None
+      )
+
+      "uses the fronts config field if present" in {
+        val frontJsonWithCanonical = frontJson.copy(canonical = Some("collection2"))
+        Front.fromFrontJson("frontId", frontJsonWithCanonical).canonicalCollection should equal("collection2")
+      }
+
+      "in the absence of a fronts config field, takes the first present collection" in {
+        Front.fromFrontJson("frontId", frontJson).canonicalCollection should equal("collection1")
+      }
+    }
+  }
+}

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -20,6 +20,18 @@ class FrontTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneI
       "in the absence of a fronts config field, takes the first present collection" in {
         Front.fromFrontJson("frontId", frontJson).canonicalCollection should equal("collection1")
       }
+
+      "on the uk front, always takes the uk headlines container even if it is not at the top" in {
+        Front.fromFrontJson("uk", frontJson).canonicalCollection should equal("uk-alpha/news/regular-stories")
+      }
+
+      "on the us front, takes the uk headlines container even if it is not at the top" in {
+        Front.fromFrontJson("us", frontJson).canonicalCollection should equal("us-alpha/news/regular-stories")
+      }
+
+      "on the au front, takes the uk headlines container even if it is not at the top" in {
+        Front.fromFrontJson("au", frontJson).canonicalCollection should equal("au-alpha/news/regular-stories")
+      }
     }
   }
 }


### PR DESCRIPTION
This PR replaces https://github.com/guardian/facia-scala-client/pull/80. The canonical container either comes from the FrontJson, or is the first container on the front.

Note that this PR contains two commits, the second specifies the edition network fronts' canonical containers as well. While we wait for the tools to support this feature, the network front canonical containers can be hard-coded. This commit can be rolled back when the tools support is in place and the correct JSON is actually coming through.

Don't merge this yet, it's open for comment/review, I'm going to test it by integrating it with MAPI.

Note that I'm assured there can never be a front with 0 containers. I've raised a an issue (https://github.com/guardian/facia-scala-client/issues/83) suggesting we capture this by making that a `NonEmptyList`. That would remove the need for the `"no collections"` fallback string.