### PR TITLE
Fix batch size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 0.60
+
+  - Fix the batching so that it does not request more than 50 at a time in a search query. There is a restriction in CAPI of 50 items in a search query.
+
 #### 0.59
 
   - Adds a publishedBy to Trail

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/IdsSearchQueries.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/IdsSearchQueries.scala
@@ -7,10 +7,14 @@ object IdsSearchQueries {
   type Url = String
 
   val MaxUrlSize = com.gu.contentapi.client.Limits.UrlSize
+  //Maximum size that can be requested from CAPI is 50.
+  val MaxBatchSize = 50
 
   def makeBatches(ids: Seq[Id])(urlFromIds: Seq[Id] => Url): Option[Seq[Seq[Id]]] = {
     def batchAndRemaining(ids: Seq[Id]): Option[(Seq[Id], Seq[Id])] =
-      ids.inits.find(urlFromIds(_).length <= MaxUrlSize) map { batch =>
+      ids.inits.find{ init =>
+        init.length <= MaxBatchSize && urlFromIds(init).length <= MaxUrlSize
+      } map { batch =>
         (batch, ids.drop(batch.length))
       }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/IdsSearchQueriesTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/IdsSearchQueriesTest.scala
@@ -46,4 +46,20 @@ class IdsSearchQueriesTest extends FreeSpec with ShouldMatchers {
       )))
     }
   }
+
+  "limit batches" - {
+    val fifty = List.fill(50)("abc").toSeq
+    val fiftyOne = fifty :+ "fiftyFirst"
+
+    "leave batches under or equal to 50" in {
+      IdsSearchQueries.makeBatches(fifty) {
+        _.mkString("")
+      } should be(Some(Seq(fifty)))
+    }
+
+    "should limit batches over 50" in {
+      IdsSearchQueries.makeBatches(fiftyOne){_.mkString("")} should be (Some(
+        Seq(fifty, Seq("fiftyFirst"))))
+    }
+  }
 }


### PR DESCRIPTION
The maximum amount of `ids` that can be requested through a `search` query from the content API is 50.
This restricts the batch size to 50.

@piuccio 