### PR TITLE
Upgrade the contentAPI client to 6.3

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -27,7 +27,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
   val content = Content(
     "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
     fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-    Nil, None, Nil, None
+    Nil, None, Nil, None, None, None
   )
   val contents = Set(content)
   val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(href = Some("collectionConfigHref")))
@@ -180,11 +180,11 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       val snapContentOne = Content(
         "content-id-one", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
         fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-        Nil, None, Nil, None)
+        Nil, None, Nil, None, None, None)
       val snapContentTwo = Content(
         "content-id-two", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
         fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-        Nil, None, Nil, None)
+        Nil, None, Nil, None, None, None)
 
       val snapContent = Map("snap/8474745745660" -> Some(snapContentOne), "snap/4324234234234" -> Some(snapContentTwo))
 
@@ -244,11 +244,11 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
         val snapContentOne = Content(
           "content-id-one", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
           fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-          Nil, None, Nil, None)
+          Nil, None, Nil, None, None, None)
         val snapContentTwo = Content(
           "content-id-two", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
           fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-          Nil, None, Nil, None)
+          Nil, None, Nil, None, None, None)
 
         val snapContent = Map("snap/8474745745660" -> Some(snapContentOne), "snap/4324234234234" -> Some(snapContentTwo))
 
@@ -274,11 +274,11 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       val snapContentOne = Content(
         "content-id-one", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
         fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-        Nil, None, Nil, None)
+        Nil, None, Nil, None, None, None)
       val snapContentTwo = Content(
         "content-id-two", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
         fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-        Nil, None, Nil, None)
+        Nil, None, Nil, None, None, None)
 
       val snapContent = Map("snap/8474745745660" -> Some(snapContentOne), "snap/4324234234234" -> Some(snapContentTwo))
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -15,12 +15,12 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val contentWithFieldHeadline = Content(
       "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     val contentWithoutFieldHeadline = Content(
       "content-id", Some("section"), Some("Section Name"), None, "contentWithoutFieldHeadlineHeadline", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     val trailMetaDataWithHeadline = TrailMetaData(Map("headline" -> JsString("trailMetaDataHeadline")))
     val trailMetaDataWithoutHeadline = TrailMetaData(Map.empty)
@@ -44,7 +44,7 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val emptyContent = Content(
       "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None)
+      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None, None, None)
     val emptyTrailMetaData = TrailMetaData(Map.empty)
     val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
     val collectionConfigShowSections = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showSections = Option(true)))
@@ -83,7 +83,7 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val emptyContent = Content(
       "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None)
+      List(Tag("id", "type", None, None, "", "", "")), None, Nil, None, None, None)
     val emptyTrailMetaData = TrailMetaData(Map.empty)
     val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
     val collectionConfigShowSections = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showSections = Option(true)))

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
@@ -22,12 +22,12 @@ class FaciaImageCutoutTest extends FreeSpec with Matchers {
     Content(
       "id", None, None, None,
       "webTitle", "webUrl", "apiUrl", None,
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
   def contentWithContributorTag(bylineLargeImageUrl: String): Content =
     emptyContent.copy(tags = List(Tag(
       "tagid", "contributor", None, None, "webTitle",
-      "webUrl", "apiUrl", Nil, None, None, bylineImageUrl = None,
+      "webUrl", "apiUrl", Nil, None, None, None,
       Option(bylineLargeImageUrl), None, None, None, None)))
 
   val bylineImageUrl = "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/3/13/1394733744420/MichaelWhite.png"

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -34,7 +34,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
   val content = Content(
     "content-id", Some("section"), Some("Section Name"), Option(staticDateTime), "webTitle", "webUrl", "apiUrl",
     fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-    Nil, None, Nil, None)
+    Nil, None, Nil, None, None, None)
 
   def makeLatestSnap(latestSnapId: String, content: Content = content) = LatestSnap(
     id = latestSnapId,
@@ -105,7 +105,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     val contentWithNoDatetime = Content(
       "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     val now = DateTime.now()
 
@@ -150,7 +150,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     def contentWithTagIds(tagIds: String*) = Content(
       "content-id", Some("section"), Some("Section Name"), Option(staticDateTime), "webTitle", "webUrl", "apiUrl",
       fields = Some(Map("internalContentCode" -> "CODE", "headline" -> "Content headline", "href" -> "Content href", "trailText" -> "Content trailtext", "byline" -> "Content byline")),
-      tagIds.toList.map(tagId => Tag(tagId, "type", None, None, "", "", "")), None, Nil, None)
+      tagIds.toList.map(tagId => Tag(tagId, "type", None, None, "", "", "")), None, Nil, None, None, None)
 
     "should return a None for a LinkSnap" in {
       val linkSnap = makeLinkSnap("some-link-snap")
@@ -207,7 +207,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     def contentWithFields(fields: Map[String, String]) = Content(
       "content-id", Some("section"), Some("Section Name"), Option(staticDateTime), "webTitle", "webUrl", "apiUrl",
       fields = Option(fields),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     "should return a false for a LinkSnap" in {
       val linkSnap = makeLinkSnap("some-link-snap")
@@ -271,7 +271,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     def contentWithFields(fields: Map[String, String]) = Content(
       "content-id", Some("section"), Some("Section Name"), Option(staticDateTime), "webTitle", "webUrl", "apiUrl",
       fields = Option(fields),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     "should return a false for a LinkSnap" in {
       val linkSnap = makeLinkSnap("some-link-snap")
@@ -334,7 +334,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     def contentWithShortUrl(shortUrl: String) = Content(
       "content-id", Some("section"), Some("Section Name"), Option(staticDateTime), "webTitle", "webUrl", "apiUrl",
       fields = Option(Map("shortUrl" -> shortUrl)),
-      Nil, None, Nil, None)
+      Nil, None, Nil, None, None, None)
 
     val contentWithNoShortUrl = content
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -16,7 +16,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers {
 
   def contentWithTags(tags: Tag*): Content = Content(
     "content-id", Some("section"), Some("Section Name"), None, "webTitle", "webUrl", "apiUrl",
-    fields = Option(Map.empty), tags.toList, None, Nil, None)
+    fields = Option(Map.empty), tags.toList, None, Nil, None, None, None)
 
   val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
   val contentWithComment = contentWithTags(tagWithId("tone/comment"))

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk" % "1.7.9"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "5.0"
+  val contentApi = "com.gu" %% "content-api-client" % "6.3"
   val mockito = "org.mockito" % "mockito-all" % "1.10.8" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.3.6"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.1" % "test"


### PR DESCRIPTION
I merged this, then reverted it when I realised how many problems will arise from it. I don't have the time to handle these problems now (They aren't problems in this repo, problems in `frontend`)

I will merge this when I am ready to receive it.

@DiegoVazquezNanini Is there anything in particular you want from `6.3`?