### PR TITLE
Group fronts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 0.57
+
+  - Adds Front.group meta
+
 #### 0.56
 
   - Adds a convenience function: ResolvedMetaData.toMap

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -77,7 +77,8 @@ case class FrontJson(
   isImageDisplayed: Option[Boolean],
   priority: Option[String],
   isHidden: Option[Boolean],
-  canonical: Option[String]
+  canonical: Option[String],
+  group: Option[String]
 )
 
 object ConfigJson {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -24,7 +24,8 @@ case class Front(
                   isImageDisplayed: Boolean,
                   priority: FrontPriority,
                   isHidden: Boolean,
-                  canonicalCollection: String)
+                  canonicalCollection: String,
+                  group: Option[String])
 
 object Front {
   private def getFrontPriority(frontJson: FrontJson): FrontPriority =
@@ -53,7 +54,8 @@ object Front {
       frontJson.isImageDisplayed.getOrElse(false),
       getFrontPriority(frontJson),
       frontJson.isHidden.getOrElse(false),
-      canonicalCollection(id, frontJson)
+      canonicalCollection(id, frontJson),
+      frontJson.group
     )
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -9,7 +9,7 @@ class FrontTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneI
     "when generating the canonical field" - {
       val frontJson = FrontJson(
         collections = List("collection1", "collection2", "collection3", "collection4"),
-        None, None, None, None, None, None, None, None, None, None, None, None
+        None, None, None, None, None, None, None, None, None, None, None, None, None
       )
 
       "uses the fronts config field if present" in {


### PR DESCRIPTION
Group commercial fronts by 'something' that resemble desks, but not really.

Looks like this in fronts tool
![screen shot 2015-09-25 at 16 58 58](https://cloud.githubusercontent.com/assets/680284/10105506/ea64aa38-63a6-11e5-8ed7-a63d5053ec2b.png)

@janua is this a breaking change?