### PR TITLE
Enable testing using AWS session token

### DIFF
--- a/fapi-client/src/test/scala/demo.sc
+++ b/fapi-client/src/test/scala/demo.sc
@@ -9,8 +9,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 // demo config
-val apiKey = "CONTENT_API_KEY"
-val awsProfileName = Some("AWS_PROFILE_NAME")
+val apiKey = "INSERT_CONTENT_API_KEY_HERE"
+val awsProfileName = "cmsFronts"
 
 implicit val capiClient =  new GuardianContentClient(apiKey)
 implicit val apiClient: ApiClient = {
@@ -18,9 +18,7 @@ implicit val apiClient: ApiClient = {
     val credentialsProvider = new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider(),
       new SystemPropertiesCredentialsProvider(),
-      awsProfileName map {
-        new ProfileCredentialsProvider(_)
-      } getOrElse new ProfileCredentialsProvider()
+      new ProfileCredentialsProvider(awsProfileName)
     )
     new AmazonS3Client(credentialsProvider)
   }

--- a/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
+++ b/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
@@ -1,21 +1,32 @@
 package lib
 
+import com.amazonaws.auth._
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
 
-private case class TestContentApiClient(override val apiKey: String, override val targetUrl: String) extends GuardianContentClient(apiKey)
+private case class TestContentApiClient(override val apiKey: String, override val targetUrl: String)
+  extends GuardianContentClient(apiKey)
 
 trait IntegrationTestConfig extends ExecutionContext {
-  val apiKey: String = scala.sys.env.getOrElse("CONTENT_API_KEY", "")
-  val targetUrl: Option[String] = scala.sys.env.get("FACIA_CLIENT_TARGET_URL")
 
-  implicit val capiClient: GuardianContentClient =
-    targetUrl.fold(ifEmpty = new GuardianContentClient(apiKey)){ targetUrl =>
-      new TestContentApiClient(
-        apiKey,
-        targetUrl)}
+  implicit val capiClient: GuardianContentClient = {
+    val apiKey: String = scala.sys.env.getOrElse("CONTENT_API_KEY", "")
+    val targetUrl: Option[String] = scala.sys.env.get("FACIA_CLIENT_TARGET_URL")
+    targetUrl.fold(ifEmpty = new GuardianContentClient(apiKey)) { targetUrl =>
+      new TestContentApiClient(apiKey, targetUrl)
+    }
+  }
 
-  private val amazonS3Client = new AmazonS3Client()
-  implicit val apiClient: ApiClient = ApiClient("aws-frontend-store", "DEV", AmazonSdkS3Client(amazonS3Client))
+  implicit val apiClient: ApiClient = {
+    val awsProfileName: Option[String] = scala.sys.env.get("AWS_PROFILE_NAME")
+    val credentialsProvider = new AWSCredentialsProviderChain(
+      new EnvironmentVariableCredentialsProvider(),
+      new SystemPropertiesCredentialsProvider(),
+      new ProfileCredentialsProvider(awsProfileName.getOrElse(""))
+    )
+    val amazonS3Client = new AmazonS3Client(credentialsProvider)
+    ApiClient("aws-frontend-store", "DEV", AmazonSdkS3Client(amazonS3Client))
+  }
 }

--- a/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
+++ b/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
@@ -13,7 +13,7 @@ trait IntegrationTestConfig extends ExecutionContext {
 
   private val apiKey: String = scala.sys.env.getOrElse("CONTENT_API_KEY", "")
   private val targetUrl: Option[String] = scala.sys.env.get("FACIA_CLIENT_TARGET_URL")
-  private val awsProfileName: Option[String] = scala.sys.env.get("AWS_PROFILE_NAME")
+  private val awsProfileName: String = "cmsFronts"
 
   implicit val capiClient: GuardianContentClient = {
     targetUrl.fold(ifEmpty = new GuardianContentClient(apiKey)) { targetUrl =>
@@ -25,9 +25,7 @@ trait IntegrationTestConfig extends ExecutionContext {
     val credentialsProvider = new AWSCredentialsProviderChain(
       new EnvironmentVariableCredentialsProvider(),
       new SystemPropertiesCredentialsProvider(),
-      awsProfileName map {
-        new ProfileCredentialsProvider(_)
-      } getOrElse new ProfileCredentialsProvider()
+      new ProfileCredentialsProvider(awsProfileName)
     )
     val amazonS3Client = new AmazonS3Client(credentialsProvider)
     ApiClient("aws-frontend-store", "DEV", AmazonSdkS3Client(amazonS3Client))


### PR DESCRIPTION
This adds a named AWS profile to the credentials provider chain in the integration tests and demo worksheet.