### PR TITLE
Label paid content accordingly

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -55,6 +55,8 @@ object CardStyle {
       || hashedTagIds.contains("7037b49de72275eb72b73a111da31849")      // australia-news/series/healthcare-in-detention
       || hashedTagIds.contains("efb4e63b9a3a926314724b45764a5a5a") ) {  // society/series/this-is-the-nhs
       SpecialReport
+    } else if (content.isPaid) {
+      Paid
     } else if (content.isLiveBlog) {
       if (content.isLive) {
         LiveBlog
@@ -75,8 +77,6 @@ object CardStyle {
       Letters
     } else if (content.isFeature) {
       Feature
-    } else if (content.isPaid) {
-      Paid
     } else {
       DefaultCardstyle
     }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -20,6 +20,7 @@ object CardStyle {
   val letters = "letters"
   val external = "external"
   val news = "news"
+  val paid = "paid"
 
   private val salt = "a-public-salt3W#ywHav!p+?r+W2$E6="
   private val digest = MessageDigest.getInstance("MD5")
@@ -74,6 +75,8 @@ object CardStyle {
       Letters
     } else if (content.isFeature) {
       Feature
+    } else if (content.isPaid) {
+      Paid
     } else {
       DefaultCardstyle
     }
@@ -128,6 +131,10 @@ case object Letters extends CardStyle {
 
 case object ExternalLink extends CardStyle {
   val toneString = CardStyle.external
+}
+
+case object Paid extends CardStyle {
+  val toneString = CardStyle.paid
 }
 
 case object DefaultCardstyle extends CardStyle {

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
@@ -15,6 +15,7 @@ object ContentApiUtils {
     lazy val blogs: Seq[Tag] = tagsOfType(TagType.Blog)
     lazy val tones: Seq[Tag] = tagsOfType(TagType.Tone)
     lazy val types: Seq[Tag] = tagsOfType(TagType.Type)
+    lazy val paid: Seq[Tag] = tagsOfType(TagType.PaidContent)
 
     lazy val isLiveBlog: Boolean = tones.exists(t => Tags.liveMappings.contains(t.id))
     lazy val isComment = tones.exists(t => Tags.commentMappings.contains(t.id))
@@ -28,6 +29,7 @@ object ContentApiUtils {
     lazy val isCartoon = types.exists(_.id == Tags.Cartoon)
     lazy val isLetters = tones.exists(_.id == Tags.Letters)
     lazy val isCrossword = types.exists(_.id == Tags.Crossword)
+    lazy val isPaid = paid.nonEmpty
 
     lazy val isArticle: Boolean = content.tags.exists { _.id == Tags.Article }
     lazy val isSudoku: Boolean = content.tags.exists { _.id == Tags.Sudoku } || content.tags.exists(t => t.id == "lifeandstyle/series/sudoku")

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -202,6 +202,7 @@ object FaciaContentUtils {
   def blogs(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("blog")
   def tones(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("tone")
   def types(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("type")
+  def paid(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("paid-content")
 
   def contributors(fc: FaciaContent): Seq[Tag] = maybeContent(fc).map(_.contributors).getOrElse(Nil)
   def isContributorPage(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.contributors.nonEmpty)
@@ -220,8 +221,7 @@ object FaciaContentUtils {
   def isReview(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.isReview)
   def isLetters(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.isLetters)
   def isFeature(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.isFeature)
-
-
+  def isPaid(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.isPaid)
 
   def supporting(fc: FaciaContent): List[FaciaContent] = fold(fc)(
     curatedContent => curatedContent.supportingContent,


### PR DESCRIPTION
Paid content in facia tool appears as 'news' and it needs to be labelled to indicate that this is 'paid' content instead.

This has been tested with the `facia-tool`.