### PR TITLE
Upgrade capi client 7.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 0.64
+
+  - Upgrade capi client to v7.13
+
 #### 0.63
 
   - Upgrade capi client to v7.12

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 0.63
+
+  - Upgrade capi client to v7.12
+
 #### 0.62
 
   - Upgrade capi client to v7.11

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ easily-used types.
 
 Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "fapi-client" % "0.62"
+    libraryDependencies += "com.gu" %% "fapi-client" % "0.63"
 
 ### Using the library
 
@@ -35,7 +35,7 @@ This library provides underlying behaviour for the main Fronts API client.
 
 Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "facia-json" % "0.62"
+    libraryDependencies += "com.gu" %% "facia-json" % "0.63"
 
 ### Making calls to the API
 

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ easily-used types.
 
 Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "fapi-client" % "0.63"
+    libraryDependencies += "com.gu" %% "fapi-client" % "0.64"
 
 ### Using the library
 
@@ -35,7 +35,7 @@ This library provides underlying behaviour for the main Fronts API client.
 
 Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "facia-json" % "0.63"
+    libraryDependencies += "com.gu" %% "facia-json" % "0.64"
 
 ### Making calls to the API
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.10.37"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "7.11"
+  val contentApi = "com.gu" %% "content-api-client" % "7.12"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.4"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.10.37"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "7.12"
+  val contentApi = "com.gu" %% "content-api-client" % "7.13"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.4"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.63-SNAPSHOT"
+version in ThisBuild := "0.63"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.63"
+version in ThisBuild := "0.64-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.64-SNAPSHOT"
+version in ThisBuild := "0.64"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.64"
+version in ThisBuild := "0.65-SNAPSHOT"


### PR DESCRIPTION
Bumps the content api client dependency to 7.13.

This version has a fix for crossword separator locations.