### PR TITLE
default to true for all video content type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+##### 2.0.7
+
+  - set `showMainVideo` default to `true` for all video content type
+
 ##### 2.0.6
 
   - set `showMainVideo` to `false` for Video Atoms

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -21,17 +21,6 @@ object ResolvedMetaData {
   def isVideoForContent(content: Content): Boolean =
     content.tags.exists(_.id == Video)
 
-  def isVideoAtom(content: Content): Boolean = {
-    val atomExists: Option[Boolean] = for {
-      videoContentType <- content.tags.find(_.id == Video)
-      blocks <- content.blocks
-      main <- blocks.main
-    } yield main.elements.exists(e => e.`type` == ElementType.Contentatom)
-
-    atomExists.getOrElse(false)
-  }
-
-
   val Default = ResolvedMetaData(
     isBreaking = false,
     isBoosted = false,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -73,7 +73,6 @@ object ResolvedMetaData {
           showQuotedHeadline = true,
           imageCutoutReplace = true)
         case _ if isCartoonForContent(content) => Default.copy(showByline = true)
-        case _ if isVideoAtom(content) => Default.copy(showMainVideo = false)
         case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
         case _ => Default
       }

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -144,7 +144,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
     "should resolve correct for video with Atom" in {
       val resolvedVideo = ResolvedMetaData.fromContentAndTrailMetaData(contentWithAtom, emptyTrailMetaData, DefaultCardstyle)
       resolvedVideo should have(
-        'showMainVideo (false))
+        'showMainVideo (true))
     }
 
     "should resolve correct for cartoon when trailMetaData IS set" in {


### PR DESCRIPTION
Default `showMainVideo` to true for all videos, this is in preparation for adding support for playable media atoms in facia-tool and frontend.

CC @Reettaphant @janua 