### PR TITLE
Add width and height to image replace

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -9,7 +9,7 @@ object SlideshowAsset {
   implicit val slideshowAssetFormat = Json.format[SlideshowAsset]
 }
 
-case class ImageSourceAsset(src: String, origin: String)
+case class ImageSourceAsset(src: String, origin: String, width: String, height: String)
 object ImageSourceAsset {
   implicit val imageSourceAssetFormat = Json.format[ImageSourceAsset]
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -8,7 +8,6 @@ sealed trait FaciaImage
 case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
 case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage
 case class ImageSlideshow(assets: List[Replace]) extends FaciaImage
-case class ImageReplace(src: String) extends FaciaImage
 
 object FaciaImage {
 
@@ -42,7 +41,7 @@ object FaciaImage {
   def imageReplace(trailMeta: MetaDataCommonFields, resolvedMetaData: ResolvedMetaData): Option[FaciaImage] = {
     trailMeta.imageSource match {
       case Some(imageSource) =>
-        Some(ImageReplace(imageSource.src))
+        Some(Replace(imageSource.src, imageSource.width, imageSource.height))
       case None =>
         for {
           src <- trailMeta.imageSrc

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
@@ -21,8 +21,10 @@ class FaciaImageReplaceTest extends FlatSpec with Matchers {
       "imageSrcHeight" -> JsString("theImageSrcHeight")))
 
   val imageSourceAsset = JsObject(List(
-    "src" -> JsString("theImageSrc"),
-    "origin" -> JsString("theImageSrcOrigin")
+    "src" -> JsString("theImageSrcAsset"),
+    "origin" -> JsString("theImageSrcOrigin"),
+    "width" -> JsString("500"),
+    "height" -> JsString("300")
   ))
 
   val trailMetaDataWithImageSource =
@@ -47,6 +49,6 @@ class FaciaImageReplaceTest extends FlatSpec with Matchers {
 
   it should "give back an ImageSource when imageSource present in metadata" in {
     val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSource)
-    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSource, resolvedMetaData) should be (Some(ImageReplace("theImageSrc")))
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSource, resolvedMetaData) should be (Some(Replace("theImageSrcAsset", "500", "300")))
   }
 }


### PR DESCRIPTION
Some time ago we added a new image replace object, including only src and origin. Turns out that iphone requires width and height to compute the aspect ratio

This change adds width and height to facia-json (the low level layer) and remove ImageReplace from the upper level.
Case class Replace is capable of representing all the information needed by applications.

@janua  @Reettaphant 