### PR TITLE
Change ImageCutout fromContentTags

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -34,6 +34,7 @@ object ImageCutout {
 
   def fromContentTags(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] = {
     val contributorTags = content.tags.filter(_.`type` == "contributor")
+    if (contributorTags.length == 1)
       for {
         tag <- contributorTags.find(_.bylineLargeImageUrl.isDefined)
         path <- tag.bylineLargeImageUrl
@@ -41,6 +42,8 @@ object ImageCutout {
         path,
         None,
         None)
+    else
+      None
   }
 
   def fromContentAndTrailMeta(content: Content, trailMeta: MetaDataCommonFields): Option[ImageCutout] = {


### PR DESCRIPTION
This changes `ImageCutout.fromContentTags` so return an `ImageCutout` when there is only one contributor in the `tags` for the `Content`.

This brings back the original behaviour which got lost in the transfer from `frontend`.

@adamnfish @robertberry @DiegoVazquezNanini 