### PR TITLE
Hide show more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 0.58
+
+  - Adds Collections.hideShowMore
+
 #### 0.57
 
   - Adds Front.group meta

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -44,6 +44,7 @@ sealed trait MetaDataCommonFields {
   lazy val slideshow: Option[List[SlideshowAsset]] =
     json.get("slideshow").flatMap(_.asOpt[List[SlideshowAsset]]).filter(_.nonEmpty)
   lazy val showLivePlayable: Option[Boolean] = json.get("showLivePlayable").flatMap(_.asOpt[Boolean])
+  lazy val hideShowMore: Option[Boolean] = json.get("hideShowMore").flatMap(_.asOpt[Boolean])
 }
 
 object SupportingItemMetaData {

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.Json
 object CollectionConfigJson {
   implicit val jsonFormat = Json.format[CollectionConfigJson]
 
-  val emptyConfig: CollectionConfigJson = withDefaults(None, None, None, None, None, None, None, None, None, None, None)
+  val emptyConfig: CollectionConfigJson = withDefaults(None, None, None, None, None, None, None, None, None, None, None, None)
 
   def withDefaults(
     displayName: Option[String] = None,
@@ -21,7 +21,8 @@ object CollectionConfigJson {
     showDateHeader: Option[Boolean] = None,
     showLatestUpdate: Option[Boolean] = None,
     excludeFromRss: Option[Boolean] = None,
-    showTimestamps: Option[Boolean] = None
+    showTimestamps: Option[Boolean] = None,
+    hideShowMore: Option[Boolean] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -37,7 +38,8 @@ object CollectionConfigJson {
     showDateHeader,
     showLatestUpdate,
     excludeFromRss,
-    showTimestamps
+    showTimestamps,
+    hideShowMore
   )
 }
 
@@ -55,7 +57,8 @@ case class CollectionConfigJson(
   showDateHeader: Option[Boolean],
   showLatestUpdate: Option[Boolean],
   excludeFromRss: Option[Boolean],
-  showTimestamps: Option[Boolean]
+  showTimestamps: Option[Boolean],
+  hideShowMore: Option[Boolean]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -18,7 +18,8 @@ case class CollectionConfig(
     showDateHeader: Boolean,
     showLatestUpdate: Boolean,
     excludeFromRss: Boolean,
-    showTimestamps: Boolean)
+    showTimestamps: Boolean,
+    hideShowMore: Boolean)
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-VI"
@@ -37,7 +38,8 @@ object CollectionConfig {
     showDateHeader = false,
     showLatestUpdate = false,
     excludeFromRss = false,
-    showTimestamps = false)
+    showTimestamps = false,
+    hideShowMore = false)
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -47,12 +49,13 @@ object CollectionConfig {
       collectionJson.href,
       collectionJson.description,
       collectionJson.groups.map(Groups),
-      collectionJson.uneditable.getOrElse(false),
-      collectionJson.showTags.getOrElse(false),
-      collectionJson.showSections.getOrElse(false),
-      collectionJson.hideKickers.getOrElse(false),
-      collectionJson.showDateHeader.getOrElse(false),
-      collectionJson.showLatestUpdate.getOrElse(false),
+      collectionJson.uneditable.exists(identity),
+      collectionJson.showTags.exists(identity),
+      collectionJson.showSections.exists(identity),
+      collectionJson.hideKickers.exists(identity),
+      collectionJson.showDateHeader.exists(identity),
+      collectionJson.showLatestUpdate.exists(identity),
       collectionJson.excludeFromRss.exists(identity),
-      collectionJson.showTimestamps.exists(identity))
+      collectionJson.showTimestamps.exists(identity),
+      collectionJson.hideShowMore.exists(identity))
 }


### PR DESCRIPTION
Extra option on the collection to disable `show more` button even when there are extra trails.

TODO before merge
- [x] merge #127 
- [x] update `CHANGES.md`

TODO after merge
- [ ] update frontend to remove show more button
- [ ] [optional] update facia press to limit the number of trail
- [ ] update facia-tool to allow switching this value on/off
- [ ] rejoice

@janua 