### PR TITLE
Change Snap methods to fallback to LinkSnap 

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -64,11 +64,12 @@ object Snap {
   val LinkType = "link"
   val DefaultType = LinkType
 
-  def maybeFromTrail(trail: Trail): Option[Snap] = trail.safeMeta.snapType match {
+  def maybeFromTrail(trail: Trail): Option[Snap] = {
+  val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trail.safeMeta)
+  trail.safeMeta.snapType match {
     case Some("latest") =>
       Option(LatestSnap.fromTrailAndContent(trail, None))
     case Some(snapType) =>
-      val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trail.safeMeta)
       Option(LinkSnap(
       trail.id,
       snapType,
@@ -88,14 +89,36 @@ object Snap {
       ItemKicker.fromTrailMetaData(trail.safeMeta),
       trail.safeMeta.showBoostedHeadline.exists(identity),
       trail.safeMeta.showQuotedHeadline.exists(identity)))
-    case _ => None
+    case None =>
+      Option(LinkSnap(
+        trail.id,
+        LinkType,
+        trail.safeMeta.snapUri,
+        trail.safeMeta.snapCss,
+        trail.safeMeta.headline,
+        trail.safeMeta.href,
+        trail.safeMeta.trailText,
+        trail.safeMeta.group.getOrElse("0"),
+        FaciaImage.getFaciaImage(None, trail.safeMeta, resolvedMetaData),
+        trail.safeMeta.isBreaking.exists(identity),
+        trail.safeMeta.isBoosted.exists(identity),
+        trail.safeMeta.showMainVideo.exists(identity),
+        trail.safeMeta.showKickerTag.exists(identity),
+        trail.safeMeta.byline,
+        trail.safeMeta.showByline.exists(identity),
+        ItemKicker.fromTrailMetaData(trail.safeMeta),
+        trail.safeMeta.showBoostedHeadline.exists(identity),
+        trail.safeMeta.showQuotedHeadline.exists(identity)))
+    }
   }
 
-  def maybeFromSupportingItem(supportingItem: SupportingItem): Option[Snap] = supportingItem.safeMeta.snapType match {
+
+  def maybeFromSupportingItem(supportingItem: SupportingItem): Option[Snap] = {
+    val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta)
+    supportingItem.safeMeta.snapType match {
     case Some("latest") =>
       Option(LatestSnap.fromSupportingItemAndContent(supportingItem, None))
     case Some(snapType) =>
-      val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta)
       Option(LinkSnap(
       supportingItem.id,
       snapType,
@@ -114,9 +137,28 @@ object Snap {
       supportingItem.safeMeta.showByline.exists(identity),
       ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
       supportingItem.safeMeta.showBoostedHeadline.exists(identity),
-      supportingItem.safeMeta.showQuotedHeadline.exists(identity)
-  ))
-    case _ => None
+      supportingItem.safeMeta.showQuotedHeadline.exists(identity)))
+    case None =>
+      Option(LinkSnap(
+        supportingItem.id,
+        LinkType,
+        supportingItem.safeMeta.snapUri,
+        supportingItem.safeMeta.snapCss,
+        supportingItem.safeMeta.headline,
+        supportingItem.safeMeta.href,
+        supportingItem.safeMeta.trailText,
+        supportingItem.safeMeta.group.getOrElse("0"),
+        FaciaImage.getFaciaImage(None, supportingItem.safeMeta, resolvedMetaData),
+        supportingItem.safeMeta.isBreaking.exists(identity),
+        supportingItem.safeMeta.isBoosted.exists(identity),
+        supportingItem.safeMeta.showMainVideo.exists(identity),
+        supportingItem.safeMeta.showKickerTag.exists(identity),
+        supportingItem.safeMeta.byline,
+        supportingItem.safeMeta.showByline.exists(identity),
+        ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
+        supportingItem.safeMeta.showBoostedHeadline.exists(identity),
+        supportingItem.safeMeta.showQuotedHeadline.exists(identity)))
+    }
   }
 }
 


### PR DESCRIPTION
#### Problem

There are legacy snaps hanging around our data without a `snapType`. After ~ Jan 2015, all snaps get a `snapType`, but some fronts (especially commercial fronts) have been static since long before this date.

#### Fix

This changes the `Snap` object methods `maybeFromTrail` and `maybeFromSupportingItem` to fallback to a `LinkSnap` when there is no `snapType` defined.

@stephanfowler @piuccio @robertberry 