### PR TITLE
Bump CAPI client and add better logging in ContentApi

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+#### 2.0.4
+
+  - Upgrade CAPI client to 10.5
+  - Add better logging in ContentApi object
+  - Add type annotations in Backfill
+
 #### 2.0.0
 
   - Revert `ImageReplace` changes introduced to `FaciaImage`.

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -1,6 +1,8 @@
 package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.ContentApiClientLogic
+import com.gu.contentapi.client.model.v1.{ItemResponse, SearchResponse}
+import com.gu.contentapi.client.model.{ItemQuery, SearchQuery}
 import com.gu.facia.api.contentapi.ContentApi
 import com.gu.facia.api.contentapi.ContentApi._
 import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
@@ -31,10 +33,10 @@ object BackfillResolver {
               (implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     resolver match {
       case CapiBackfill(query, collectionConfig) =>
-        val capiQuery = ContentApi.buildBackfillQuery(query)
+        val capiQuery: Either[ItemQuery, SearchQuery] = ContentApi.buildBackfillQuery(query)
           .right.map(adjustSearchQuery)
           .left.map(adjustItemQuery)
-        val backfillResponse = ContentApi.getBackfillResponse(capiClient, capiQuery)
+        val backfillResponse: Either[Response[ItemResponse], Response[SearchResponse]] = ContentApi.getBackfillResponse(capiClient, capiQuery)
         for {
           backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
         } yield {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.7"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "10.1"
+  val contentApi = "com.gu" %% "content-api-client" % "10.5"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"


### PR DESCRIPTION
This bumps the CAPI client to `10.5`.

This also adds better logging into the `ContentApi` object; warning when a response may be attempted to be construed as an `ItemResponse` when it is actually a  `SearchResponse`.

I've also added a few lose types.

@gtrufitt @LATaylor-guardian 
