### PR TITLE
default show main video to true for video atom pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+##### 2.0.7
+  - set `showMainVideo` to `true` for Video Atoms
+
 ##### 2.0.6
 
   - set `showMainVideo` to `false` for Video Atoms


### PR DESCRIPTION
defaults show main video to true for video atom pages. This is in preparation for adding playable support to frontend. 

This is restricted to YouTube atoms, so it will still be false for other types of media atoms.

CC @Reettaphant @janua 