### PR TITLE
Add UnknownMetadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
+#### 1.6.2
+
+  - Add `UnknownMetadata` to `Metadata` ADT to handle cases of new future types in old libraries
+  - Add logging via `logback` and `scala-logging`
+
 #### 1.6.1
 
   - Expose branding metadata in CollectionConfig.
-  
+
 #### 1.6.0
 
   - Support the marking of collections to indicate that they should have commercial branding.

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val faciaJson = project.in(file("facia-json"))
       commonsIo,
       specs2,
       playJson,
+      logback,
       scalaLogging
     ),
     publishArtifact := true
@@ -100,6 +101,7 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
       commonsIo,
       specs2,
       playJson25,
+      logback,
       scalaLogging
     ),
     publishArtifact := true

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,6 @@ lazy val faciaJson = project.in(file("facia-json"))
       commonsIo,
       specs2,
       playJson,
-      logback,
       scalaLogging
     ),
     publishArtifact := true
@@ -101,7 +100,6 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
       commonsIo,
       specs2,
       playJson25,
-      logback,
       scalaLogging
     ),
     publishArtifact := true

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,8 @@ lazy val faciaJson = project.in(file("facia-json"))
       awsSdk,
       commonsIo,
       specs2,
-      playJson
+      playJson,
+      scalaLogging
     ),
     publishArtifact := true
   )
@@ -98,7 +99,8 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
       awsSdk,
       commonsIo,
       specs2,
-      playJson25
+      playJson25,
+      scalaLogging
     ),
     publishArtifact := true
   )

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -20,6 +20,8 @@ case object Breaking extends Metadata
 
 case object Branded extends Metadata
 
+case object UnknownMetadata extends Metadata
+
 
 object Metadata {
 
@@ -32,7 +34,8 @@ object Metadata {
       (json \ "type").transform[JsString](Reads.JsStringReads) match {
         case JsSuccess(JsString(string), _) => tags.get(string) match {
           case Some(result) => JsSuccess(result)
-          case _ => JsError("Could not convert CollectionTag: string is of unknown type")
+          case None =>
+            JsSuccess(UnknownMetadata)
         }
         case _ => JsError("Could not convert CollectionTag: type is not a string")
       }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -1,5 +1,6 @@
 package com.gu.facia.client.models
 
+import com.sun.corba.se.spi.legacy.interceptor.UnknownType
 import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json._
 
@@ -48,6 +49,7 @@ object Metadata extends StrictLogging {
       case Special => JsObject(Seq("type" -> JsString("Special")))
       case Breaking => JsObject(Seq("type" -> JsString("Breaking")))
       case Branded => JsObject(Seq("type" -> JsString("Branded")))
+      case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }
 }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -1,5 +1,6 @@
 package com.gu.facia.client.models
 
+import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json._
 
 object Backfill {
@@ -23,7 +24,7 @@ case object Branded extends Metadata
 case object UnknownMetadata extends Metadata
 
 
-object Metadata {
+object Metadata extends StrictLogging {
 
   val tags: Map[String, Metadata] = Map(
     ("Canonical", Canonical), ("Special", Special), ("Breaking", Breaking), ("Branded", Branded)
@@ -35,6 +36,7 @@ object Metadata {
         case JsSuccess(JsString(string), _) => tags.get(string) match {
           case Some(result) => JsSuccess(result)
           case None =>
+            logger.warn("Could not convert CollectionTag: string is of unknown type")
             JsSuccess(UnknownMetadata)
         }
         case _ => JsError("Could not convert CollectionTag: type is not a string")

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -37,7 +37,7 @@ object Metadata extends StrictLogging {
         case JsSuccess(JsString(string), _) => tags.get(string) match {
           case Some(result) => JsSuccess(result)
           case None =>
-            logger.warn("Could not convert CollectionTag: string is of unknown type")
+            logger.warn(s"Could not convert CollectionTag: $string is of unknown type")
             JsSuccess(UnknownMetadata)
         }
         case _ => JsError("Could not convert CollectionTag: type is not a string")

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,5 +9,6 @@ object Dependencies {
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.1"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
+  val logback = "ch.qos.logback" %  "logback-classic" % "1.1.7"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
 }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,4 +9,5 @@ object Dependencies {
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.1"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
+  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
 }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,6 +9,5 @@ object Dependencies {
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.1"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
-  val logback = "ch.qos.logback" %  "logback-classic" % "1.1.7"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
 }


### PR DESCRIPTION
This adds `UnknownMetadata` to the `Metadata` ADT.

This means when we add new tags to `Metadata`, we don't break old clients. Clients will have to correctly handle `UnknownMetadata` after this change.

This **also** adds logging via `logback` and `scala-logging` to log out the case of falling back to `UnknownMetadata`; we will also use logging in other parts of the library also.

@piuccio @kelvin-chappell 