### PR TITLE
Fix SnapLatest Fields

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -171,13 +171,13 @@ object LatestSnap {
       supportingItem.safeMeta.snapUri,
       supportingItem.safeMeta.snapCss,
       maybeContent,
-      supportingItem.safeMeta.headline,
-      supportingItem.safeMeta.href,
-      supportingItem.safeMeta.trailText,
+      supportingItem.safeMeta.headline.orElse(maybeContent.flatMap(_.safeFields.get("headline"))).orElse(maybeContent.map(_.webTitle)),
+      supportingItem.safeMeta.href.orElse(maybeContent.flatMap(_.safeFields.get("href"))),
+      supportingItem.safeMeta.trailText.orElse(maybeContent.flatMap(_.safeFields.get("trailText"))),
       supportingItem.safeMeta.group.getOrElse("0"),
       FaciaImage.getFaciaImage(maybeContent, supportingItem.safeMeta, resolvedMetaData),
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
-      supportingItem.safeMeta.byline,
+      supportingItem.safeMeta.byline.orElse(maybeContent.flatMap(_.safeFields.get("byline"))),
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData)
     )
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -150,7 +150,7 @@ object LatestSnap {
       trail.safeMeta.snapCss,
       maybeContent,
       trail.safeMeta.headline.orElse(maybeContent.flatMap(_.safeFields.get("headline"))).orElse(maybeContent.map(_.webTitle)),
-      trail.safeMeta.href.orElse(maybeContent.flatMap(_.safeFields.get("href"))),
+      trail.safeMeta.href.orElse(maybeContent.map(_.id)),
       trail.safeMeta.trailText.orElse(maybeContent.flatMap(_.safeFields.get("trailText"))),
       trail.safeMeta.group.getOrElse("0"),
       FaciaImage.getFaciaImage(maybeContent, trail.safeMeta, resolvedMetaData),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -149,13 +149,13 @@ object LatestSnap {
       trail.safeMeta.snapUri,
       trail.safeMeta.snapCss,
       maybeContent,
-      trail.safeMeta.headline,
-      trail.safeMeta.href,
-      trail.safeMeta.trailText,
+      trail.safeMeta.headline.orElse(maybeContent.flatMap(_.safeFields.get("headline"))).orElse(maybeContent.map(_.webTitle)),
+      trail.safeMeta.href.orElse(maybeContent.flatMap(_.safeFields.get("href"))),
+      trail.safeMeta.trailText.orElse(maybeContent.flatMap(_.safeFields.get("trailText"))),
       trail.safeMeta.group.getOrElse("0"),
       FaciaImage.getFaciaImage(maybeContent, trail.safeMeta, resolvedMetaData),
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
-      trail.safeMeta.byline,
+      trail.safeMeta.byline.orElse(maybeContent.flatMap(_.safeFields.get("byline"))),
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData)
     )
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -80,7 +80,7 @@ object FaciaContentUtils {
     curatedContent => Option(curatedContent.headline),
     supportingCuratedContent => Option(supportingCuratedContent.headline),
     linkSnap => linkSnap.headline,
-    latestSnap => latestSnap.headline.orElse(latestSnap.latestContent.map(_.fields.get("headline"))))
+    latestSnap => latestSnap.headline)
 
   def headline(fc: FaciaContent): String = headlineOption(fc).getOrElse("Missing Headline")
 
@@ -99,7 +99,7 @@ object FaciaContentUtils {
     curatedContent => curatedContent.href,
     supportingCuratedContent => supportingCuratedContent.href,
     linkSnap => linkSnap.href.orElse(linkSnap.snapUri),
-    latestSnap => latestSnap.latestContent.map(_.id).orElse(latestSnap.snapUri))
+    latestSnap => latestSnap.href.orElse(latestSnap.snapUri))
 
   def mediaType(fc: FaciaContent): Option[MediaType] = {
     def mediaTypeFromContent(content: Content): Option[MediaType] =
@@ -181,7 +181,7 @@ object FaciaContentUtils {
     curatedContent => curatedContent.byline,
     supportingCuratedContent => supportingCuratedContent.byline,
     linkSnap => linkSnap.byline,
-    latestSnap => latestSnap.latestContent.flatMap(_.safeFields.get("byline")))
+    latestSnap => latestSnap.byline)
 
   def showByline(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showByline,
@@ -228,8 +228,8 @@ object FaciaContentUtils {
   def trailText(fc: FaciaContent): Option[String] = fold(fc)(
     curatedContent => curatedContent.trailText,
     supportingCuratedContent => supportingCuratedContent.trailText,
-    linkSnap => None,
-    latestSnap => None)
+    linkSnap => linkSnap.trailText,
+    latestSnap => latestSnap.trailText)
 
   def  maybeWebTitle(fc: FaciaContent): Option[String] = fold(fc)(
     curatedContent => Option(curatedContent.content.webTitle),

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -182,8 +182,22 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       faciaContent.length should be (4)
       faciaContent(0) should be (makeLinkSnap(id = "snap/1415985080061", maybeFrontPublicationDate = Option(1L), snapUri = Some("abc")))
       faciaContent(1) should be (makeLinkSnap(id = "snap/5345345215342", maybeFrontPublicationDate = Option(1L), snapCss = Some("css")))
-      faciaContent(2) should be (makeLatestSnap(id = "snap/8474745745660", maybeFrontPublicationDate = Option(1L), href = Some("uk"), latestContent = Some(snapContentOne)))
-      faciaContent(3) should be (makeLatestSnap(id = "snap/4324234234234", maybeFrontPublicationDate = Option(1L), href = Some("culture"), latestContent = Some(snapContentTwo)))
+      faciaContent(2) should be (makeLatestSnap(
+                                  id = "snap/8474745745660",
+                                  maybeFrontPublicationDate = Option(1L),
+                                  href = Some("uk"),
+                                  headline = Some("Content headline"),
+                                  byline = Some("Content byline"),
+                                  trailText = Some("Content trailtext"),
+                                  latestContent = Some(snapContentOne)))
+      faciaContent(3) should be (makeLatestSnap(
+                                  id = "snap/4324234234234",
+                                  maybeFrontPublicationDate = Option(1L),
+                                  href = Some("culture"),
+                                  headline = Some("Content headline"),
+                                  byline = Some("Content byline"),
+                                  trailText = Some("Content trailtext"),
+                                  latestContent = Some(snapContentTwo)))
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -2,9 +2,12 @@ package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.utils.{ContentProperties, DefaultCardstyle, FaciaContentUtils}
+import com.gu.facia.client.models.{TrailMetaData, Trail}
 import org.scalatest.{FreeSpec, Matchers}
 
 class FaciaContentHelperTest extends FreeSpec with Matchers {
+
+  val emptyTrail: Trail = Trail("no-id", 0, Option(TrailMetaData.empty))
 
   val emptyContentProperties =
     ContentProperties(
@@ -37,12 +40,12 @@ class FaciaContentHelperTest extends FreeSpec with Matchers {
 
   "should return a href for a LatestSnap" in {
     val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, None, None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
-    FaciaContentUtils.href(snap) should equal(None)
+    FaciaContentUtils.href(snap) should equal(Some("The href"))
   }
 
   "should return a byline for a LatestSnap" in {
     val content = Content("myId", None, None, None, "myTitle", "myUrl", "myApi", Some(Map("byline" -> "myByline")), Nil, None, Nil, None)
-    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, Some(content), None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap.fromTrailAndContent(emptyTrail, Option(content))
     FaciaContentUtils.byline(snap) should equal(Some("myByline"))
   }
 


### PR DESCRIPTION
This fixes fields in `LatestSnap` that were never being filled out properly like they were with the other types.

The fields changed are:
  - `href`
  - `byline`
  - `trailText`
  - `headline`

The only odd one is `href` in that it `FaciaContentUtils` it falls back to `snapUri`, whilst this `snapUri` can never end up in `href` on `LatestSnap` itself.

@robertberry