### PR TITLE
Fix kickers

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -332,7 +332,7 @@ object LatestSnap {
       trail.safeMeta.showKickerTag.exists(identity),
       trail.safeMeta.byline,
       trail.safeMeta.showByline.exists(identity),
-      ItemKicker.fromTrailMetaData(trail.safeMeta),
+      ItemKicker.fromTrailMetaDataAndMaybeContent(trail.safeMeta, maybeContent),
       ImageCutout.fromTrailMeta(trail.safeMeta),
       trail.safeMeta.showBoostedHeadline.exists(identity),
       trail.safeMeta.showQuotedHeadline.exists(identity)
@@ -357,7 +357,7 @@ object LatestSnap {
       supportingItem.safeMeta.showKickerTag.exists(identity),
       supportingItem.safeMeta.byline,
       supportingItem.safeMeta.showByline.exists(identity),
-      ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
+      ItemKicker.fromTrailMetaDataAndMaybeContent(supportingItem.safeMeta, maybeContent),
       ImageCutout.fromTrailMeta(supportingItem.safeMeta),
       supportingItem.safeMeta.showBoostedHeadline.exists(identity),
       supportingItem.safeMeta.showQuotedHeadline.exists(identity)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -41,7 +41,10 @@ object ItemKicker {
     }
   }
 
-  def fromTrailMetaData(trailMeta: MetaDataCommonFields): Option[ItemKicker] = fromContentAndTrail(None, trailMeta, ResolvedMetaData.Default, None)
+  def fromTrailMetaData(trailMeta: MetaDataCommonFields): Option[ItemKicker] = fromContentAndTrail(None, trailMeta, ResolvedMetaData.fromTrailMetaData(trailMeta), None)
+
+  def fromTrailMetaDataAndMaybeContent(trailMeta: MetaDataCommonFields, maybeContent: Option[Content]): Option[ItemKicker] =
+    fromContentAndTrail(maybeContent, trailMeta, ResolvedMetaData.fromTrailMetaData(trailMeta), None)
 
   def fromContentAndTrail(content: Content, trailMeta: MetaDataCommonFields, metaDataDefaults: ResolvedMetaData, config: Option[CollectionConfig]): Option[ItemKicker]
     = fromContentAndTrail(Option(content), trailMeta, metaDataDefaults, config)


### PR DESCRIPTION
When `LatestSnaps` were being created, they were using `ResolvedMetaData.Default` as the `ResolvedMetaData` instead of resolving from the `Trail` `MetaDataCommonFields`.

This also passes along an `Option[Content]` to the kicker resolving for `LatestSnap`.

@adamnfish @robertberry 