### PR TITLE
construct the short code more robustly

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -136,7 +136,7 @@ object FaciaContentUtils {
   )
   def maybeShortUrl(fc: FaciaContent) = fieldsGet(fc)(_.flatMap(_.shortUrl))
   def shortUrl(fc: FaciaContent): String = maybeShortUrl(fc).getOrElse("")
-  def shortUrlPath(fc: FaciaContent) = maybeShortUrl(fc).map(_.replace("http://gu.com", ""))
+  def shortUrlPath(fc: FaciaContent) = maybeShortUrl(fc).map(_.replaceFirst("[a-z]+://gu.com", ""))
   def discussionId(fc: FaciaContent) = shortUrlPath(fc)
 
   def isBoosted(fc: FaciaContent): Boolean = fold(fc)(

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -136,7 +136,7 @@ object FaciaContentUtils {
   )
   def maybeShortUrl(fc: FaciaContent) = fieldsGet(fc)(_.flatMap(_.shortUrl))
   def shortUrl(fc: FaciaContent): String = maybeShortUrl(fc).getOrElse("")
-  def shortUrlPath(fc: FaciaContent) = maybeShortUrl(fc).map(_.replaceFirst("[a-z]+://gu.com", ""))
+  def shortUrlPath(fc: FaciaContent) = maybeShortUrl(fc).map(_.replaceFirst("^[a-zA-Z]+://gu.com", ""))
   def discussionId(fc: FaciaContent) = shortUrlPath(fc)
 
   def isBoosted(fc: FaciaContent): Boolean = fold(fc)(


### PR DESCRIPTION
we need the short code for discussion comment requests.  CAPI doesn't supply that (at present) so we try to work it out by stripping http://gu.com from the front of the short url.  Now that they're https it doesn't work, so comment counts are not working in prod due to the data-discussion-id still having the https part.

Perhaps in reality discussion should be happy with long urls? or CAPI should supply the discussion key? @guardian/discussion @guardian/content-platforms 

Anyway for now I've just made the regex more generous.  But fabio said he's noticed it hard coded in a few places.

Once I've merged this one I'll ship a new version of fapi-client and ship a frontend PR to use it.

@piuccio @janua 