### PR TITLE
Publish a separate artifact for play-json 2.5.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ val sonatypeReleaseSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(faciaJson, faciaJson_play25, fapiClient)
+  .aggregate(faciaJson, faciaJson_play25, fapiClient, fapiClient_play25)
   .settings(publishArtifact := false)
   .settings(sonatypeReleaseSettings: _*)
 
@@ -84,7 +84,7 @@ lazy val faciaJson = project.in(file("facia-json"))
   )
   .settings(sonatypeReleaseSettings: _*)
 
-lazy val faciaJson_play25 = project.in(file("facia-json25"))
+lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     organization := "com.gu",
@@ -121,3 +121,22 @@ lazy val fapiClient = project.in(file("fapi-client"))
     publishArtifact := true
   )
   .dependsOn(faciaJson)
+
+lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
+  .settings(sonatypeReleaseSettings: _*)
+  .settings(
+    organization := "com.gu",
+    name := "fapi-client-play25",
+    sourceDirectory := baseDirectory.value / "../fapi-client/src",
+    resolvers ++= Seq(
+      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+    ),
+    libraryDependencies ++= Seq(
+      contentApi,
+      scalaTest,
+      mockito
+    ),
+    publishArtifact := true
+  )
+  .dependsOn(faciaJson_play25)

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ val sonatypeReleaseSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(faciaJson, fapiClient)
+  .aggregate(faciaJson, faciaJson_play25, fapiClient)
   .settings(publishArtifact := false)
   .settings(sonatypeReleaseSettings: _*)
 
@@ -79,6 +79,26 @@ lazy val faciaJson = project.in(file("facia-json"))
       commonsIo,
       specs2,
       playJson
+    ),
+    publishArtifact := true
+  )
+  .settings(sonatypeReleaseSettings: _*)
+
+lazy val faciaJson_play25 = project.in(file("facia-json25"))
+  .settings(sonatypeReleaseSettings: _*)
+  .settings(
+    organization := "com.gu",
+    name := "facia-json-play25",
+    sourceDirectory := baseDirectory.value / "../facia-json/src",
+    resolvers ++= Seq(
+      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+    ),
+    libraryDependencies ++= Seq(
+      awsSdk,
+      commonsIo,
+      specs2,
+      playJson25
     ),
     publishArtifact := true
   )

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   val contentApi = "com.gu" %% "content-api-client" % "8.2"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
+  val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.1"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
 }


### PR DESCRIPTION
It seems that play-json 2.4.6 doesn't play nicely (excuse the pun) when you use the lib in a Play 2.5.1 app.