### PR TITLE
set showMainVideo to for Video Atoms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+##### 2.0.6
+
+  - set `showMainVideo` to `false` for Video Atoms
+
 ##### 2.0.5
 
   - Update capi client to v10.17

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -1,8 +1,8 @@
 package com.gu.facia.api.utils
 
-import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.client.models.MetaDataCommonFields
 import play.api.libs.json.{Format, Json}
+import com.gu.contentapi.client.model.v1.{Content, Element, ElementType}
 
 
 object ResolvedMetaData {
@@ -20,6 +20,20 @@ object ResolvedMetaData {
 
   def isVideoForContent(content: Content): Boolean =
     content.tags.exists(_.id == Video)
+
+  def isVideoAtom(content: Content): Boolean = {
+    isVideoForContent(content) &&
+      content.elements.flatMap(
+        _.find { element =>
+          element.`type` == ElementType.Contentatom && element.relation == "main"
+        }).isDefined
+  }
+
+  def getShowMainVideo(trailShowVideo: Option[Boolean], default: Boolean, content: Content): Boolean = {
+    if (isVideoAtom(content)) false else trailShowVideo.getOrElse(default)
+  }
+
+
 
   val Default = ResolvedMetaData(
     isBreaking = false,
@@ -76,7 +90,7 @@ object ResolvedMetaData {
       showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
       showKickerCustom = trailMeta.showKickerCustom.getOrElse(metaDataFromContent.showKickerCustom),
       showBoostedHeadline = trailMeta.showBoostedHeadline.getOrElse(metaDataFromContent.showBoostedHeadline),
-      showMainVideo = trailMeta.showMainVideo.getOrElse(metaDataFromContent.showMainVideo),
+      showMainVideo = getShowMainVideo(trailShowVideo = trailMeta.showMainVideo, default = metaDataFromContent.showMainVideo, content = content),
       showLivePlayable = trailMeta.showLivePlayable.getOrElse(metaDataFromContent.showLivePlayable),
       showKickerTag = trailMeta.showKickerTag.getOrElse(metaDataFromContent.showKickerTag),
       showByline = trailMeta.showByline.getOrElse(metaDataFromContent.showByline),

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -23,17 +23,12 @@ object ResolvedMetaData {
 
   def isVideoAtom(content: Content): Boolean = {
     isVideoForContent(content) &&
-      content.elements.exists(
-        _.exists { element =>
-          element.`type` == ElementType.Contentatom && element.relation == "main"
+      content.blocks.exists(
+        _.main.exists { block =>
+          block.elements.exists {element => element.`type` == ElementType.Contentatom }
         }
       )
   }
-
-  def getShowMainVideo(trailShowVideo: Option[Boolean], default: Boolean, content: Content): Boolean = {
-    if (isVideoAtom(content)) false else trailShowVideo.getOrElse(default)
-  }
-
 
 
   val Default = ResolvedMetaData(
@@ -70,15 +65,17 @@ object ResolvedMetaData {
       imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity)
   )
 
-  def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
-    cardStyle match {
-      case com.gu.facia.api.utils.Comment => Default.copy(
-        showByline = true,
-        showQuotedHeadline = true,
-        imageCutoutReplace = true)
-      case _ if isCartoonForContent(content) => Default.copy(showByline = true)
-      case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
-      case _ => Default
+  def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData = {
+      cardStyle match {
+        case com.gu.facia.api.utils.Comment => Default.copy(
+          showByline = true,
+          showQuotedHeadline = true,
+          imageCutoutReplace = true)
+        case _ if isCartoonForContent(content) => Default.copy(showByline = true)
+        case _ if isVideoAtom(content) => Default.copy(showMainVideo = false)
+        case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
+        case _ => Default
+      }
     }
 
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields, cardStyle: CardStyle): ResolvedMetaData = {
@@ -91,7 +88,7 @@ object ResolvedMetaData {
       showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
       showKickerCustom = trailMeta.showKickerCustom.getOrElse(metaDataFromContent.showKickerCustom),
       showBoostedHeadline = trailMeta.showBoostedHeadline.getOrElse(metaDataFromContent.showBoostedHeadline),
-      showMainVideo = getShowMainVideo(trailShowVideo = trailMeta.showMainVideo, default = metaDataFromContent.showMainVideo, content = content),
+      showMainVideo =  trailMeta.showMainVideo.getOrElse(metaDataFromContent.showMainVideo),
       showLivePlayable = trailMeta.showLivePlayable.getOrElse(metaDataFromContent.showLivePlayable),
       showKickerTag = trailMeta.showKickerTag.getOrElse(metaDataFromContent.showKickerTag),
       showByline = trailMeta.showByline.getOrElse(metaDataFromContent.showByline),

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -23,10 +23,11 @@ object ResolvedMetaData {
 
   def isVideoAtom(content: Content): Boolean = {
     isVideoForContent(content) &&
-      content.elements.flatMap(
-        _.find { element =>
+      content.elements.exists(
+        _.exists { element =>
           element.`type` == ElementType.Contentatom && element.relation == "main"
-        }).isDefined
+        }
+      )
   }
 
   def getShowMainVideo(trailShowVideo: Option[Boolean], default: Boolean, content: Content): Boolean = {

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -22,14 +22,13 @@ object ResolvedMetaData {
     content.tags.exists(_.id == Video)
 
   def isVideoAtom(content: Content): Boolean = {
-    val maybeAtom = for {
+    val atomExists: Option[Boolean] = for {
       videoContentType <- content.tags.find(_.id == Video)
       blocks <- content.blocks
       main <- blocks.main
-      atomElement <- main.elements.find(e => e.`type` == ElementType.Contentatom)
-    } yield atomElement
+    } yield main.elements.exists(e => e.`type` == ElementType.Contentatom)
 
-  maybeAtom.isDefined
+    atomExists.getOrElse(false)
   }
 
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -22,12 +22,14 @@ object ResolvedMetaData {
     content.tags.exists(_.id == Video)
 
   def isVideoAtom(content: Content): Boolean = {
-    isVideoForContent(content) &&
-      content.blocks.exists(
-        _.main.exists { block =>
-          block.elements.exists {element => element.`type` == ElementType.Contentatom }
-        }
-      )
+    val maybeAtom = for {
+      videoContentType <- content.tags.find(_.id == Video)
+      blocks <- content.blocks
+      main <- blocks.main
+      atomElement <- main.elements.find(e => e.`type` == ElementType.Contentatom)
+    } yield atomElement
+
+  maybeAtom.isDefined
   }
 
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -67,7 +67,7 @@ object ResolvedMetaData {
       imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity)
   )
 
-  def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData = {
+  def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
       cardStyle match {
         case com.gu.facia.api.utils.Comment => Default.copy(
           showByline = true,
@@ -78,7 +78,6 @@ object ResolvedMetaData {
         case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
         case _ => Default
       }
-    }
 
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields, cardStyle: CardStyle): ResolvedMetaData = {
     val metaDataFromContent = fromContent(content, cardStyle)

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -21,7 +21,16 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
   val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
   val contentWithComment = contentWithTags(tagWithId("tone/comment"))
   val contentWithVideo = contentWithTags(tagWithId("type/video"))
-  val contentWithAtom: Content = contentWithVideo.copy(blocks = Some(Blocks(main = Some(Block(id = "foo", bodyHtml = "foo", bodyTextSummary = "foo", title = None, attributes = BlockAttributes(), published = true, elements = Seq(BlockElement(`type` = ElementType.Contentatom)))))))
+  val atomBlock = Some(Block(
+    id = "foo",
+    bodyHtml = "foo",
+    bodyTextSummary = "foo",
+    attributes = BlockAttributes(),
+    published = true,
+    elements = Seq(BlockElement(`type` = ElementType.Contentatom))))
+
+  val contentWithAtom: Content = contentWithVideo.copy(blocks = Some(Blocks(atomBlock)))
+
   val emptyTrailMetaData = TrailMetaData(Map.empty)
   val trailMetaDataWithFieldsSetTrue = TrailMetaData(
     Map("showByline" -> JsBoolean(true),

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -8,6 +8,16 @@ import lib.TestContent
 
 class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
+  def tagWithId(id: String) = Tag(
+    id = id,
+    `type` = TagType.Keyword,
+    webTitle = "",
+    webUrl = "",
+    apiUrl = "")
+
+
+  def contentWithTags(tags: Tag*): Content = baseContent.copy(tags = tags.toList)
+
   val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
   val contentWithComment = contentWithTags(tagWithId("tone/comment"))
   val contentWithVideo = contentWithTags(tagWithId("type/video"))
@@ -24,26 +34,17 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
       "showQuotedHeadline" -> JsBoolean(false),
       "imageCutoutReplace" -> JsBoolean(false)))
 
-  def tagWithId(id: String) = Tag(
-    id = id,
-    `type` = TagType.Keyword,
-    webTitle = "",
-    webUrl = "",
-    apiUrl = "")
-
-  def contentWithTags(tags: Tag*): Content = baseContent.copy(tags = tags.toList)
-
   "Resolving Metadata using fromContent" - {
 
     "Content with type cartoon should showByline" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithCartoon, DefaultCardstyle)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showByline (true))
     }
 
     "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithComment, Comment)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true))
@@ -51,14 +52,14 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Content with type video should showMainVideo" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo, DefaultCardstyle)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showMainVideo (true))
     }
 
     "Content with silly type should all false" in {
       val contentWithVideo = contentWithTags(tagWithId("sillyid"))
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo, DefaultCardstyle)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false),
@@ -77,7 +78,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Resolve all to false for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(emptyTrailMetaData)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false),
@@ -93,7 +94,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Resolve all to true for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMetaDataWithFieldsSetTrue)
-      resolvedMetaData should have(
+      resolvedMetaData should have (
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true),
@@ -113,13 +114,13 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for cartoon when trailMetaData is not set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, emptyTrailMetaData, DefaultCardstyle)
-      resolvedCartoon should have(
+      resolvedCartoon should have (
         'showByline (true))
     }
 
     "should resolve correct for comment when trailMetaData is not set" in {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData, Comment)
-      resolvedComment should have(
+      resolvedComment should have (
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true))
@@ -127,7 +128,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for video when trailMetaData is not set" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, emptyTrailMetaData, DefaultCardstyle)
-      resolvedVideo should have(
+      resolvedVideo should have (
         'showMainVideo (true))
     }
 
@@ -139,13 +140,13 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for cartoon when trailMetaData IS set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedCartoon should have(
+      resolvedCartoon should have (
         'showByline (false))
     }
 
     "should resolve correct for comment when trailMetaData IS set" in {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedComment should have(
+      resolvedComment should have (
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false))
@@ -153,7 +154,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for video when trailMetaData IS set" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedVideo should have(
+      resolvedVideo should have (
         'showMainVideo (false))
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -8,6 +8,22 @@ import lib.TestContent
 
 class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
+  val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
+  val contentWithComment = contentWithTags(tagWithId("tone/comment"))
+  val contentWithVideo = contentWithTags(tagWithId("type/video"))
+  val contentWithAtom: Content = contentWithVideo.copy(blocks = Some(Blocks(main = Some(Block(id = "foo", bodyHtml = "foo", bodyTextSummary = "foo", title = None, attributes = BlockAttributes(), published = true, elements = Seq(BlockElement(`type` = ElementType.Contentatom)))))))
+  val emptyTrailMetaData = TrailMetaData(Map.empty)
+  val trailMetaDataWithFieldsSetTrue = TrailMetaData(
+    Map("showByline" -> JsBoolean(true),
+      "showMainVideo" -> JsBoolean(true),
+      "showQuotedHeadline" -> JsBoolean(true),
+      "imageCutoutReplace" -> JsBoolean(true)))
+  val trailMetaDataWithFieldsSetFalse = TrailMetaData(
+    Map("showByline" -> JsBoolean(false),
+      "showMainVideo" -> JsBoolean(false),
+      "showQuotedHeadline" -> JsBoolean(false),
+      "imageCutoutReplace" -> JsBoolean(false)))
+
   def tagWithId(id: String) = Tag(
     id = id,
     `type` = TagType.Keyword,
@@ -15,39 +31,19 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
     webUrl = "",
     apiUrl = "")
 
-
   def contentWithTags(tags: Tag*): Content = baseContent.copy(tags = tags.toList)
-
-  val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
-  val contentWithComment = contentWithTags(tagWithId("tone/comment"))
-  val contentWithVideo = contentWithTags(tagWithId("type/video"))
-  def contentWithAtom: Content = contentWithVideo.copy(elements = Some (Seq(Element(id = "foo", relation = "main",`type` = ElementType.Contentatom))))
-
-  val emptyTrailMetaData = TrailMetaData(Map.empty)
-
-  val trailMetaDataWithFieldsSetTrue = TrailMetaData(
-    Map("showByline" -> JsBoolean(true),
-      "showMainVideo" -> JsBoolean(true),
-      "showQuotedHeadline" -> JsBoolean(true),
-      "imageCutoutReplace" -> JsBoolean(true)))
-
-  val trailMetaDataWithFieldsSetFalse = TrailMetaData(
-    Map("showByline" -> JsBoolean(false),
-      "showMainVideo" -> JsBoolean(false),
-      "showQuotedHeadline" -> JsBoolean(false),
-      "imageCutoutReplace" -> JsBoolean(false)))
 
   "Resolving Metadata using fromContent" - {
 
     "Content with type cartoon should showByline" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithCartoon, DefaultCardstyle)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showByline (true))
     }
 
     "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithComment, Comment)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true))
@@ -55,14 +51,14 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Content with type video should showMainVideo" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo, DefaultCardstyle)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showMainVideo (true))
     }
 
     "Content with silly type should all false" in {
       val contentWithVideo = contentWithTags(tagWithId("sillyid"))
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithVideo, DefaultCardstyle)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false),
@@ -81,7 +77,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Resolve all to false for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(emptyTrailMetaData)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false),
@@ -97,7 +93,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "Resolve all to true for empty TrailMetaData" in {
       val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMetaDataWithFieldsSetTrue)
-      resolvedMetaData should have (
+      resolvedMetaData should have(
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true),
@@ -117,13 +113,13 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for cartoon when trailMetaData is not set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, emptyTrailMetaData, DefaultCardstyle)
-      resolvedCartoon should have (
+      resolvedCartoon should have(
         'showByline (true))
     }
 
     "should resolve correct for comment when trailMetaData is not set" in {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData, Comment)
-      resolvedComment should have (
+      resolvedComment should have(
         'showByline (true),
         'showQuotedHeadline (true),
         'imageCutoutReplace (true))
@@ -131,25 +127,25 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for video when trailMetaData is not set" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, emptyTrailMetaData, DefaultCardstyle)
-      resolvedVideo should have (
+      resolvedVideo should have(
         'showMainVideo (true))
     }
 
     "should resolve correct for video with Atom" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithAtom, emptyTrailMetaData, DefaultCardstyle)
-      resolvedVideo should have (
+      resolvedVideo should have(
         'showMainVideo (false))
     }
 
     "should resolve correct for cartoon when trailMetaData IS set" in {
       val resolvedCartoon = ResolvedMetaData.fromContentAndTrailMetaData(contentWithCartoon, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedCartoon should have (
+      resolvedCartoon should have(
         'showByline (false))
     }
 
     "should resolve correct for comment when trailMetaData IS set" in {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedComment should have (
+      resolvedComment should have(
         'showByline (false),
         'showQuotedHeadline (false),
         'imageCutoutReplace (false))
@@ -157,7 +153,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
 
     "should resolve correct for video when trailMetaData IS set" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, trailMetaDataWithFieldsSetFalse, DefaultCardstyle)
-      resolvedVideo should have (
+      resolvedVideo should have(
         'showMainVideo (false))
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.utils
 
-import com.gu.contentapi.client.model.v1.{TagType, ContentType, Content, Tag}
+import com.gu.contentapi.client.model.v1._
 import com.gu.facia.client.models.TrailMetaData
 import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.JsBoolean
@@ -21,6 +21,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
   val contentWithCartoon = contentWithTags(tagWithId("type/cartoon"))
   val contentWithComment = contentWithTags(tagWithId("tone/comment"))
   val contentWithVideo = contentWithTags(tagWithId("type/video"))
+  def contentWithAtom: Content = contentWithVideo.copy(elements = Some (Seq(Element(id = "foo", relation = "main",`type` = ElementType.Contentatom))))
 
   val emptyTrailMetaData = TrailMetaData(Map.empty)
 
@@ -132,6 +133,12 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithVideo, emptyTrailMetaData, DefaultCardstyle)
       resolvedVideo should have (
         'showMainVideo (true))
+    }
+
+    "should resolve correct for video with Atom" in {
+      val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithAtom, emptyTrailMetaData, DefaultCardstyle)
+      resolvedVideo should have (
+        'showMainVideo (false))
     }
 
     "should resolve correct for cartoon when trailMetaData IS set" in {


### PR DESCRIPTION
If video page contains atom main media set `showMainVideo` to false, else use previous behaviour.

*Perhaps not the most elegant way but we found it achieves the intended business logic*

CC @janua @Reettaphant 