### PR TITLE
Draft collections

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -95,19 +95,33 @@ object FAPI {
     yield Collection.treatContent(collection, setOfContent, snapContent)
   }
 
-  def collectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+  def liveCollectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
                                 (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     val collectionWithoutSnaps = Collection.withoutSnaps(collection)
     for(setOfContent <- getContentForCollection(collection, adjustSearchQuery))
       yield Collection.liveContent(collectionWithoutSnaps, setOfContent)
   }
 
-  def collectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
+  def liveCollectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
                                    (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     for {
       setOfContent <- getContentForCollection(collection, adjustSearchQuery)
       snapContent <- getLatestSnapContentForCollection(collection, adjustSnapItemQuery)}
     yield Collection.liveContent(collection, setOfContent, snapContent)}
+
+  def draftCollectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
+                                (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    val collectionWithoutSnaps = Collection.withoutSnaps(collection)
+    for(setOfContent <- getContentForCollection(collection, adjustSearchQuery))
+      yield Collection.draftContent(collectionWithoutSnaps, setOfContent)
+  }
+
+  def draftCollectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
+                                   (implicit capiClient: GuardianContentClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    for {
+      setOfContent <- getContentForCollection(collection, adjustSearchQuery)
+      snapContent <- getLatestSnapContentForCollection(collection, adjustSnapItemQuery)}
+    yield Collection.draftContent(collection, setOfContent, snapContent)}
 
   /**
    * Fetches content for the given backfill query. The query can be manipulated for different

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -66,54 +66,28 @@ object Collection {
     from(collection).flatMap(resolveTrail)
   }
 
+  /* Live Methods */
   def liveContent(collection: Collection,
-                  content: Set[Content],
-                  snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
+    content: Set[Content],
+    snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
     contentFrom(collection, content, snapContent, collection => collection.live)
-
-  def treatContent(collection: Collection,
-                  content: Set[Content],
-                  snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
-    contentFrom(collection, content, snapContent, collection => collection.treats)
-
-  def draftContent(collection: Collection,
-                  content: Set[Content],
-                  snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
-    contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(Nil))
 
   def liveIdsWithoutSnaps(collection: Collection): List[String] =
     collection.live.filterNot(_.isSnap).map(_.id)
 
-  def draftIdsWithoutSnaps(collection: Collection): List[String] =
-    collection.draft.map(_.filterNot(_.isSnap).map(_.id)).getOrElse(Nil)
-
   private def allLiveSupportingItems(collection: Collection): List[SupportingItem] =
     collection.live.flatMap(_.meta).flatMap(_.supporting).flatten
-
-  private def allDraftSupportingItems(collection: Collection): List[SupportingItem] =
-    collection.draft.map(_.flatMap(_.meta).flatMap(_.supporting).flatten).getOrElse(Nil)
 
   def liveSupportingIdsWithoutSnaps(collection: Collection): List[String] =
     allLiveSupportingItems(collection).filterNot(_.isSnap).map(_.id)
 
-  def draftSupportingIdsWithoutSnaps(collection: Collection): List[String] =
-    allDraftSupportingItems(collection).filterNot(_.isSnap).map(_.id)
-
   def liveSupportingSnaps(collection: Collection): LatestSnapsRequest =
     LatestSnapsRequest(
       allLiveSupportingItems(collection)
-      .filter(_.isSnap)
-      .filter(_.safeMeta.snapType == Some("latest"))
-      .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
-      .toMap)
-
-  def draftSupportingSnaps(collection: Collection): LatestSnapsRequest =
-    LatestSnapsRequest(
-      allDraftSupportingItems(collection)
-      .filter(_.isSnap)
-      .filter(_.safeMeta.snapType == Some("latest"))
-      .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
-      .toMap)
+        .filter(_.isSnap)
+        .filter(_.safeMeta.snapType == Some("latest"))
+        .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
+        .toMap)
 
   def liveLatestSnapsRequestFor(collection: Collection): LatestSnapsRequest =
     LatestSnapsRequest(
@@ -123,6 +97,29 @@ object Collection {
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap)
 
+  /* Draft Methods */
+  def draftContent(collection: Collection,
+    content: Set[Content],
+    snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
+    contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(Nil))
+
+  def draftIdsWithoutSnaps(collection: Collection): List[String] =
+    collection.draft.map(_.filterNot(_.isSnap).map(_.id)).getOrElse(Nil)
+
+  private def allDraftSupportingItems(collection: Collection): List[SupportingItem] =
+    collection.draft.map(_.flatMap(_.meta).flatMap(_.supporting).flatten).getOrElse(Nil)
+
+  def draftSupportingIdsWithoutSnaps(collection: Collection): List[String] =
+    allDraftSupportingItems(collection).filterNot(_.isSnap).map(_.id)
+
+  def draftSupportingSnaps(collection: Collection): LatestSnapsRequest =
+    LatestSnapsRequest(
+      allDraftSupportingItems(collection)
+        .filter(_.isSnap)
+        .filter(_.safeMeta.snapType == Some("latest"))
+        .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
+        .toMap)
+
   def draftLatestSnapsRequestFor(collection: Collection): LatestSnapsRequest =
     LatestSnapsRequest(
       collection.draft.map(
@@ -130,6 +127,12 @@ object Collection {
       .filter(_.safeMeta.snapType == Some("latest"))
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap).getOrElse(Map.empty))
+
+  /* Treats */
+  def treatContent(collection: Collection,
+    content: Set[Content],
+    snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
+    contentFrom(collection, content, snapContent, collection => collection.treats)
 
   def treatsRequestFor(collection: Collection): (List[String], LatestSnapsRequest) = {
     val latestSnapsRequest =

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -410,7 +410,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 2 results, got $err", err.cause),
+        err => fail(s"expected 0 results, got $err", err.cause),
         contents => {
           contents.size should be(0)
         })
@@ -442,7 +442,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val faciaContentLive = FAPI.liveCollectionContentWithoutSnaps(collection, adjustSearchQuery = searchQuery => searchQuery.showTags("all"))
 
       faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 2 results, got $err", err.cause),
+        err => fail(s"expected 4 results, got $err", err.cause),
         contents => {
           contents.size should be(4)
           contents.head.asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("culture")) should be (true)
@@ -452,7 +452,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         })
 
       faciaContentLive.asFuture.futureValue.fold(
-        err => fail(s"expected 2 results, got $err", err.cause),
+        err => fail(s"expected 1 results, got $err", err.cause),
         contents => {
           contents.size should be(1)
           contents.head.asInstanceOf[CuratedContent].headline should be ("Pope Francis greeted by huge crowds in the Philippines – video")

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -75,7 +75,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     )
 
     "should return the curated content for the collection" in {
-      FAPI.collectionContentWithSnaps(collection).asFuture.futureValue.fold(
+      FAPI.liveCollectionContentWithSnaps(collection).asFuture.futureValue.fold(
         err => fail(s"expected collection, got $err", err.cause),
         curatedContent => curatedContent.size should be > 0
       )
@@ -83,7 +83,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "will use the provided function to adjust the query used to hydrate content" in {
       val adjust: AdjustSearchQuery = q => q.showTags("tone")
-      FAPI.collectionContentWithSnaps(collection, adjust).asFuture.futureValue.fold(
+      FAPI.liveCollectionContentWithSnaps(collection, adjust).asFuture.futureValue.fold(
         err => fail(s"expected collection, got $err", err.cause),
         curatedContent => curatedContent.flatMap{
           case c: CuratedContent => Some(c)
@@ -105,7 +105,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       "should turn dream snaps into content" in {
         val collectionJson = makeCollectionJson(dreamSnapOne, dreamSnapTwo)
         val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
-        val faciaContent = FAPI.collectionContentWithSnaps(collection)
+        val faciaContent = FAPI.liveCollectionContentWithSnaps(collection)
 
         faciaContent.asFuture.futureValue.fold(
           err => fail(s"expected to get two dream snaps, got $err", err.cause),
@@ -125,7 +125,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       "work with normal content and link snaps" in {
         val collectionJson = makeCollectionJson(dreamSnapOne, normalTrail, plainSnapOne, dreamSnapTwo)
         val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
-        val faciaContent = FAPI.collectionContentWithSnaps(collection)
+        val faciaContent = FAPI.liveCollectionContentWithSnaps(collection)
 
         faciaContent.asFuture.futureValue.fold(
           err => fail(s"expected to get three items, got $err", err.cause),
@@ -151,7 +151,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       "not request dream snaps in" in {
         val collectionJson = makeCollectionJson(dreamSnapOne, normalTrail, dreamSnapTwo)
         val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
-        val faciaContent = FAPI.collectionContentWithoutSnaps(collection)
+        val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
         faciaContent.asFuture.futureValue.fold(
         err => fail(s"expected to get three items, got $err", err.cause),
@@ -238,7 +238,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "should be filled correctly" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJson), collectionConfig)
-      val faciaContent = FAPI.collectionContentWithoutSnaps(collection)
+      val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
       err => fail(s"expected to get one item with supporting, got $err", err.cause),
@@ -255,7 +255,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "should not fill in dream snaps in supporting items" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJsonSupportingWithDreamSnaps), collectionConfig)
-      val faciaContent = FAPI.collectionContentWithoutSnaps(collection)
+      val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
       err => fail(s"expected to get one item with supporting and dream snaps, got $err", err.cause),
@@ -277,7 +277,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
     "should fill in dream snaps in supporting items" in {
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Option(collectionJsonSupportingWithDreamSnaps), collectionConfig)
-      val faciaContent = FAPI.collectionContentWithSnaps(collection)
+      val faciaContent = FAPI.liveCollectionContentWithSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
       err => fail(s"expected to get one item with supporting and dream snaps, got $err", err.cause),

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -396,7 +396,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val faciaContent = FAPI.draftCollectionContentWithoutSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 2 treat result, got $err", err.cause),
+        err => fail(s"expected 2 results, got $err", err.cause),
         contents => {
           contents.size should be(2)
           contents.head.asInstanceOf[CuratedContent].headline should be ("PM returns from holiday after video shows US reporter beheaded by Briton")
@@ -410,7 +410,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
       faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 2 treat result, got $err", err.cause),
+        err => fail(s"expected 2 results, got $err", err.cause),
         contents => {
           contents.size should be(0)
         })
@@ -442,7 +442,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val faciaContentLive = FAPI.liveCollectionContentWithoutSnaps(collection, adjustSearchQuery = searchQuery => searchQuery.showTags("all"))
 
       faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 2 treat result, got $err", err.cause),
+        err => fail(s"expected 2 results, got $err", err.cause),
         contents => {
           contents.size should be(4)
           contents.head.asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("culture")) should be (true)
@@ -452,7 +452,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         })
 
       faciaContentLive.asFuture.futureValue.fold(
-        err => fail(s"expected 2 treat result, got $err", err.cause),
+        err => fail(s"expected 2 results, got $err", err.cause),
         contents => {
           contents.size should be(1)
           contents.head.asInstanceOf[CuratedContent].headline should be ("Pope Francis greeted by huge crowds in the Philippines – video")

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -432,31 +432,29 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         })
     }
 
-    "Should request a mix of both" in {
+    "Should request a mix of both" - {
       val normalTrailThree = Trail("internal-code/content/454695023", 0, None)
       val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
       val dreamSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
       val collectionJson = makeCollectionJsonWithTreats(List(dreamSnapOne, normalTrail, dreamSnapTwo, normalTrailTwo), normalTrailThree)
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
-      val faciaContent = FAPI.draftCollectionContentWithSnaps(collection, adjustSnapItemQuery = itemQuery => itemQuery.showTags("all"))
-      val faciaContentLive = FAPI.liveCollectionContentWithoutSnaps(collection, adjustSearchQuery = searchQuery => searchQuery.showTags("all"))
 
-      faciaContent.asFuture.futureValue.fold(
-        err => fail(s"expected 4 results, got $err", err.cause),
-        contents => {
+      "for draft" in {
+        val faciaContent = FAPI.draftCollectionContentWithSnaps(collection, adjustSnapItemQuery = itemQuery => itemQuery.showTags("all"))
+        faciaContent.asFuture.futureValue.fold(err => fail(s"expected 4 results, got $err", err.cause), contents => {
           contents.size should be(4)
-          contents.head.asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("culture")) should be (true)
-          contents.apply(1).asInstanceOf[CuratedContent].headline should be ("PM returns from holiday after video shows US reporter beheaded by Briton")
-          contents.apply(2).asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("technology")) should be (true)
-          contents.apply(3).asInstanceOf[CuratedContent].headline should be ("Inside the 29 August edition")
-        })
+          contents.head.asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("culture")) should be(true)
+          contents.apply(1).asInstanceOf[CuratedContent].headline should be("PM returns from holiday after video shows US reporter beheaded by Briton")
+          contents.apply(2).asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("technology")) should be(true)
+          contents.apply(3).asInstanceOf[CuratedContent].headline should be("Inside the 29 August edition")})
+      }
 
-      faciaContentLive.asFuture.futureValue.fold(
-        err => fail(s"expected 1 results, got $err", err.cause),
-        contents => {
+      "for live" in {
+        val faciaContentLive = FAPI.liveCollectionContentWithoutSnaps(collection, adjustSearchQuery = searchQuery => searchQuery.showTags("all"))
+        faciaContentLive.asFuture.futureValue.fold(err => fail(s"expected 1 results, got $err", err.cause), contents => {
           contents.size should be(1)
-          contents.head.asInstanceOf[CuratedContent].headline should be ("Pope Francis greeted by huge crowds in the Philippines – video")
-        })
+          contents.head.asInstanceOf[CuratedContent].headline should be("Pope Francis greeted by huge crowds in the Philippines – video")})
+      }
     }
   }
 


### PR DESCRIPTION
This allows one to use `FAPI` to request the `draft` content for a `Collection`.

A bit of repetition in places, especially in `Collection`. I'd rather just make clear methods over doing something clever to work around `Option[List[Trail]]` and `List[Trail]`.

For this to truly work properly, it needs to be pointed to the draft content API; the user of the client needs to provide a `GuardianContentClient` that will do that.

@adamnfish @robertberry 