### PR TITLE
Metadata changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+#### 0.56
+
+  - Adds a convenience function: ResolvedMetaData.toMap
+  - Changes ResolvedMetaData.fromContent to a non-private methods
+  - Adds CardStyle.fromContent convenience method for CardStyle
+
 #### 0.55
 
   - Shows the breaking news kicker even when tonal kickers are supressed

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -2,7 +2,7 @@ package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.Content
 import com.gu.facia.api.utils.ContentApiUtils._
-import com.gu.facia.client.models.MetaDataCommonFields
+import com.gu.facia.client.models.{TrailMetaData, MetaDataCommonFields}
 
 object CardStyle {
   val specialReport = "special-report"
@@ -51,6 +51,8 @@ object CardStyle {
       DefaultCardstyle
     }
   }
+
+  def fromContent(content: Content) = apply(content, TrailMetaData.empty)
 }
 
 sealed trait CardStyle {

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -55,7 +55,7 @@ object ResolvedMetaData {
       imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity)
   )
 
-  private[utils] def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
+  def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
     cardStyle match {
       case com.gu.facia.api.utils.Comment => Default.copy(
         showByline = true,
@@ -83,6 +83,39 @@ object ResolvedMetaData {
       imageCutoutReplace = trailMeta.imageCutoutReplace.getOrElse(metaDataFromContent.imageCutoutReplace),
       showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline),
       imageSlideshowReplace = trailMeta.imageSlideshowReplace.getOrElse(metaDataFromContent.imageSlideshowReplace))}
+
+  def toMap(resolvedMetaData: ResolvedMetaData): Map[String, Boolean] = resolvedMetaData match {
+    case ResolvedMetaData(
+      isBreaking,
+      isBoosted,
+      imageHide,
+      imageReplace,
+      showKickerSection,
+      showKickerCustom,
+      showBoostedHeadline,
+      showMainVideo,
+      showLivePlayable,
+      showKickerTag,
+      showByline,
+      imageCutoutReplace,
+      showQuotedHeadline,
+      imageSlideshowReplace) =>
+      Map(
+        "isBreaking" -> isBreaking,
+        "isBoosted" -> isBoosted,
+        "imageHide" -> imageHide,
+        "imageReplace" -> imageReplace,
+        "showKickerSection" -> showKickerSection,
+        "showKickerCustom" -> showKickerCustom,
+        "showBoostedHeadline" -> showBoostedHeadline,
+        "showMainVideo" -> showMainVideo,
+        "showLivePlayable" -> showLivePlayable,
+        "showKickerTag" -> showKickerTag,
+        "showByline" -> showByline,
+        "imageCutoutReplace" -> imageCutoutReplace,
+        "showQuotedHeadline" -> showQuotedHeadline,
+        "imageSlideshowReplace" -> imageSlideshowReplace)
+  }
 }
 
 case class ResolvedMetaData(


### PR DESCRIPTION
This just adds two convenience methods: `ResolvedMetaData.toMap` and `CardStyle.fromContent`.

Also changes `ResolvedMetaData.fromContent` to a public method.