### PR TITLE
Remove editors picks from backfill results

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 
+#### 0.54
+
+  - Changes queries to not add editorsPicks to the head of the list of backfill by default
+
+
 #### 0.53
+
   - Adds showLivePlayable content meta
 
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -90,7 +90,7 @@ object ContentApi {
                                  (implicit ec: ExecutionContext): Response[List[Content]] = {
     response.fold(
       _.map { itemResponse =>
-          itemResponse.editorsPicks ++ itemResponse.mostViewed ++ itemResponse.results
+          itemResponse.mostViewed ++ itemResponse.results
         },
       _.map { searchResponse =>
           searchResponse.results

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -56,11 +56,8 @@ object ContentApi {
         case ("show-fields", _) => true
         case _ => false
       }) rawParams else rawParams :+ ("show-fields" -> "internalContentCode,internalPageCode")
-    val paramsWithEditorsPicks =
-      if (paramsWithFields.exists {
-        case ("show-editors-picks", _) => true
-        case _ => false
-      }) paramsWithFields else paramsWithFields :+ ("show-editors-picks" -> "true")
+
+    val paramsWithEditorsPicks = paramsWithFields :+ ("show-editors-picks" -> "false")
 
     if (path.startsWith("search")) {
       val searchQuery = SearchQuery()

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -80,13 +80,18 @@ class ContentApiTest extends FreeSpec
         ContentApi.buildBackfillQuery(backfillWithFields).left.value.parameters.get("show-fields").value should equal ("headline,internalContentCode,internalPageCode")
       }
 
-      "will add editors picks if they aren't explicitly on the query" in {
+      "will add editors picks false if they aren't explicitly on the query" in {
         val backfill = "lifeandstyle/food-and-drink?show-most-viewed=true&hide-recent-content=true"
-        ContentApi.buildBackfillQuery(backfill).left.value.parameters.get("show-editors-picks").value should equal ("true")
+        ContentApi.buildBackfillQuery(backfill).left.value.parameters.get("show-editors-picks").value should equal ("false")
       }
 
-      "will not force editors picks to true if they are explicitly exluded on the query" in {
+      "will force editors picks to false if they are explicitly exluded on the query" in {
         val backfill = "lifeandstyle/food-and-drink?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true"
+        ContentApi.buildBackfillQuery(backfill).left.value.parameters.get("show-editors-picks").value should equal ("false")
+      }
+
+      "will force editors picks to false if they are explicitly included on the query" in {
+        val backfill = "lifeandstyle/food-and-drink?show-most-viewed=true&show-editors-picks=true&hide-recent-content=true"
         ContentApi.buildBackfillQuery(backfill).left.value.parameters.get("show-editors-picks").value should equal ("false")
       }
     }

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -117,18 +117,6 @@ class ContentApiTest extends FreeSpec
       )
     }
 
-    "includes editors picks in item query backfill" in {
-      val itemResponse = mock[ItemResponse]
-      when(itemResponse.results) thenReturn Nil
-      when(itemResponse.editorsPicks) thenReturn contents
-      when(itemResponse.mostViewed) thenReturn Nil
-      val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
-      ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
-        err => fail(s"expected contents result, got error $err"),
-        result => result should be(contents)
-      )
-    }
-
     "includes most viewed in item query backfill" in {
       val itemResponse = mock[ItemResponse]
       when(itemResponse.results) thenReturn Nil


### PR DESCRIPTION
TLDR; This forces `show-editors-picks` to be `false` on `backfill` queries.


### Problem

We are in a bit of a situation on some fronts that aren't massively curated and depend on backfills.

Step-by-step:
 - On frontend, when requesting backfills for a certain `path`, we ask for and **add** `editorsPicks` to the head of the `results` that `CAPI` returns to us.
 - We then generate a `lite.json` file from these results.
 - `CAPI` now reads this `lite.json` file and puts them into editors picks for the `path`.
 - On frontend, when requesting backfills for a certain `path`, we ask for and **add** `editorsPicks` to the head of the `results` that `CAPI` returns to us.

It's completely circular and confusing. We did sort this for some situations in the past, but this is what is left of it.

We have realised we definitely do not need `editorsPicks` anywhere near this library, as this library IS `editorsPicks`. Are you confused yet?

### Background
##### Why were we adding `editorsPicks` to the head of the list?

Adding `editorsPicks` to the head of the results like this worked fine and as expected up until we were the `editorPicks`. Before, `editorsPicks` came from `r2-admin`.

We always could see the circular dependency coming, and this is the last of it.

### Fix

Remove `editors-picks` from `facia-scala-client`. This will break the cycle.

@piuccio @stephanfowler @mchv 