### PR TITLE
downgrade test dependency

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -6,6 +6,6 @@ object Dependencies {
   val contentApi = "com.gu" %% "content-api-client" % "7.27"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
 }


### PR DESCRIPTION
because it conflicts with specs2

I'm sure I run the tests when bumping dependencies, but for some reason now tests fail on master.
Tracked down to some incompatible transitive dependencies...

This should work (or at least it just worked here).

<img width="479" alt="screen shot 2016-02-24 at 11 07 38" src="https://cloud.githubusercontent.com/assets/680284/13283616/9bc00816-dae6-11e5-9ff5-fdb889abe57e.png">
