### PR TITLE
Change Linksnap to use ContentProperties

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -69,26 +69,21 @@ object Snap {
       Option(LatestSnap.fromTrailAndContent(trail, None))
     case Some(snapType) =>
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trail.safeMeta)
+      val contentProperties = ContentProperties.fromResolvedMetaData(resolvedMetaData)
       Option(LinkSnap(
-      trail.id,
-      Option(trail.frontPublicationDate),
-      snapType,
-      trail.safeMeta.snapUri,
-      trail.safeMeta.snapCss,
-      trail.safeMeta.headline,
-      trail.safeMeta.href,
-      trail.safeMeta.trailText,
-      trail.safeMeta.group.getOrElse("0"),
-      FaciaImage.getFaciaImage(None, trail.safeMeta, resolvedMetaData),
-      trail.safeMeta.isBreaking.exists(identity),
-      trail.safeMeta.isBoosted.exists(identity),
-      trail.safeMeta.showMainVideo.exists(identity),
-      trail.safeMeta.showKickerTag.exists(identity),
-      trail.safeMeta.byline,
-      trail.safeMeta.showByline.exists(identity),
-      ItemKicker.fromTrailMetaData(trail.safeMeta),
-      trail.safeMeta.showBoostedHeadline.exists(identity),
-      trail.safeMeta.showQuotedHeadline.exists(identity)))
+        trail.id,
+        Option(trail.frontPublicationDate),
+        snapType,
+        trail.safeMeta.snapUri,
+        trail.safeMeta.snapCss,
+        trail.safeMeta.headline,
+        trail.safeMeta.href,
+        trail.safeMeta.trailText,
+        trail.safeMeta.group.getOrElse("0"),
+        FaciaImage.getFaciaImage(None, trail.safeMeta, resolvedMetaData),
+        contentProperties,
+        trail.safeMeta.byline,
+        ItemKicker.fromTrailMetaData(trail.safeMeta)))
     case _ => None
   }
 
@@ -97,27 +92,21 @@ object Snap {
       Option(LatestSnap.fromSupportingItemAndContent(supportingItem, None))
     case Some(snapType) =>
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta)
+      val contentProperties = ContentProperties.fromResolvedMetaData(resolvedMetaData)
       Option(LinkSnap(
-      supportingItem.id,
-      supportingItem.frontPublicationDate,
-      snapType,
-      supportingItem.safeMeta.snapUri,
-      supportingItem.safeMeta.snapCss,
-      supportingItem.safeMeta.headline,
-      supportingItem.safeMeta.href,
-      supportingItem.safeMeta.trailText,
-      supportingItem.safeMeta.group.getOrElse("0"),
-      FaciaImage.getFaciaImage(None, supportingItem.safeMeta, resolvedMetaData),
-      supportingItem.safeMeta.isBreaking.exists(identity),
-      supportingItem.safeMeta.isBoosted.exists(identity),
-      supportingItem.safeMeta.showMainVideo.exists(identity),
-      supportingItem.safeMeta.showKickerTag.exists(identity),
-      supportingItem.safeMeta.byline,
-      supportingItem.safeMeta.showByline.exists(identity),
-      ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
-      supportingItem.safeMeta.showBoostedHeadline.exists(identity),
-      supportingItem.safeMeta.showQuotedHeadline.exists(identity)
-  ))
+        supportingItem.id,
+        supportingItem.frontPublicationDate,
+        snapType,
+        supportingItem.safeMeta.snapUri,
+        supportingItem.safeMeta.snapCss,
+        supportingItem.safeMeta.headline,
+        supportingItem.safeMeta.href,
+        supportingItem.safeMeta.trailText,
+        supportingItem.safeMeta.group.getOrElse("0"),
+        FaciaImage.getFaciaImage(None, supportingItem.safeMeta, resolvedMetaData),
+        contentProperties,
+        supportingItem.safeMeta.byline,
+        ItemKicker.fromTrailMetaData(supportingItem.safeMeta)))
     case _ => None
   }
 }
@@ -134,15 +123,9 @@ case class LinkSnap(
   trailText: Option[String],
   group: String,
   image: Option[FaciaImage],
-  isBreaking: Boolean,
-  isBoosted: Boolean,
-  showMainVideo: Boolean,
-  showKickerTag: Boolean,
+  properties: ContentProperties,
   byline: Option[String],
-  showByLine: Boolean,
-  kicker: Option[ItemKicker],
-  showBoostedHeadline: Boolean,
-  showQuotedHeadline: Boolean) extends Snap
+  kicker: Option[ItemKicker]) extends Snap
 
 case class LatestSnap(
   id: String,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -135,25 +135,25 @@ object FaciaContentUtils {
   def isBoosted(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.isBoosted,
     supportingCuratedContent => supportingCuratedContent.properties.isBoosted,
-    linkSnap => linkSnap.isBoosted,
+    linkSnap => linkSnap.properties.isBoosted,
     latestSnap => latestSnap.properties.isBoosted
   )
   def showBoostedHeadline(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showBoostedHeadline,
     supportingCuratedContent => supportingCuratedContent.properties.showBoostedHeadline,
-    linkSnap => linkSnap.showBoostedHeadline,
+    linkSnap => linkSnap.properties.showBoostedHeadline,
     latestSnap => latestSnap.properties.showBoostedHeadline
   )
   def showQuotedHeadline(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showQuotedHeadline,
     supportingCuratedContent => supportingCuratedContent.properties.showQuotedHeadline,
-    linkSnap => linkSnap.showQuotedHeadline,
+    linkSnap => linkSnap.properties.showQuotedHeadline,
     latestSnap => latestSnap.properties.showQuotedHeadline
   )
   def showMainVideo(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showMainVideo,
     supportingCuratedContent => supportingCuratedContent.properties.showMainVideo,
-    linkSnap => linkSnap.showMainVideo,
+    linkSnap => linkSnap.properties.showMainVideo,
     latestSnap => latestSnap.properties.showMainVideo
   )
 
@@ -180,7 +180,7 @@ object FaciaContentUtils {
   def showByline(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showByline,
     supportingCuratedContent => supportingCuratedContent.properties.showByline,
-    linkSnap => linkSnap.showByLine,
+    linkSnap => linkSnap.properties.showByline,
     latestSnap => latestSnap.properties.showByline)
 
   private def tagsOfType(fc: FaciaContent)(tagType: String): Seq[Tag] = tags(fc).filter(_.`type` == tagType)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -43,16 +43,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     trailText: Option[String] = None,
     group: String = "0",
     image: Option[FaciaImage] = None,
-    imageHide: Boolean = false,
-    isBreaking: Boolean = false,
-    isBoosted: Boolean = false,
-    showMainVideo: Boolean = false,
-    showKickerTag: Boolean = false,
+    contentProperties: ContentProperties = ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
     byline: Option[String] = None,
-    showByLine: Boolean = false,
-    kicker: Option[ItemKicker] = None,
-    showBoostedHeadline: Boolean = false,
-    showQuotedHeadline: Boolean = false): LatestSnap =
+    kicker: Option[ItemKicker] = None): LatestSnap =
     LatestSnap(
       id,
       maybeFrontPublicationDate,
@@ -65,7 +58,7 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       trailText,
       group,
       image,
-      ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
+      contentProperties,
       byline,
       kicker)
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -80,15 +80,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
     trailText: Option[String] = None,
     group: String = "0",
     image: Option[FaciaImage] = None,
-    isBreaking: Boolean = false,
-    isBoosted: Boolean = false,
-    showMainVideo: Boolean = false,
-    showKickerTag: Boolean = false,
+    contentProperties: ContentProperties = ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
     byline: Option[String] = None,
-    showByLine: Boolean = false,
-    kicker: Option[ItemKicker] = None,
-    showBoostedHeadline: Boolean = false,
-    showQuotedHeadline: Boolean = false): LinkSnap =
+    kicker: Option[ItemKicker] = None): LinkSnap =
     LinkSnap(
       id,
       maybeFrontPublicationDate,
@@ -100,15 +94,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       trailText,
       group,
       image,
-      isBreaking,
-      isBoosted,
-      showMainVideo,
-      showKickerTag,
+      contentProperties,
       byline,
-      showByLine,
-      kicker,
-      showBoostedHeadline,
-      showQuotedHeadline)
+      kicker)
 
 
   "fromCollectionJson" - {

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -20,15 +20,9 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers {
     trailText = None,
     group = "",
     image = None,
-    isBreaking = false,
-    isBoosted = false,
-    showMainVideo = false,
-    showKickerTag = false,
+    ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
     byline = None,
-    showByLine = false,
-    kicker = None,
-    showBoostedHeadline = false,
-    showQuotedHeadline = false)
+    kicker = None)
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
 


### PR DESCRIPTION
A bit of cleaning around `LinkSnap`.

Other types of `FaciaContent` (`CuratedContent`, `LatestContent` and `SupportingCuratedContent`) use `ContentProperties` for its `boolean`s.

This brings `LinkSnap` in line with how the other types work already.

@robertberry 