### PR TITLE
Add a backfillLimit to the collection config model.

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -122,7 +122,7 @@ case class CollectionConfigJson(
   excludeFromRss: Option[Boolean],
   showTimestamps: Option[Boolean],
   hideShowMore: Option[Boolean],
-  displayHints: Option[DisplayHints] = None
+  displayHints: Option[DisplayHints]
   ) {
   val collectionType = `type`
 }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -54,6 +54,11 @@ object Metadata extends StrictLogging {
   }
 }
 
+object DisplayHints {
+  implicit val jsonFormat = Json.format[DisplayHints]
+}
+
+case class DisplayHints(maxItemsToDisplay: Option[Int])
 
 object CollectionConfigJson {
   implicit val jsonFormat = Json.format[CollectionConfigJson]
@@ -77,7 +82,7 @@ object CollectionConfigJson {
     excludeFromRss: Option[Boolean] = None,
     showTimestamps: Option[Boolean] = None,
     hideShowMore: Option[Boolean] = None,
-    backfillLimit: Option[Int] = None
+    displayHints: Option[DisplayHints] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -96,7 +101,7 @@ object CollectionConfigJson {
     excludeFromRss,
     showTimestamps,
     hideShowMore,
-    backfillLimit
+    displayHints
   )
 }
 
@@ -117,7 +122,7 @@ case class CollectionConfigJson(
   excludeFromRss: Option[Boolean],
   showTimestamps: Option[Boolean],
   hideShowMore: Option[Boolean],
-  backfillLimit: Option[Int]
+  displayHints: Option[DisplayHints] = None
   ) {
   val collectionType = `type`
 }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -76,7 +76,8 @@ object CollectionConfigJson {
     showLatestUpdate: Option[Boolean] = None,
     excludeFromRss: Option[Boolean] = None,
     showTimestamps: Option[Boolean] = None,
-    hideShowMore: Option[Boolean] = None
+    hideShowMore: Option[Boolean] = None,
+    backfillLimit: Option[Int] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -94,7 +95,8 @@ object CollectionConfigJson {
     showLatestUpdate,
     excludeFromRss,
     showTimestamps,
-    hideShowMore
+    hideShowMore,
+    backfillLimit
   )
 }
 
@@ -114,7 +116,8 @@ case class CollectionConfigJson(
   showLatestUpdate: Option[Boolean],
   excludeFromRss: Option[Boolean],
   showTimestamps: Option[Boolean],
-  hideShowMore: Option[Boolean]
+  hideShowMore: Option[Boolean],
+  backfillLimit: Option[Int]
   ) {
   val collectionType = `type`
 }


### PR DESCRIPTION
Currently, emails fronts created in the fronts tool can have containers with backfill but then in frontend we restrict the number of items in a backfill-ed container to 6. 

It is going to be required to be able to specify the number of items in the containers. There will be a related PR in the fronts tool to specify this value, but for this to be possible, inevitably the config model for collections needs to have an optional backfillLimit field. 