### PR TITLE
add a mention about target url for running tests to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,8 @@ Returns the collection with the given ID.
 
 ## Running the tests
 
-To run the tests you need to pass a content api key to the library via your environment.
- 
+To run the tests you need to pass a content api key and facia client target url to the library via your environment.
+
     export CONTENT_API_KEY="<api-key>"
+    export FACIA_CLIENT_TARGET_URL="<target-url>"
     sbt test


### PR DESCRIPTION
Add  a note to the readme about the need to specify a facia client target url in order to run tests. 