### PR TITLE
Fix CutOut resolving

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -14,12 +14,13 @@ object FaciaImage {
   def getFaciaImage(maybeContent: Option[Content], trailMeta: MetaDataCommonFields, resolvedMetadata: ResolvedMetaData): Option[FaciaImage] = {
     if (resolvedMetadata.imageHide) None
     else {
-      maybeContent flatMap { content =>
-        if (resolvedMetadata.imageCutoutReplace)
-          imageCutout(trailMeta) orElse fromContentTags(content, trailMeta)
-        else None
-      } orElse
-          imageSlideshow(trailMeta, resolvedMetadata) orElse imageCutout(trailMeta) orElse imageReplace(trailMeta, resolvedMetadata)
+      if (resolvedMetadata.imageSlideshowReplace)
+        imageSlideshow(trailMeta, resolvedMetadata)
+      else if (resolvedMetadata.imageCutoutReplace)
+        imageCutout(trailMeta) orElse maybeContent.flatMap(fromContentTags(_, trailMeta))
+      else if (resolvedMetadata.imageReplace)
+        imageReplace(trailMeta, resolvedMetadata)
+      else None
     }
   }
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -19,7 +19,7 @@ object FaciaImage {
           imageCutout(trailMeta) orElse fromContentTags(content, trailMeta)
         else None
       } orElse
-          imageSlideshow(trailMeta, resolvedMetadata) orElse imageReplace(trailMeta, resolvedMetadata)
+          imageSlideshow(trailMeta, resolvedMetadata) orElse imageCutout(trailMeta) orElse imageReplace(trailMeta, resolvedMetadata)
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageCutoutTest.scala
@@ -84,6 +84,17 @@ class FaciaImageCutoutTest extends FreeSpec with Matchers {
       val imageCutout = FaciaImage.getFaciaImage(Some(contentWithContributor), trailMeta, resolvedMetaData)
       imageCutout should be (None)
     }
+
+    "should not return an Image of type cutout from a None content imageCutoutReplace is true" in {
+      val src = Option("src")
+      val width  = Option("width")
+      val height = Option("height")
+
+      val trailMeta = trailMetaDataWithImageCutout(true, src, width, height)
+      val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMeta)
+      val imageCutout = FaciaImage.getFaciaImage(None, trailMeta, resolvedMetaData)
+      imageCutout should be (Some(Cutout("src", width, height)))
+    }
   }
 
 }


### PR DESCRIPTION
When there was no `Content` in `getFaciaImage`, only `imageSlideShow` and `imageReplace` were getting called as fallbacks.

This adds in `imageCutout`. I have also simplified the code.

@robertberry 