### PR TITLE
Remove backfill errors 

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -22,7 +22,7 @@ object BackfillResolver {
     collectionConfig.backfill match {
       case Some(Backfill("capi", query: String)) => CapiBackfill(query, collectionConfig)
       case Some(Backfill("collection", query: String)) => CollectionBackfill(query)
-      case Some(Backfill(backFillType, _)) => throw new InvalidBackfillConfiguration(s"Invalid backfill type $backFillType")
+      case Some(Backfill(backFillType, _)) => EmptyBackfill
       case None => EmptyBackfill
     }
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -40,10 +40,16 @@ object BackfillResolver {
         } yield {
           backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig))
         }
-      case CollectionBackfill(parentCollectionId) =>
-        for {
+      case CollectionBackfill(parentCollectionId) => {
+       val collectionBackfillResult =
+         for {
           collection <- FAPI.getCollection(parentCollectionId)
           curatedCollection <- FAPI.liveCollectionContentWithSnaps(collection, adjustSearchQuery, adjustItemQuery)
         } yield curatedCollection
+
+        collectionBackfillResult recover {
+          err => List()
+        }
+      }
       case EmptyBackfill => Response.Right(Nil)}}
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -267,7 +267,7 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
 
       FAPI.backfillFromConfig(child.collectionConfig).asFuture.futureValue.fold(
         err => err.message should equal("Collection config not found for this-collection-id-does-not-exist"),
-        backfillContents => fail(s"expecting an empty collection to fail")
+        backfillContents => backfillContents.size should be (0)
       )
     }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -340,10 +340,11 @@ class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures wit
       )
     )
 
-    "throws an error" in {
-      intercept[InvalidBackfillConfiguration] {
-        FAPI.backfillFromConfig(collection.collectionConfig)
-      }
+    "returns an empty list" in {
+      FAPI.backfillFromConfig(collection.collectionConfig).asFuture.futureValue.fold(
+        err => fail(s"expected backfill results, got $err", err.cause),
+        backfillContents => backfillContents.size should be (0)
+      )
     }
   }
 


### PR DESCRIPTION
This pull request fixes two things: 

- If a collection has a backfill of type collection where the collectionId refers to a parent collection that does not exist, don't return an error but just return an empty list for the backfill instead

- If a backfill has a backfill type that is not recognised, don't throw an error but return an empty backfill.