### PR TITLE
Carry embed values

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -382,7 +382,10 @@ case class CuratedContent(
   kicker: Option[ItemKicker],
   imageCutout: Option[ImageCutout],
   showBoostedHeadline: Boolean,
-  showQuotedHeadline: Boolean) extends FaciaContent
+  showQuotedHeadline: Boolean,
+  embedType: Option[String],
+  embedUri: Option[String],
+  embedCss: Option[String]) extends FaciaContent
 
 case class SupportingCuratedContent(
   content: Content,
@@ -429,7 +432,10 @@ object CuratedContent {
       ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
       resolvedMetaData.showBoostedHeadline,
-      resolvedMetaData.showQuotedHeadline)}
+      resolvedMetaData.showQuotedHeadline,
+      embedType = trailMetaData.snapType,
+      embedUri = trailMetaData.snapUri,
+      embedCss = trailMetaData.snapCss)}
 
   def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
@@ -453,8 +459,10 @@ object CuratedContent {
       ItemKicker.fromContentAndTrail(content, trailMetaData, resolvedMetaData, Some(collectionConfig)),
       ImageCutout.fromContentAndTrailMeta(content, trailMetaData),
       resolvedMetaData.showBoostedHeadline,
-      resolvedMetaData.showQuotedHeadline
-    )}
+      resolvedMetaData.showQuotedHeadline,
+      embedType = trailMetaData.snapType,
+      embedUri = trailMetaData.snapUri,
+      embedCss = trailMetaData.snapCss)}
 }
 
 object SupportingCuratedContent {

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -12,13 +12,13 @@ class FaciaContentHelperTest extends FreeSpec with Matchers {
 
   "should return the headline for a CuratedContent" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val cc = CuratedContent(content, Nil, "The headline", None, None, "myGroup", None, false, false, false, false, false, None, false, None, None, false, false)
+    val cc = CuratedContent(content, Nil, "The headline", None, None, "myGroup", None, false, false, false, false, false, None, false, None, None, false, false, None, None, None)
     FaciaContent.headline(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val cc = CuratedContent(content, Nil, "The headline", None, None, "myGroup", None, false, false, false, false, false, None, false, None, None, false, false)
+    val cc = CuratedContent(content, Nil, "The headline", None, None, "myGroup", None, false, false, false, false, false, None, false, None, None, false, false, None, None, None)
     FaciaContent.href(cc) should equal(None)
   }
 


### PR DESCRIPTION
In `facia-tool`, we have three fields that are used extensively with `Snap`s: `snapType`, `snapUri` and `snapCss`. They are used for embeds, such as when a football widget gets embedded on a page via a `LinkSnap`.

`Thrashers` on the other hand, use the same fields but are also an actual piece of content (For when they don't get upgraded). So for `thrashers` to work, normal content (`CuratedContent`) needs to carry these `snapX` fields, except now that it's no longer a `Snap` it makes no sense to call them `snapX`, they will now be known as `embedX`.

`SupportingCuratedContent` does not carry the fields as I don't think they need to right now.

@adamnfish @robertberry 
