### PR TITLE
Carry frontPublicationDate through types

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -167,7 +167,7 @@ object FAPI {
     for {
       backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
     } yield {
-      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, collection.collectionConfig))
+      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collection.collectionConfig))
     }
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -45,8 +45,8 @@ object Collection {
         .map { content =>
         trail.safeMeta.supporting
           .map(_.flatMap(resolveSupportingContent))
-          .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, supportingItems, collection.collectionConfig))
-          .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, collection.collectionConfig))}
+          .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, Option(trail.frontPublicationDate), supportingItems, collection.collectionConfig))
+          .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, Option(trail.frontPublicationDate), collection.collectionConfig))}
         .orElse {
           snapContent
             .find{case (id, _) => trail.id == id}
@@ -56,7 +56,7 @@ object Collection {
     def resolveSupportingContent(supportingItem: SupportingItem): Option[FaciaContent] = {
       content
         .find(c => supportingItem.id.endsWith("/" + c.safeFields.getOrElse("internalContentCode", throw new RuntimeException("No internal content code"))))
-        .map { content => SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, collection.collectionConfig)}
+        .map { content => SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, supportingItem.frontPublicationDate, collection.collectionConfig)}
         .orElse {
           snapContent
             .find{case (id, _) => supportingItem.id == id}

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -71,6 +71,7 @@ object Snap {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trail.safeMeta)
       Option(LinkSnap(
       trail.id,
+      Option(trail.frontPublicationDate),
       snapType,
       trail.safeMeta.snapUri,
       trail.safeMeta.snapCss,
@@ -98,6 +99,7 @@ object Snap {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta)
       Option(LinkSnap(
       supportingItem.id,
+      supportingItem.frontPublicationDate,
       snapType,
       supportingItem.safeMeta.snapUri,
       supportingItem.safeMeta.snapCss,
@@ -123,6 +125,7 @@ object Snap {
 sealed trait Snap extends FaciaContent
 case class LinkSnap(
   id: String,
+  maybeFrontPublicationDate: Option[Long],
   snapType: String,
   snapUri: Option[String],
   snapCss: Option[String],
@@ -143,6 +146,7 @@ case class LinkSnap(
 
 case class LatestSnap(
   id: String,
+  maybeFrontPublicationDate: Option[Long],
   cardStyle: CardStyle,
   snapUri: Option[String],
   snapCss: Option[String],
@@ -163,6 +167,7 @@ object LatestSnap {
       maybeContent.fold(ResolvedMetaData.fromTrailMetaData(trail.safeMeta))(ResolvedMetaData.fromContentAndTrailMetaData(_, trail.safeMeta, cardStyle))
     LatestSnap(
       trail.id,
+      Option(trail.frontPublicationDate),
       cardStyle,
       trail.safeMeta.snapUri,
       trail.safeMeta.snapCss,
@@ -184,6 +189,7 @@ object LatestSnap {
       maybeContent.fold(ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta))(ResolvedMetaData.fromContentAndTrailMetaData(_, supportingItem.safeMeta, cardStyle))
     LatestSnap(
       supportingItem.id,
+      supportingItem.frontPublicationDate,
       cardStyle,
       supportingItem.safeMeta.snapUri,
       supportingItem.safeMeta.snapCss,
@@ -202,6 +208,7 @@ object LatestSnap {
 
 case class CuratedContent(
   content: Content,
+  maybeFrontPublicationDate: Option[Long],
   supportingContent: List[FaciaContent],
   cardStyle: CardStyle,
   headline: String,
@@ -218,6 +225,7 @@ case class CuratedContent(
 
 case class SupportingCuratedContent(
   content: Content,
+  maybeFrontPublicationDate: Option[Long],
   cardStyle: CardStyle,
   headline: String,
   href: Option[String],
@@ -230,7 +238,9 @@ case class SupportingCuratedContent(
 
 object CuratedContent {
 
-  def fromTrailAndContentWithSupporting(content: Content, trailMetaData: TrailMetaData,
+  def fromTrailAndContentWithSupporting(content: Content,
+                                        trailMetaData: TrailMetaData,
+                                        maybeFrontPublicationDate: Option[Long],
                                         supportingContent: List[FaciaContent],
                                         collectionConfig: CollectionConfig) = {
     val contentFields: Map[String, String] = content.safeFields
@@ -239,6 +249,7 @@ object CuratedContent {
 
     CuratedContent(
       content,
+      maybeFrontPublicationDate,
       supportingContent,
       cardStyle,
       trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
@@ -253,13 +264,18 @@ object CuratedContent {
       embedUri = trailMetaData.snapUri,
       embedCss = trailMetaData.snapCss)}
 
-  def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): CuratedContent = {
+  def fromTrailAndContent(content: Content,
+                          trailMetaData: MetaDataCommonFields,
+                          maybeFrontPublicationDate: Option[Long],
+                          collectionConfig: CollectionConfig): CuratedContent = {
+
     val contentFields: Map[String, String] = content.safeFields
     val cardStyle = CardStyle(content, trailMetaData)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
     CuratedContent(
       content,
+      maybeFrontPublicationDate,
       supportingContent = Nil,
       cardStyle = cardStyle,
       trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
@@ -276,13 +292,17 @@ object CuratedContent {
 }
 
 object SupportingCuratedContent {
-  def fromTrailAndContent(content: Content, trailMetaData: MetaDataCommonFields, collectionConfig: CollectionConfig): SupportingCuratedContent = {
+  def fromTrailAndContent(content: Content,
+                          trailMetaData: MetaDataCommonFields,
+                          maybeFrontPublicationDate: Option[Long],
+                          collectionConfig: CollectionConfig): SupportingCuratedContent = {
     val contentFields: Map[String, String] = content.safeFields
     val cardStyle = CardStyle(content, trailMetaData)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
     SupportingCuratedContent(
       content,
+      maybeFrontPublicationDate,
       cardStyle,
       trailMetaData.headline.orElse(content.safeFields.get("headline")).getOrElse(content.webTitle),
       trailMetaData.href.orElse(contentFields.get("href")),

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -34,6 +34,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
 
   def makeLatestSnap(
     id: String = "id",
+    maybeFrontPublicationDate: Option[Long] = None,
     snapUri: Option[String] = None,
     snapCss: Option[String] = None,
     latestContent: Option[Content] = None,
@@ -54,6 +55,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     showQuotedHeadline: Boolean = false): LatestSnap =
     LatestSnap(
       id,
+      maybeFrontPublicationDate,
       DefaultCardstyle,
       snapUri,
       snapCss,
@@ -69,6 +71,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
 
   def makeLinkSnap(
     id: String = "id",
+    maybeFrontPublicationDate: Option[Long] = None,
     snapType: String = Snap.DefaultType,
     snapUri: Option[String] = None,
     snapCss: Option[String] = None,
@@ -88,6 +91,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     showQuotedHeadline: Boolean = false): LinkSnap =
     LinkSnap(
       id,
+      maybeFrontPublicationDate,
       snapType,
       snapUri,
       snapCss,
@@ -195,10 +199,10 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       val faciaContent = Collection.liveContent(collection, Set.empty, snapContent)
 
       faciaContent.length should be (4)
-      faciaContent(0) should be (makeLinkSnap(id = "snap/1415985080061", snapUri = Some("abc")))
-      faciaContent(1) should be (makeLinkSnap(id = "snap/5345345215342", snapCss = Some("css")))
-      faciaContent(2) should be (makeLatestSnap(id = "snap/8474745745660", href = Some("uk"), latestContent = Some(snapContentOne)))
-      faciaContent(3) should be (makeLatestSnap(id = "snap/4324234234234", href = Some("culture"), latestContent = Some(snapContentTwo)))
+      faciaContent(0) should be (makeLinkSnap(id = "snap/1415985080061", maybeFrontPublicationDate = Option(1L), snapUri = Some("abc")))
+      faciaContent(1) should be (makeLinkSnap(id = "snap/5345345215342", maybeFrontPublicationDate = Option(1L), snapCss = Some("css")))
+      faciaContent(2) should be (makeLatestSnap(id = "snap/8474745745660", maybeFrontPublicationDate = Option(1L), href = Some("uk"), latestContent = Some(snapContentOne)))
+      faciaContent(3) should be (makeLatestSnap(id = "snap/4324234234234", maybeFrontPublicationDate = Option(1L), href = Some("culture"), latestContent = Some(snapContentTwo)))
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -26,16 +26,16 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val trailMetaDataWithoutHeadline = TrailMetaData(Map.empty)
 
     "should resolve the headline from TrailMetaData" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, None, collectionConfig)
       curatedContent.headline should be ("trailMetaDataHeadline")
     }
 
     "should resolve the headline from Content fields.headline" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig)
       curatedContent.headline should be ("Content headline")
     }
     "should resolve the headline from Content webTitle" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig)
       curatedContent.headline should be ("contentWithoutFieldHeadlineHeadline")
     }
   }
@@ -51,30 +51,30 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
 
     "should resolve to None" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig)
       curatedContent.kicker should be (None)
     }
 
     "should resolve to SectionKicker with config showSections true" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowSections)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections)
       curatedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to TagKicker with config showTags true" in {
       //This test requires content to have tags
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags)
       curatedContent.kicker.value shouldBe a [TagKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
       val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags)
       curatedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
       val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags)
       curatedContent.kicker.value shouldBe a [TagKicker]
     }
   }
@@ -90,29 +90,29 @@ class CuratedContentTest extends FreeSpec with Matchers {
     val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
 
     "should resolve to None" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfig)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to None with config showSections true" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowSections)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to None with config showTags true" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
       val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags)
       supportingCuratedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
       val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags)
       supportingCuratedContent.kicker.value shouldBe a [TagKicker]
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -19,30 +19,30 @@ class FaciaContentHelperTest extends FreeSpec with Matchers {
       imageSlideshowReplace = false)
 
   "should return 'Missing Headline' when the headline is None in a Snaps" in {
-    val snap = LatestSnap("myId", DefaultCardstyle, None, None, None, None, None, None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, None, None, None, None, "myGroup", None, emptyContentProperties, None, None)
     FaciaContentUtils.headlineOption(snap) should equal(None)
   }
 
   "should return the headline for a CuratedContent" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val cc = CuratedContent(content, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
     FaciaContentUtils.headlineOption(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val cc = CuratedContent(content, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
     FaciaContentUtils.href(cc) should equal(None)
   }
 
   "should return a href for a LatestSnap" in {
-    val snap = LatestSnap("myId", DefaultCardstyle, None, None, None, None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, None, None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
     FaciaContentUtils.href(snap) should equal(None)
   }
 
   "should return a byline for a LatestSnap" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val snap = LatestSnap("myId", DefaultCardstyle, None, None, Some(content), None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, Some(content), None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
     FaciaContentUtils.byline(snap) should equal(Some("myByline"))
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -11,6 +11,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
 
   def makeLinkSnap(linkSnapId: String) = LinkSnap(
     id = linkSnapId,
+    maybeFrontPublicationDate = None,
     snapType = "",
     snapUri = None,
     snapCss = None,
@@ -38,6 +39,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
 
   def makeLatestSnap(latestSnapId: String, content: Content = content) = LatestSnap(
     id = latestSnapId,
+    maybeFrontPublicationDate = None,
     cardStyle = DefaultCardstyle,
     snapUri = None,
     snapCss = None,
@@ -53,6 +55,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
     content = content,
+    maybeFrontPublicationDate = None,
     supportingContent = Nil,
     cardStyle = DefaultCardstyle,
     headline = "",
@@ -69,6 +72,7 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
     content = content,
+    maybeFrontPublicationDate = None,
     cardStyle = DefaultCardstyle,
     headline = "",
     href = None,


### PR DESCRIPTION
For breaking news, we would like to `frontPublicationDate` that exists on each `Trail` item in the `collection.json` files to be exposed in the higher level `fapi-client`.

We will put this into `lite.json`.

@stephanfowler @robertberry 