### PR TITLE
Front backfill

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.models
 
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson}
+import com.gu.facia.client.models.{Metadata, Backfill, CollectionConfigJson}
 
 case class Groups(groups: List[String])
 
@@ -10,6 +10,7 @@ case class CollectionConfig(
     collectionType: String,
     href: Option[String],
     description: Option[String],
+    metadata: Option[List[Metadata]],
     groups: Option[Groups],
     uneditable: Boolean,
     showTags: Boolean,
@@ -30,6 +31,7 @@ object CollectionConfig {
     collectionType = DefaultCollectionType,
     href = None,
     description = None,
+    metadata = None,
     groups = None,
     uneditable = false,
     showTags = false,
@@ -48,6 +50,7 @@ object CollectionConfig {
       collectionJson.collectionType getOrElse DefaultCollectionType,
       collectionJson.href,
       collectionJson.description,
+      collectionJson.metadata,
       collectionJson.groups.map(Groups),
       collectionJson.uneditable.exists(identity),
       collectionJson.showTags.exists(identity),

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -3,7 +3,7 @@ package com.gu.facia.api.utils
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.facia.api.contentapi.ContentApi
 import com.gu.facia.api.contentapi.ContentApi._
-import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
+import com.gu.facia.api.models.{Collection, CollectionConfig, CuratedContent, FaciaContent}
 import com.gu.facia.api.{FAPI, Response}
 import com.gu.facia.client.ApiClient
 import com.gu.facia.client.models.{Backfill, TrailMetaData}
@@ -15,6 +15,7 @@ case class InvalidBackfillConfiguration(msg: String) extends Exception(msg)
 sealed trait BackfillResolver
 case class CapiBackfill(query: String, collectionConfig: CollectionConfig) extends BackfillResolver
 case class CollectionBackfill(parentCollectionId: String) extends BackfillResolver
+case class FrontMetadataBackfill(query: String, tagName: String) extends BackfillResolver
 case object EmptyBackfill extends BackfillResolver
 
 object BackfillResolver {
@@ -22,6 +23,13 @@ object BackfillResolver {
     collectionConfig.backfill match {
       case Some(Backfill("capi", query: String)) => CapiBackfill(query, collectionConfig)
       case Some(Backfill("collection", query: String)) => CollectionBackfill(query)
+      case Some(Backfill("front-metadata", query: String)) => {
+        val parameters = query.split('|')
+        if (parameters.length == 2)
+          FrontMetadataBackfill(parameters(0), parameters(1))
+        else
+          EmptyBackfill
+      }
       case Some(Backfill(backFillType, _)) => EmptyBackfill
       case None => EmptyBackfill
     }
@@ -46,8 +54,7 @@ object BackfillResolver {
             parentCollection <- FAPI.getCollection(parentCollectionId)
             curatedCollection <- FAPI.liveCollectionContentWithSnaps(parentCollection, adjustSearchQuery, adjustItemQuery)
             nestedBackfill <- parentCollection.collectionConfig.backfill match {
-              case Some(Backfill("capi", query)) =>
-                backfill(CapiBackfill(query, parentCollection.collectionConfig))
+              case Some(Backfill("capi", query)) => backfill(CapiBackfill(query, parentCollection.collectionConfig))
               case _ => backfill(EmptyBackfill)
             }
           } yield {
@@ -57,6 +64,19 @@ object BackfillResolver {
           collectionBackfillResult recover {
             err => List()
           }
+
+      case FrontMetadataBackfill(frontId, tagName) =>
+
+       val frontBackfillResult = FAPI.getFrontCollectionWithMetadataId(frontId, tagName).flatMap(collectionId => {
+          collectionId match {
+            case Some(id) => backfill(CollectionBackfill(id))
+            case None => backfill(EmptyBackfill)
+          }
+        })
+
+        frontBackfillResult recover {
+          err => List()
+        }
 
       case EmptyBackfill => Response.Right(Nil)}}
 }


### PR DESCRIPTION
Add a new front backfill resolver 

It backfills with the first collection in the front that has a tag passed to the resolver.