### PR TITLE
Request treats

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -87,6 +87,19 @@ object FAPI {
     for(snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, allSnaps, adjustItemQuery))
       yield snapContent}
 
+  def getTreatsForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+                      (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
+    val treatsRequest = Collection.treatsRequestFor(collection)
+    ContentApi.buildHydrateQueries(capiClient, treatsRequest.treatIds, adjustSearchQuery) match {
+      case Success(hydrateQueries) =>
+        for {
+          hydrateResponses <- ContentApi.getHydrateResponse(capiClient, hydrateQueries)
+          snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, treatsRequest.latestSnapsRequest, adjustItemQuery)
+          setOfContent = ContentApi.itemsFromSearchResponses(hydrateResponses)}
+    yield Collection.treatContent(collection, setOfContent, snapContent)
+      case Failure(error) =>
+        Response.Left(UrlConstructError(error.getMessage, Some(error)))}}
+
   def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
                                 (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     val collectionWithoutSnaps = Collection.withoutSnaps(collection)

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -9,7 +9,6 @@ import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.TrailMetaData
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 
 
 object FAPI {

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -89,12 +89,12 @@ object FAPI {
 
   def getTreatsForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
                             (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
-    val treatsRequest = Collection.treatsRequestFor(collection)
-    ContentApi.buildHydrateQueries(capiClient, treatsRequest.treatIds, adjustSearchQuery) match {
+    val (treatIds, treatsSnapsRequest) = Collection.treatsRequestFor(collection)
+    ContentApi.buildHydrateQueries(capiClient, treatIds, adjustSearchQuery) match {
       case Success(hydrateQueries) =>
         for {
           hydrateResponses <- ContentApi.getHydrateResponse(capiClient, hydrateQueries)
-          snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, treatsRequest.latestSnapsRequest, adjustItemQuery)
+          snapContent <- ContentApi.latestContentFromLatestSnaps(capiClient, treatsSnapsRequest, adjustItemQuery)
           setOfContent = ContentApi.itemsFromSearchResponses(hydrateResponses)}
     yield Collection.treatContent(collection, setOfContent, snapContent)
       case Failure(error) =>

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -88,7 +88,7 @@ object FAPI {
       yield snapContent}
 
   def getTreatsForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-                      (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
+                            (implicit capiClient: GuardianContentClient, ec: ExecutionContext) = {
     val treatsRequest = Collection.treatsRequestFor(collection)
     ContentApi.buildHydrateQueries(capiClient, treatsRequest.treatIds, adjustSearchQuery) match {
       case Success(hydrateQueries) =>

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -13,6 +13,13 @@ case class LatestSnapsRequest(snaps: Map[String, String]) {
   def join(other: LatestSnapsRequest): LatestSnapsRequest = this.copy(snaps = this.snaps ++ other.snaps)
 }
 
+case class TreatsRequest(treatIds: List[String], latestSnapsRequest: LatestSnapsRequest) {
+  def join(other: TreatsRequest): TreatsRequest =
+    this.copy(
+      latestSnapsRequest = this.latestSnapsRequest.join(other.latestSnapsRequest),
+      treatIds = this.treatIds ++ treatIds)
+}
+
 object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery
   type AdjustItemQuery = ItemQuery => ItemQuery

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -13,8 +13,6 @@ case class LatestSnapsRequest(snaps: Map[String, String]) {
   def join(other: LatestSnapsRequest): LatestSnapsRequest = this.copy(snaps = this.snaps ++ other.snaps)
 }
 
-case class TreatsRequest(treatIds: List[String], latestSnapsRequest: LatestSnapsRequest)
-
 object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery
   type AdjustItemQuery = ItemQuery => ItemQuery

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import com.gu.contentapi.client.{GuardianContentClient, ContentApiClientLogic}
 import com.gu.contentapi.client.model._
-import com.gu.facia.api.{CapiError, Response}
+import com.gu.facia.api.{UrlConstructError, CapiError, Response}
 
 import scala.concurrent.{Future, ExecutionContext}
 import scala.util.Try
@@ -17,22 +17,18 @@ object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery
   type AdjustItemQuery = ItemQuery => ItemQuery
 
-  def buildHydrateQueries(client: ContentApiClientLogic, ids: List[String], adjustSearchQuery: AdjustSearchQuery = identity): Try[Seq[SearchQuery]] = {
+  def buildHydrateQueries(client: ContentApiClientLogic, ids: List[String], adjustSearchQuery: AdjustSearchQuery = identity): Response[Seq[SearchQuery]] = {
     def queryForIds(ids: Seq[String]) = adjustSearchQuery(client.search
       .ids(ids mkString ",")
       .pageSize(ids.size)
       .showFields("internalContentCode"))
 
-    Try {
-      IdsSearchQueries.makeBatches(ids)(ids => client.getUrl(queryForIds(ids))) match {
+    IdsSearchQueries.makeBatches(ids)(ids => client.getUrl(queryForIds(ids))) match {
         case Some(batches) =>
-          batches.map(queryForIds)
-
+          Response.Right(batches.map(queryForIds))
         case None =>
-          throw new RuntimeException("Unable to construct url for ids search query (the constructed URL for a " +
-            s"single ID must be too long!): ${ids.mkString(", ")}")
-      }
-    }
+          Response.Left(UrlConstructError("Unable to construct url for ids search query (the constructed URL for a " +
+            s"single ID must be too long!): ${ids.mkString(", ")}"))}
   }
 
   def getHydrateResponse(client: ContentApiClientLogic, searchQueries: Seq[SearchQuery])(implicit ec: ExecutionContext): Response[Seq[SearchResponse]] = {

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -7,7 +7,7 @@ import com.gu.contentapi.client.model._
 import com.gu.facia.api.{UrlConstructError, CapiError, Response}
 
 import scala.concurrent.{Future, ExecutionContext}
-import scala.util.Try
+import scala.util.{Success, Try}
 
 case class LatestSnapsRequest(snaps: Map[String, String]) {
   def join(other: LatestSnapsRequest): LatestSnapsRequest = this.copy(snaps = this.snaps ++ other.snaps)
@@ -23,10 +23,10 @@ object ContentApi {
       .pageSize(ids.size)
       .showFields("internalContentCode"))
 
-    IdsSearchQueries.makeBatches(ids)(ids => client.getUrl(queryForIds(ids))) match {
-        case Some(batches) =>
+    Try(IdsSearchQueries.makeBatches(ids)(ids => client.getUrl(queryForIds(ids)))) match {
+        case Success(Some(batches)) =>
           Response.Right(batches.map(queryForIds))
-        case None =>
+        case _ =>
           Response.Left(UrlConstructError("Unable to construct url for ids search query (the constructed URL for a " +
             s"single ID must be too long!): ${ids.mkString(", ")}"))}
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -13,12 +13,7 @@ case class LatestSnapsRequest(snaps: Map[String, String]) {
   def join(other: LatestSnapsRequest): LatestSnapsRequest = this.copy(snaps = this.snaps ++ other.snaps)
 }
 
-case class TreatsRequest(treatIds: List[String], latestSnapsRequest: LatestSnapsRequest) {
-  def join(other: TreatsRequest): TreatsRequest =
-    this.copy(
-      latestSnapsRequest = this.latestSnapsRequest.join(other.latestSnapsRequest),
-      treatIds = this.treatIds ++ treatIds)
-}
+case class TreatsRequest(treatIds: List[String], latestSnapsRequest: LatestSnapsRequest)
 
 object ContentApi {
   type AdjustSearchQuery = SearchQuery => SearchQuery

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -98,7 +98,21 @@ object Collection {
       collection.live
       .filter(_.isSnap)
       .filter(_.safeMeta.snapType == Some("latest"))
-      .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri)).toMap)
+      .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
+      .toMap)
+
+  def treatsRequestFor(collection: Collection): TreatsRequest = {
+    val latestSnapsRequest =
+      LatestSnapsRequest(
+        collection.treats
+          .filter(_.isSnap)
+          .filter(_.safeMeta.snapType == Some("latest"))
+          .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
+          .toMap)
+
+    val treatIds = collection.treats.filterNot(_.isSnap).map(_.id)
+
+    TreatsRequest(treatIds, latestSnapsRequest)}
 
   def withoutSnaps(collection: Collection): Collection = {
     collection.copy(

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -12,6 +12,7 @@ case class Collection(
   href: Option[String],
   live: List[Trail],
   draft: Option[List[Trail]],
+  treats: List[Trail],
   lastUpdated: Option[DateTime],
   updatedBy: Option[String],
   updatedEmail: Option[String],

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -76,6 +76,11 @@ object Collection {
                   snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
     contentFrom(collection, content, snapContent, collection => collection.treats)
 
+  def draftContent(collection: Collection,
+                  content: Set[Content],
+                  snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
+    contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(Nil))
+
   def liveIdsWithoutSnaps(collection: Collection): List[String] =
     collection.live.filterNot(_.isSnap).map(_.id)
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -1,7 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
-import com.gu.facia.api.contentapi.{TreatsRequest, LatestSnapsRequest}
+import com.gu.facia.api.contentapi.LatestSnapsRequest
 import com.gu.facia.api.utils.IntegerString
 import com.gu.facia.client.models.{SupportingItem, Trail, CollectionJson}
 import org.joda.time.DateTime
@@ -101,7 +101,7 @@ object Collection {
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap)
 
-  def treatsRequestFor(collection: Collection): TreatsRequest = {
+  def treatsRequestFor(collection: Collection): (List[String], LatestSnapsRequest) = {
     val latestSnapsRequest =
       LatestSnapsRequest(
         collection.treats
@@ -112,7 +112,7 @@ object Collection {
 
     val treatIds = collection.treats.filterNot(_.isSnap).map(_.id)
 
-    TreatsRequest(treatIds, latestSnapsRequest)}
+    (treatIds, latestSnapsRequest)}
 
   def withoutSnaps(collection: Collection): Collection = {
     collection.copy(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -2,7 +2,7 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.{Content, Tag}
 import com.gu.facia.api.models.CollectionConfig
-import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
+import com.gu.facia.client.models.MetaDataCommonFields
 
 object ItemKicker {
   def fromContentAndTrail(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -1,8 +1,7 @@
 package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.Content
-import com.gu.facia.api.models._
-import com.gu.facia.client.models.{TrailMetaData, MetaDataCommonFields}
+import com.gu.facia.client.models.MetaDataCommonFields
 
 
 object ResolvedMetaData {

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -22,11 +22,17 @@ class ContentApiTest extends FreeSpec
 
   "buildHydrateQueries" - {
     "should do a search query with the provided ids" in {
-      ContentApi.buildHydrateQueries(testClient, List("1", "2")).success.get.head.parameters.get("ids").value should equal("1,2")
+      ContentApi.buildHydrateQueries(testClient, List("1", "2")).asFuture.futureValue.fold(
+        err => fail(s"expected hydrated queries, got error $err"),
+        result => result.head.parameters.get("ids").value should equal("1,2")
+      )
     }
 
     "sets page size to the number of curated items" in {
-      ContentApi.buildHydrateQueries(testClient, List("1", "2")).success.get.head.parameters.get("page-size").value should equal("2")
+      ContentApi.buildHydrateQueries(testClient, List("1", "2")).asFuture.futureValue.fold(
+        err => fail(s"expected hydrated queries, got error $err"),
+        result => result.head.parameters.get("page-size").value should equal("2")
+      )
     }
   }
 


### PR DESCRIPTION
This adds the ability to request `treats` for a given `Collection`.

For normal `items`/`trails`, it requests via a `SearchQuery`. For dream snaps, it requests via an `ItemQuery`.

@adamnfish @robertberry 