### PR TITLE
Convert apiquery to backfill

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### 0.66
+
+  - Add `backfill` in collectiong config. This is meant to replace `apiQuery` in future releases.
+  - The method `FAPI.backfill(apiQuery: String, collection: Collection)` has been deprecated, `FAPI.backfillFromConfig(collection: Collection)` should be used instead as it automatically handles the backfill query and returns an empty list in case no backfill is set.
+
 #### 0.65
 
   - Add This Is The NHS Tag to Special Report

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
-#### 0.66
+#### 0.67
 
   - Add `backfill` in collectiong config. This is meant to replace `apiQuery` in future releases.
   - The method `FAPI.backfill(apiQuery: String, collection: Collection)` has been deprecated, `FAPI.backfillFromConfig(collection: Collection)` should be used instead as it automatically handles the backfill query and returns an empty list in case no backfill is set.
+
+
+#### 0.66
+
+  - Invalid release, don't use
 
 #### 0.65
 

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -2,14 +2,23 @@ package com.gu.facia.client.models
 
 import play.api.libs.json.Json
 
+object Backfill {
+  implicit val jsonFormat = Json.format[Backfill]
+}
+case class Backfill(
+  `type`: String,
+  query: String
+)
+
 object CollectionConfigJson {
   implicit val jsonFormat = Json.format[CollectionConfigJson]
 
-  val emptyConfig: CollectionConfigJson = withDefaults(None, None, None, None, None, None, None, None, None, None, None, None)
+  val emptyConfig: CollectionConfigJson = withDefaults(None, None, None, None, None, None, None, None, None, None, None, None, None)
 
   def withDefaults(
     displayName: Option[String] = None,
     apiQuery: Option[String] = None,
+    backfill: Option[Backfill] = None,
     `type`: Option[String] = None,
     href: Option[String] = None,
     description: Option[String] = None,
@@ -27,6 +36,7 @@ object CollectionConfigJson {
     = CollectionConfigJson(
     displayName,
     apiQuery,
+    backfill,
     `type`,
     href,
     description,
@@ -46,6 +56,7 @@ object CollectionConfigJson {
 case class CollectionConfigJson(
   displayName: Option[String],
   apiQuery: Option[String],
+  backfill: Option[Backfill],
   `type`: Option[String],
   href: Option[String],
   description: Option[String],

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.contentapi.{ContentApi, LatestSnapsRequest}
 import com.gu.facia.api.models._
-import com.gu.facia.api.utils.BackfillContent
+import com.gu.facia.api.utils.{BackfillResolver, BackfillContent}
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.TrailMetaData
 
@@ -182,7 +182,7 @@ object FAPI {
                          adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
                         (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
 
-    BackfillContent.resolveFromConfig(collection.collectionConfig)
-    .backfill(adjustSearchQuery, adjustItemQuery)
+    val resolver = BackfillContent.resolveFromConfig(collection.collectionConfig)
+    BackfillResolver.backfill(resolver, adjustSearchQuery, adjustItemQuery)
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -182,7 +182,7 @@ object FAPI {
                          adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
                         (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
 
-    val resolver = BackfillResolver.resolveFromConfig(collection.collectionConfig)
-    BackfillResolver.backfill(resolver, adjustSearchQuery, adjustItemQuery)
+    val backfillRequest = BackfillResolver.resolveFromConfig(collection.collectionConfig)
+    BackfillResolver.backfill(backfillRequest, adjustSearchQuery, adjustItemQuery)
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.contentapi.{ContentApi, LatestSnapsRequest}
 import com.gu.facia.api.models._
-import com.gu.facia.api.utils.{BackfillResolver, BackfillContent}
+import com.gu.facia.api.utils.BackfillResolver
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.TrailMetaData
 
@@ -182,7 +182,7 @@ object FAPI {
                          adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
                         (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
 
-    val resolver = BackfillContent.resolveFromConfig(collection.collectionConfig)
+    val resolver = BackfillResolver.resolveFromConfig(collection.collectionConfig)
     BackfillResolver.backfill(resolver, adjustSearchQuery, adjustItemQuery)
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -5,6 +5,7 @@ import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.contentapi.{ContentApi, LatestSnapsRequest}
 import com.gu.facia.api.models._
+import com.gu.facia.api.utils.BackfillContent
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.TrailMetaData
 
@@ -156,6 +157,7 @@ object FAPI {
    * requirements by providing adjustment functions. The results then have their facia metadata
    * resolved using the collection information.
    */
+  @deprecated
   def backfill(backfillQuery: String, collection: Collection,
                adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
               (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[CuratedContent]] = {
@@ -169,5 +171,18 @@ object FAPI {
     } yield {
       backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collection.collectionConfig))
     }
+  }
+
+  /**
+    * Fetches content for the configured backfill query. The query can be manipulated for different
+    * requirements by providing adjustment functions. The results then have their facia metadata
+    * resolved using the collection information.
+    */
+  def backfillFromConfig(collection: Collection,
+                         adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+                        (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+
+    BackfillContent.resolveFromConfig(collection.collectionConfig)
+    .backfill(adjustSearchQuery, adjustItemQuery)
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -1,12 +1,14 @@
 package com.gu.facia.api.models
 
 import com.gu.facia.client.models.CollectionConfigJson
+import com.gu.facia.client.models.Backfill
 
 case class Groups(groups: List[String])
 
 case class CollectionConfig(
     displayName: Option[String],
     apiQuery: Option[String],
+    backfill: Option[Backfill],
     collectionType: String,
     href: Option[String],
     description: Option[String],
@@ -27,6 +29,7 @@ object CollectionConfig {
   val empty = CollectionConfig(
     displayName = None,
     apiQuery = None,
+    backfill = None,
     collectionType = DefaultCollectionType,
     href = None,
     description = None,
@@ -45,6 +48,7 @@ object CollectionConfig {
     CollectionConfig(
       collectionJson.displayName,
       collectionJson.apiQuery,
+      collectionJson.backfill,
       collectionJson.collectionType getOrElse DefaultCollectionType,
       collectionJson.href,
       collectionJson.description,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -10,7 +10,7 @@ import com.gu.facia.client.models.{Backfill, TrailMetaData}
 
 import scala.concurrent.ExecutionContext
 
-case class InvalidBackfillConfiguration(msg: String) extends Error(msg)
+case class InvalidBackfillConfiguration(msg: String) extends Exception(msg)
 
 sealed trait BackfillResolver
 case class CapiBackfill(query: String, collectionConfig: CollectionConfig) extends BackfillResolver

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -1,0 +1,63 @@
+package com.gu.facia.api.utils
+
+import com.gu.contentapi.client.GuardianContentClient
+import com.gu.facia.api.{FAPI, Response}
+import com.gu.facia.api.contentapi.ContentApi
+import com.gu.facia.api.contentapi.ContentApi._
+import com.gu.facia.api.models.{FaciaContent, CollectionConfig, CuratedContent}
+import com.gu.facia.client.ApiClient
+import com.gu.facia.client.models.{CollectionJson, Backfill, TrailMetaData}
+
+import scala.concurrent.ExecutionContext
+
+object BackfillContent {
+  def resolveFromConfig(collectionConfig: CollectionConfig): BackfillResolver = {
+    collectionConfig.backfill match {
+      case Some(backfill: Backfill) => backfill.`type` match {
+        case "capi" => CapiBackfill(backfill.query, collectionConfig)
+        case "collection" => CollectionBackfill(backfill.query)
+        case _ => throw new Error(s"Invalid backfill type ${backfill.`type`}")
+      }
+      case None => collectionConfig.apiQuery match {
+        case Some(query: String) => CapiBackfill(query, collectionConfig)
+        case None => EmptyBackfill()
+      }
+    }
+  }
+}
+
+sealed trait BackfillResolver {
+  def backfill(adjustSearchQuery: AdjustSearchQuery, adjustItemQuery: AdjustItemQuery)
+              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]]
+}
+
+case class CapiBackfill(query: String, collectionConfig: CollectionConfig) extends BackfillResolver {
+  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+
+    val capiQuery = ContentApi.buildBackfillQuery(query)
+      .right.map(adjustSearchQuery)
+      .left.map(adjustItemQuery)
+    val backfillResponse = ContentApi.getBackfillResponse(capiClient, capiQuery)
+    for {
+      backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
+    } yield {
+      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig))
+    }
+  }
+}
+
+case class CollectionBackfill(parentCollectionId: String) extends BackfillResolver {
+  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+    for {
+      collection <- FAPI.getCollection(parentCollectionId)
+      curatedCollection <- FAPI.liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustItemQuery)
+    } yield curatedCollection
+  }
+}
+
+case class EmptyBackfill() extends BackfillResolver {
+  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = Response.Right(Nil)
+}

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -27,38 +27,29 @@ object BackfillContent {
   }
 }
 
-sealed trait BackfillResolver {
-  def backfill(adjustSearchQuery: AdjustSearchQuery, adjustItemQuery: AdjustItemQuery)
-              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]]
-}
+sealed trait BackfillResolver
+case class CapiBackfill(query: String, collectionConfig: CollectionConfig) extends BackfillResolver
+case class CollectionBackfill(parentCollectionId: String) extends BackfillResolver
+case object EmptyBackfill extends BackfillResolver
 
-case class CapiBackfill(query: String, collectionConfig: CollectionConfig) extends BackfillResolver {
-  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
+object BackfillResolver {
+  def backfill(resolver: BackfillResolver, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
               (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
-
-    val capiQuery = ContentApi.buildBackfillQuery(query)
-      .right.map(adjustSearchQuery)
-      .left.map(adjustItemQuery)
-    val backfillResponse = ContentApi.getBackfillResponse(capiClient, capiQuery)
-    for {
-      backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
-    } yield {
-      backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig))
-    }
-  }
-}
-
-case class CollectionBackfill(parentCollectionId: String) extends BackfillResolver {
-  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
-    for {
-      collection <- FAPI.getCollection(parentCollectionId)
-      curatedCollection <- FAPI.liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustItemQuery)
-    } yield curatedCollection
-  }
-}
-
-case object EmptyBackfill extends BackfillResolver {
-  def backfill(adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-              (implicit capiClient: GuardianContentClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = Response.Right(Nil)
+    resolver match {
+      case CapiBackfill(query, collectionConfig) =>
+        val capiQuery = ContentApi.buildBackfillQuery(query)
+          .right.map(adjustSearchQuery)
+          .left.map(adjustItemQuery)
+        val backfillResponse = ContentApi.getBackfillResponse(capiClient, capiQuery)
+        for {
+          backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
+        } yield {
+          backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig))
+        }
+      case CollectionBackfill(parentCollectionId) =>
+        for {
+          collection <- FAPI.getCollection(parentCollectionId)
+          curatedCollection <- FAPI.liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustItemQuery)
+        } yield curatedCollection
+      case EmptyBackfill => Response.Right(Nil)}}
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -1,12 +1,12 @@
 package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.api.contentapi.ContentApi
 import com.gu.facia.api.contentapi.ContentApi._
-import com.gu.facia.api.models.{FaciaContent, CollectionConfig, CuratedContent}
+import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
+import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.client.ApiClient
-import com.gu.facia.client.models.{CollectionJson, Backfill, TrailMetaData}
+import com.gu.facia.client.models.{Backfill, TrailMetaData}
 
 import scala.concurrent.ExecutionContext
 
@@ -15,11 +15,10 @@ case class InvalidBackfillConfiguration(msg: String) extends Error(msg)
 object BackfillContent {
   def resolveFromConfig(collectionConfig: CollectionConfig): BackfillResolver = {
     collectionConfig.backfill match {
-      case Some(backfill: Backfill) => backfill.`type` match {
-        case "capi" => CapiBackfill(backfill.query, collectionConfig)
-        case "collection" => CollectionBackfill(backfill.query)
-        case _ => throw new InvalidBackfillConfiguration(s"Invalid backfill type ${backfill.`type`}")
-      }
+      case Some(Backfill("capi", query: String)) => CapiBackfill(query, collectionConfig)
+      case Some(Backfill("collection", query: String)) => CollectionBackfill(query)
+      case Some(Backfill(backFillType, _)) => throw new InvalidBackfillConfiguration(s"Invalid backfill type $backFillType")
+      // TODO once the deprecated `apiQuery` is removed, the case None should simply return EmptyBackfill
       case None => collectionConfig.apiQuery match {
         case Some(query: String) => CapiBackfill(query, collectionConfig)
         case None => EmptyBackfill

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.TagType
 import com.gu.facia.api.FAPI
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.models._
-import com.gu.facia.api.utils.SectionKicker
+import com.gu.facia.api.utils.{InvalidBackfillConfiguration, SectionKicker}
 import com.gu.facia.client.models._
 import lib.IntegrationTestConfig
 import org.joda.time.DateTime
@@ -169,7 +169,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     }
   }
 
-  // TODO this should be remove once deprecation ends
+  // TODO this should be removed once deprecation ends
   "backfill - deprecated capi query" - {
     val collection = Collection(
       "uk/business/regular-stories",
@@ -219,7 +219,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     }
   }
 
-  // TODO this should be remove once deprecation ends
+  // TODO this should be removed once deprecation ends
   "backfill - fallback to collection string" - {
     val collection = Collection(
       "uk/business/regular-stories",
@@ -446,6 +446,32 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
           backfillContents.head.asInstanceOf[CuratedContent].headline should equal("Our weather pages are now bringing you real sunshine | Chris Elliott: Open door")
         }
       )
+    }
+  }
+
+  "backfill - invalid configuration" - {
+    val collection = Collection(
+      "uk/business/regular-stories",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty.copy(
+        backfill = Some(Backfill(
+          `type` = "invalid-backfill-configuration",
+          query = "any"
+        ))
+      )
+    )
+
+    "throws an error" in {
+      intercept[InvalidBackfillConfiguration] {
+        FAPI.backfillFromConfig(collection)
+      }
     }
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -5,7 +5,7 @@ import com.gu.facia.api.FAPI
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.models._
 import com.gu.facia.api.utils.SectionKicker
-import com.gu.facia.client.models.{CollectionConfigJson, CollectionJson, TrailMetaData, Trail}
+import com.gu.facia.client.models._
 import lib.IntegrationTestConfig
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
@@ -169,7 +169,8 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
     }
   }
 
-  "backfill" - {
+  // TODO this should be remove once deprecation ends
+  "backfill - deprecated capi query" - {
     val collection = Collection(
       "uk/business/regular-stories",
       "economy",
@@ -214,6 +215,236 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       FAPI.backfill(query, collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true)), adjustSearchQuery = adjust).asFuture.futureValue.fold(
         err => fail(s"expected backfill results, got $err", err.cause),
         backfillContents => backfillContents.head.content.tags.exists(_.id.contains("sustainable-business/series/finance")) should equal(true)
+      )
+    }
+  }
+
+  // TODO this should be remove once deprecation ends
+  "backfill - fallback to collection string" - {
+    val collection = Collection(
+      "uk/business/regular-stories",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty.copy(apiQuery = Some("business?edition=uk"))
+    )
+
+    "can get the backfill for a collection" in {
+      FAPI.backfillFromConfig(collection).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.size should be > 0
+      )
+    }
+
+    "collection metadata is resolved on backfill content" in {
+      FAPI.backfillFromConfig(collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true))).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].kicker.value shouldBe a [SectionKicker]
+      )
+    }
+
+    "item query can be adjusted" in {
+      val adjust: AdjustItemQuery = q => q.showTags("all")
+      FAPI.backfillFromConfig(collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true)), adjustItemQuery = adjust).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].content.tags.exists(_.id.contains("business")) should equal(true)
+      )
+    }
+
+    "search query can be adjusted" in {
+      val testCollection = collection.copy(collectionConfig = CollectionConfig.empty.copy(
+        apiQuery = Some("search?tag=sustainable-business/series/finance&use-date=published"),
+        showSections = true))
+      val adjust: AdjustSearchQuery = q => q.showTags("series")
+      FAPI.backfillFromConfig(testCollection, adjustSearchQuery = adjust).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].content.tags.exists(_.id.contains("sustainable-business/series/finance")) should equal(true)
+      )
+    }
+  }
+
+  "backfill - capi query in backfill object" - {
+    val collection = Collection(
+      "uk/business/regular-stories",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty.copy(backfill = Some(Backfill(
+        `type` = "capi",
+        query = "business?edition=uk")))
+    )
+
+    "can get the backfill for a collection" in {
+      FAPI.backfillFromConfig(collection).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.size should be > 0
+      )
+    }
+
+    "collection metadata is resolved on backfill content" in {
+      FAPI.backfillFromConfig(collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true))).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].kicker.value shouldBe a [SectionKicker]
+      )
+    }
+
+    "item query can be adjusted" in {
+      val adjust: AdjustItemQuery = q => q.showTags("all")
+      FAPI.backfillFromConfig(collection.copy(collectionConfig = collection.collectionConfig.copy(showSections = true)), adjustItemQuery = adjust).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].content.tags.exists(_.id.contains("business")) should equal(true)
+      )
+    }
+
+    "search query can be adjusted" in {
+      val testCollection = collection.copy(collectionConfig = CollectionConfig.empty.copy(
+        backfill = Some(Backfill(
+          `type` = "capi",
+          query = "search?tag=sustainable-business/series/finance&use-date=published")),
+        showSections = true))
+      val adjust: AdjustSearchQuery = q => q.showTags("series")
+      FAPI.backfillFromConfig(testCollection, adjustSearchQuery = adjust).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].content.tags.exists(_.id.contains("sustainable-business/series/finance")) should equal(true)
+      )
+    }
+  }
+
+  "backfill - empty" - {
+    val collection = Collection(
+      "uk/business/regular-stories",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty
+    )
+
+    "returns empty list" in {
+      FAPI.backfillFromConfig(collection).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.size should be (0)
+      )
+    }
+  }
+
+  // TODO this should be remove once deprecation ends
+  "backfill - priority" - {
+    val collection = Collection(
+      "uk/business/regular-stories",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty.copy(
+        apiQuery = Some("business?edition=uk"),
+        backfill = Some(Backfill(
+          `type` = "capi",
+          query = "search?tag=sustainable-business/series/finance&use-date=published"))
+      )
+    )
+
+    "results taken from backfill object" in {
+      val adjust: AdjustSearchQuery = q => q.showTags("series")
+      FAPI.backfillFromConfig(collection, adjust).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.head.asInstanceOf[CuratedContent].content.tags.exists(_.id.contains("sustainable-business/series/finance")) should equal(true)
+      )
+    }
+  }
+
+  "backfill - from collection" - {
+    val collection = Collection(
+      "us/business",
+      "economy",
+      None,
+      Nil,
+      None,
+      Nil,
+      Some(new DateTime(1)),
+      Some("updatedBy"),
+      Some("updatedBy@example.com"),
+      CollectionConfig.empty
+    )
+
+    "inheriting from a non existing collection" in {
+      val child = collection.copy(
+        collectionConfig = CollectionConfig.empty.copy(
+          backfill = Some(Backfill(
+            `type` = "collection",
+            query = "this-collection-id-does-not-exist")))
+      )
+
+      FAPI.backfillFromConfig(child).asFuture.futureValue.fold(
+        err => err.message should equal("Collection config not found for this-collection-id-does-not-exist"),
+        backfillContents => fail(s"expecting an empty collection to fail")
+      )
+    }
+
+    "inheriting from an empty collection" in {
+      val child = collection.copy(
+        collectionConfig = CollectionConfig.empty.copy(
+          backfill = Some(Backfill(
+            `type` = "collection",
+            query = "au/commentisfree/feature-stories")))
+      )
+
+      FAPI.backfillFromConfig(child).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.size should be (0)
+      )
+    }
+
+    "inheriting from a valid collection" in {
+      val child = collection.copy(
+        collectionConfig = CollectionConfig.empty.copy(
+          backfill = Some(Backfill(
+            `type` = "collection",
+            query = "au/money/feature-stories")))
+      )
+
+      FAPI.backfillFromConfig(child).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => {
+          backfillContents.size should be (2)
+          backfillContents(0).asInstanceOf[CuratedContent].headline should equal("Life in North Korea – the early years")
+          backfillContents(1).asInstanceOf[CuratedContent].headline should equal("Strictly Come Dancing 2015 – Custom headline")
+        }
+      )
+    }
+
+    "inheriting from a valid collection but ignore parent backfill" in {
+      val child = collection.copy(
+        collectionConfig = CollectionConfig.empty.copy(
+          backfill = Some(Backfill(
+            `type` = "collection",
+            query = "uk/business/feature-stories")))
+      )
+
+      FAPI.backfillFromConfig(child).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => {
+          backfillContents.size should be (4)
+          backfillContents.head.asInstanceOf[CuratedContent].headline should equal("Our weather pages are now bringing you real sunshine | Chris Elliott: Open door")
+        }
       )
     }
   }


### PR DESCRIPTION
Backfill is now an object with type and query. This allows future extensions to queries that are not backed by capi.

As a first step both `apiQuery` and `backfill` are available, the client tries to use `backfill` first and `apiQuery` if missing.

There's a change in a public method interface so I've created a new method with a different signature, users of the library have time to migrate.

@janua @DiegoVazquezNanini @davidfurey 