### PR TITLE
Fix draft requesting

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -103,30 +103,31 @@ object Collection {
     snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
     contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(Nil))
 
-  def draftIdsWithoutSnaps(collection: Collection): List[String] =
-    collection.draft.map(_.filterNot(_.isSnap).map(_.id)).getOrElse(Nil)
+  def draftIdsWithoutSnaps(collection: Collection): Option[List[String]] =
+    collection.draft.map(_.filterNot(_.isSnap).map(_.id))
 
-  private def allDraftSupportingItems(collection: Collection): List[SupportingItem] =
-    collection.draft.map(_.flatMap(_.meta).flatMap(_.supporting).flatten).getOrElse(Nil)
+  private def allDraftSupportingItems(collection: Collection): Option[List[SupportingItem]] =
+    collection.draft.map(_.flatMap(_.meta).flatMap(_.supporting).flatten)
 
-  def draftSupportingIdsWithoutSnaps(collection: Collection): List[String] =
-    allDraftSupportingItems(collection).filterNot(_.isSnap).map(_.id)
+  def draftSupportingIdsWithoutSnaps(collection: Collection): Option[List[String]] =
+    allDraftSupportingItems(collection).map(_.filterNot(_.isSnap).map(_.id))
 
-  def draftSupportingSnaps(collection: Collection): LatestSnapsRequest =
-    LatestSnapsRequest(
+  def draftSupportingSnaps(collection: Collection): Option[LatestSnapsRequest] =
       allDraftSupportingItems(collection)
-        .filter(_.isSnap)
-        .filter(_.safeMeta.snapType.contains("latest"))
-        .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
-        .toMap)
+        .map( listOfSupportingItems =>
+          LatestSnapsRequest(
+            listOfSupportingItems.filter(_.isSnap)
+              .filter(_.safeMeta.snapType.contains("latest"))
+              .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
+              .toMap))
 
-  def draftLatestSnapsRequestFor(collection: Collection): LatestSnapsRequest =
-    LatestSnapsRequest(
-      collection.draft.map(
-      _.filter(_.isSnap)
-      .filter(_.safeMeta.snapType.contains("latest"))
-      .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
-      .toMap).getOrElse(Map.empty))
+  def draftLatestSnapsRequestFor(collection: Collection): Option[LatestSnapsRequest] =
+      collection.draft.map( listOfTrails =>
+        LatestSnapsRequest(
+          listOfTrails.filter(_.isSnap)
+          .filter(_.safeMeta.snapType.contains("latest"))
+          .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
+          .toMap))
 
   /* Treats */
   def treatContent(collection: Collection,

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -85,7 +85,7 @@ object Collection {
     LatestSnapsRequest(
       allLiveSupportingItems(collection)
         .filter(_.isSnap)
-        .filter(_.safeMeta.snapType.contains("latest"))
+        .filter(_.safeMeta.snapType == Some("latest"))
         .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
         .toMap)
 
@@ -93,7 +93,7 @@ object Collection {
     LatestSnapsRequest(
       collection.live
       .filter(_.isSnap)
-      .filter(_.safeMeta.snapType.contains("latest"))
+      .filter(_.safeMeta.snapType == Some("latest"))
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap)
 
@@ -117,7 +117,7 @@ object Collection {
         .map( listOfSupportingItems =>
           LatestSnapsRequest(
             listOfSupportingItems.filter(_.isSnap)
-              .filter(_.safeMeta.snapType.contains("latest"))
+              .filter(_.safeMeta.snapType == Some("latest"))
               .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
               .toMap))
 
@@ -125,7 +125,7 @@ object Collection {
       collection.draft.map( listOfTrails =>
         LatestSnapsRequest(
           listOfTrails.filter(_.isSnap)
-          .filter(_.safeMeta.snapType.contains("latest"))
+          .filter(_.safeMeta.snapType == Some("latest"))
           .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
           .toMap))
 
@@ -140,7 +140,7 @@ object Collection {
       LatestSnapsRequest(
         collection.treats
           .filter(_.isSnap)
-          .filter(_.safeMeta.snapType.contains("latest"))
+          .filter(_.safeMeta.snapType == Some("latest"))
           .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
           .toMap)
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -85,7 +85,7 @@ object Collection {
     LatestSnapsRequest(
       allLiveSupportingItems(collection)
         .filter(_.isSnap)
-        .filter(_.safeMeta.snapType == Some("latest"))
+        .filter(_.safeMeta.snapType.contains("latest"))
         .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
         .toMap)
 
@@ -93,7 +93,7 @@ object Collection {
     LatestSnapsRequest(
       collection.live
       .filter(_.isSnap)
-      .filter(_.safeMeta.snapType == Some("latest"))
+      .filter(_.safeMeta.snapType.contains("latest"))
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap)
 
@@ -116,7 +116,7 @@ object Collection {
     LatestSnapsRequest(
       allDraftSupportingItems(collection)
         .filter(_.isSnap)
-        .filter(_.safeMeta.snapType == Some("latest"))
+        .filter(_.safeMeta.snapType.contains("latest"))
         .flatMap(snap => snap.meta.flatMap(_.snapUri).map(uri => snap.id ->uri))
         .toMap)
 
@@ -124,7 +124,7 @@ object Collection {
     LatestSnapsRequest(
       collection.draft.map(
       _.filter(_.isSnap)
-      .filter(_.safeMeta.snapType == Some("latest"))
+      .filter(_.safeMeta.snapType.contains("latest"))
       .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
       .toMap).getOrElse(Map.empty))
 
@@ -139,7 +139,7 @@ object Collection {
       LatestSnapsRequest(
         collection.treats
           .filter(_.isSnap)
-          .filter(_.safeMeta.snapType == Some("latest"))
+          .filter(_.safeMeta.snapType.contains("latest"))
           .flatMap(snap => snap.safeMeta.snapUri.map(uri => snap.id -> uri))
           .toMap)
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -101,7 +101,7 @@ object Collection {
   def draftContent(collection: Collection,
     content: Set[Content],
     snapContent: Map[String, Option[Content]] = Map.empty): List[FaciaContent] =
-    contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(Nil))
+    contentFrom(collection, content, snapContent, collection => collection.draft.getOrElse(collection.live))
 
   def draftIdsWithoutSnaps(collection: Collection): Option[List[String]] =
     collection.draft.map(_.filterNot(_.isSnap).map(_.id))

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -432,6 +432,38 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
         })
     }
 
+    "should request what is in live when draft is None" - {
+      "for normal content" in {
+        val collectionJson = makeCollectionJson(normalTrail, normalTrailTwo)
+        val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
+
+        val faciaContent = FAPI.draftCollectionContentWithoutSnaps(collection)
+
+        faciaContent.asFuture.futureValue.fold(err => fail(s"expected 2 results, got $err", err.cause), contents => {
+          contents.size should be(2)
+          contents.head.asInstanceOf[CuratedContent].headline should be("PM returns from holiday after video shows US reporter beheaded by Briton")
+          contents.apply(1).asInstanceOf[CuratedContent].headline should be("Inside the 29 August edition")
+        })
+      }
+
+      "for dreamsnaps" in {
+        val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
+        val dreamSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
+        val collectionJson = makeCollectionJson(normalTrail, normalTrailTwo, dreamSnapOne, dreamSnapTwo)
+        val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
+
+        val faciaContent = FAPI.draftCollectionContentWithSnaps(collection, adjustSnapItemQuery = itemQuery => itemQuery.showTags("all"))
+
+        faciaContent.asFuture.futureValue.fold(err => fail(s"expected 4 results, got $err", err.cause), contents => {
+          contents.size should be(4)
+          contents.head.asInstanceOf[CuratedContent].headline should be("PM returns from holiday after video shows US reporter beheaded by Briton")
+          contents.apply(1).asInstanceOf[CuratedContent].headline should be("Inside the 29 August edition")
+          contents.apply(2).asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("culture")) should be(true)
+          contents.apply(3).asInstanceOf[LatestSnap].latestContent.get.tags.exists(_.sectionId == Some("technology")) should be(true)
+        })
+      }
+    }
+
     "Should request a mix of both" - {
       val normalTrailThree = Trail("internal-code/content/454695023", 0, None)
       val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -375,7 +375,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
   }
 
   "Draft" - {
-    def makeCollectionJsonWithTreats(draft: List[Trail], live: Trail*) = CollectionJson(
+    def makeCollectionJsonWithDraft(draft: List[Trail], live: Trail*) = CollectionJson(
       live = live.toList,
       draft = Option(draft),
       treats = None,
@@ -391,7 +391,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
 
     "should request draft items" in {
-      val collectionJson = makeCollectionJsonWithTreats(List(normalTrail, normalTrailTwo))
+      val collectionJson = makeCollectionJsonWithDraft(List(normalTrail, normalTrailTwo))
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
       val faciaContent = FAPI.draftCollectionContentWithoutSnaps(collection)
 
@@ -405,7 +405,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     }
 
     "should return nothing" in {
-      val collectionJson = makeCollectionJsonWithTreats(List(normalTrail, normalTrailTwo))
+      val collectionJson = makeCollectionJsonWithDraft(List(normalTrail, normalTrailTwo))
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
       val faciaContent = FAPI.liveCollectionContentWithoutSnaps(collection)
 
@@ -419,7 +419,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     "should request dreamsnaps in draft" in {
       val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
       val dreamSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
-      val collectionJson = makeCollectionJsonWithTreats(List(dreamSnapOne, dreamSnapTwo))
+      val collectionJson = makeCollectionJsonWithDraft(List(dreamSnapOne, dreamSnapTwo))
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
       val faciaContent = FAPI.draftCollectionContentWithSnaps(collection, adjustSnapItemQuery = itemQuery => itemQuery.showTags("all"))
 
@@ -436,7 +436,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       val normalTrailThree = Trail("internal-code/content/454695023", 0, None)
       val dreamSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
       val dreamSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
-      val collectionJson = makeCollectionJsonWithTreats(List(dreamSnapOne, normalTrail, dreamSnapTwo, normalTrailTwo), normalTrailThree)
+      val collectionJson = makeCollectionJsonWithDraft(List(dreamSnapOne, normalTrail, dreamSnapTwo, normalTrailTwo), normalTrailThree)
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJson), collectionConfig)
 
       "for draft" in {


### PR DESCRIPTION
We were not properly falling back to `live` when `draft` was a `None`.

This changes the signatures a bit to know that `draft` is a `None` and then fallback to `live` in the `None` case.

@robertberry 