### PR TITLE
ImageGallery for FaciaImage

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -4,6 +4,11 @@ import play.api.libs.json._
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
 
+case class SlideshowAsset(src: String, width: String, height: String)
+object SlideshowAsset {
+  implicit val slideshowAssetFormat = Json.format[SlideshowAsset]
+}
+
 sealed trait MetaDataCommonFields {
   val json: Map[String, JsValue]
 
@@ -35,6 +40,9 @@ sealed trait MetaDataCommonFields {
   lazy val showBoostedHeadline: Option[Boolean] = json.get("showBoostedHeadline").flatMap(_.asOpt[Boolean])
   lazy val showQuotedHeadline: Option[Boolean] = json.get("showQuotedHeadline").flatMap(_.asOpt[Boolean])
   lazy val excludeFromRss: Option[Boolean] = json.get("excludeFromRss").flatMap(_.asOpt[Boolean])
+  lazy val imageSlideshowReplace: Option[Boolean] = json.get("imageSlideshowReplace").flatMap(_.asOpt[Boolean])
+  lazy val slideshow: Option[List[SlideshowAsset]] =
+    json.get("slideshow").flatMap(_.asOpt[List[SlideshowAsset]]).filter(_.nonEmpty)
 }
 
 object SupportingItemMetaData {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -4,16 +4,10 @@ import com.gu.contentapi.client.model.{Tag, Content}
 import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, TrailMetaData}
 
-case class FaciaImage(
-  imageType: ImageType,
-  imageSrc: String,
-  imageSrcWidth: Option[String],
-  imageSrcHeight: Option[String]
-)
-
-sealed trait ImageType
-case object Cutout extends ImageType { override def toString = "cutout" }
-case object Replace extends ImageType { override def toString = "replace" }
+sealed trait FaciaImage
+case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage { override def toString = "cutout" }
+case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage { override def toString = "replace" }
+case class ImageSlideshow(replace: List[Replace]) extends FaciaImage
 
 object FaciaImage {
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -5,8 +5,8 @@ import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, TrailMetaData}
 
 sealed trait FaciaImage
-case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage { override def toString = "cutout" }
-case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage { override def toString = "replace" }
+case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
+case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage
 case class ImageSlideshow(replace: List[Replace]) extends FaciaImage
 
 object FaciaImage {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -7,7 +7,7 @@ import com.gu.facia.client.models.{SupportingItem, MetaDataCommonFields, Trail, 
 sealed trait FaciaImage
 case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
 case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage
-case class ImageSlideshow(replace: List[Replace]) extends FaciaImage
+case class ImageSlideshow(assets: List[Replace]) extends FaciaImage
 
 object FaciaImage {
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -30,7 +30,8 @@ object ResolvedMetaData {
     showKickerTag = false,
     showByline = false,
     imageCutoutReplace = false,
-    showQuotedHeadline = false)
+    showQuotedHeadline = false,
+    imageSlideshowReplace = false)
 
   def fromTrailMetaData(trailMeta: MetaDataCommonFields): ResolvedMetaData =
     ResolvedMetaData(
@@ -45,7 +46,9 @@ object ResolvedMetaData {
       showKickerTag = trailMeta.showKickerTag.exists(identity),
       showByline = trailMeta.showByline.exists(identity),
       imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
-      showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity))
+      showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity),
+      imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity)
+  )
 
   private[utils] def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
     cardStyle match {
@@ -72,7 +75,8 @@ object ResolvedMetaData {
       showKickerTag = trailMeta.showKickerTag.getOrElse(metaDataFromContent.showKickerTag),
       showByline = trailMeta.showByline.getOrElse(metaDataFromContent.showByline),
       imageCutoutReplace = trailMeta.imageCutoutReplace.getOrElse(metaDataFromContent.imageCutoutReplace),
-      showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline))}
+      showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline),
+      imageSlideshowReplace = trailMeta.imageSlideshowReplace.getOrElse(metaDataFromContent.imageSlideshowReplace))}
 }
 
 case class ResolvedMetaData(
@@ -87,7 +91,8 @@ case class ResolvedMetaData(
     showKickerTag: Boolean,
     showByline: Boolean,
     imageCutoutReplace: Boolean,
-    showQuotedHeadline: Boolean)
+    showQuotedHeadline: Boolean,
+    imageSlideshowReplace: Boolean)
 
 object ContentProperties {
   def fromResolvedMetaData(resolvedMetaData: ResolvedMetaData): ContentProperties =

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -104,7 +104,8 @@ object ContentProperties {
       showMainVideo = resolvedMetaData.showMainVideo,
       showKickerTag = resolvedMetaData.showKickerTag,
       showByline = resolvedMetaData.showByline,
-      showQuotedHeadline = resolvedMetaData.showQuotedHeadline)
+      showQuotedHeadline = resolvedMetaData.showQuotedHeadline,
+      imageSlideshowReplace = resolvedMetaData.imageSlideshowReplace)
 }
 
 case class ContentProperties(
@@ -115,4 +116,5 @@ case class ContentProperties(
     showMainVideo: Boolean,
     showKickerTag: Boolean,
     showByline: Boolean,
-    showQuotedHeadline: Boolean)
+    showQuotedHeadline: Boolean,
+    imageSlideshowReplace: Boolean)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -6,7 +6,17 @@ import org.scalatest.{FreeSpec, Matchers}
 
 class FaciaContentHelperTest extends FreeSpec with Matchers {
 
-  val emptyContentProperties = ContentProperties(isBreaking = false, isBoosted = false, imageHide = false, showBoostedHeadline = false, showMainVideo = false, showKickerTag = false, showByline = false, showQuotedHeadline = false)
+  val emptyContentProperties =
+    ContentProperties(
+      isBreaking = false,
+      isBoosted = false,
+      imageHide = false,
+      showBoostedHeadline = false,
+      showMainVideo = false,
+      showKickerTag = false,
+      showByline = false,
+      showQuotedHeadline = false,
+      imageSlideshowReplace = false)
 
   "should return 'Missing Headline' when the headline is None in a Snaps" in {
     val snap = LatestSnap("myId", DefaultCardstyle, None, None, None, None, None, None, "myGroup", None, emptyContentProperties, None, None)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
@@ -51,9 +51,7 @@ class FaciaImageCutoutTest extends FreeSpec with Matchers {
       val resolvedMetaDataTrue = ResolvedMetaData.fromTrailMetaData(trailMetaTrue)
       val imageCutoutTrue = FaciaImage.getFaciaImage(Some(emptyContent), trailMetaTrue, resolvedMetaDataTrue)
       imageCutoutTrue.isDefined should be (true)
-      imageCutoutTrue.get.imageSrc should be (src)
-      imageCutoutTrue.get.imageSrcWidth should be (width)
-      imageCutoutTrue.get.imageSrcHeight should be (height)
+      imageCutoutTrue should be (Some(Cutout(src, width, height)))
 
       val trailMetaFalse = trailMetaDataWithImageCutout(false, Option(src), width, height)
       val resolvedMetaDataFalse = ResolvedMetaData.fromTrailMetaData(trailMetaFalse)
@@ -77,7 +75,7 @@ class FaciaImageCutoutTest extends FreeSpec with Matchers {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMeta)
       val imageCutout = FaciaImage.getFaciaImage(Some(contentWithContributor), trailMeta, resolvedMetaData)
       imageCutout.isDefined should be (true)
-      imageCutout should be (Some(FaciaImage(Cutout, bylineImageUrl, None, None)))
+      imageCutout should be (Some(Cutout(bylineImageUrl, None, None)))
     }
 
     "should not return an Image of type cutout from content tags if imageCutoutReplace is false" in {

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
@@ -27,6 +27,6 @@ class FaciaImageReplaceTest extends FlatSpec with Matchers {
 
   it should "give back an Image when true" in {
     val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageReplace)
-    FaciaImage.getFaciaImage(None, trailMetaDataWithImageReplace, resolvedMetaData) should be (Some(FaciaImage(Replace, "theImageSrc", Some("theImageSrcWidth"), Some("theImageSrcHeight"))))
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageReplace, resolvedMetaData) should be (Some(Replace("theImageSrc", "theImageSrcWidth", "theImageSrcHeight")))
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageSlideshowTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageSlideshowTest.scala
@@ -1,0 +1,54 @@
+package com.gu.facia.api.models
+
+import com.gu.facia.api.utils.ResolvedMetaData
+import com.gu.facia.client.models.TrailMetaData
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.libs.json.{JsObject, JsArray, JsString, JsBoolean}
+
+class FaciaImageSlideshowTest extends FlatSpec with Matchers {
+  val assetOne = JsObject(List(
+    "src" -> JsString("theImageSrcOne"),
+    "width" -> JsString("theImageSrcWidthOne"),
+    "height" -> JsString("theImageSrcHeightOne")))
+
+  val assetTwo = JsObject(List(
+    "src" -> JsString("theImageSrcTwo"),
+    "width" -> JsString("theImageSrcWidthTwo"),
+    "height" -> JsString("theImageSrcHeightTwo")))
+
+  val assetThree = JsObject(List(
+    "src" -> JsString("theImageSrcThree"),
+    "width" -> JsString("theImageSrcWidthThree"),
+    "height" -> JsString("theImageSrcHeightThree")))
+
+  val trailMetaDataWithoutImageSlideshowReplace =
+    TrailMetaData(Map(
+      "imageSlideshowReplace" -> JsBoolean(value = false),
+      "slideshow" -> JsArray(List(assetOne, assetTwo, assetThree))))
+
+  val trailMetaDataWithImageSlideshowReplace =
+    TrailMetaData(Map(
+      "imageSlideshowReplace" -> JsBoolean(value = true),
+      "slideshow" -> JsArray(List(assetOne, assetTwo, assetThree))))
+
+  val trailMetaDataWithImageSlideshowReplaceAndNoAssets =
+    TrailMetaData(Map(
+      "imageSlideshowReplace" -> JsBoolean(value = true),
+      "slideshow" -> JsArray(Nil)))
+
+  "Image" should "give a None if when imageSlideshowReplace not set" in {
+    val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithoutImageSlideshowReplace)
+    FaciaImage.getFaciaImage(None, trailMetaDataWithoutImageSlideshowReplace, resolvedMetaData) should be (None)
+  }
+
+  it should "give back an ImageGallery when true" in {
+    val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSlideshowReplace)
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSlideshowReplace, resolvedMetaData) should be (Some(ImageSlideshow(List(Replace("theImageSrcOne", "theImageSrcWidthOne", "theImageSrcHeightOne"), Replace("theImageSrcTwo", "theImageSrcWidthTwo", "theImageSrcHeightTwo"), Replace("theImageSrcThree", "theImageSrcWidthThree", "theImageSrcHeightThree")))))
+  }
+
+  it should "give back a None when imageSlideshowReplace true with no assets" in {
+    val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSlideshowReplaceAndNoAssets)
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSlideshowReplaceAndNoAssets, resolvedMetaData) should be (None)
+  }
+}
+


### PR DESCRIPTION
This changes FaciaImage away from a `case class` into an `ADT`, which is what `ImageType` was.

On top of this, `ImageSlideshow` has been added to the type to represent `slideshows` from the tool.

In `facia-json`, there are now accessors for `imageSlideshowReplace` and `slideshow` which are keys in the `JSON` coming from the tool representing `slideshows`.

I have also removed the `toString` methods. If we want these as strings we should just make a method that says why it's turning into a `String`.

@adamnfish @robertberry @DiegoVazquezNanini 