### PR TITLE
Update hash for new special report tag

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -44,13 +44,14 @@ object CardStyle {
 
     if (trailMetaData.snapType.contains("link") && href.exists(ExternalLinks.external)) {
       ExternalLink
-    } else if (hashedTagIds.contains("344ce3383665e23496bedd160675780c") // news/series/hsbc-files
+    } else if ( // Note: if adding a hash use the same md5 implementation as above
+         hashedTagIds.contains("344ce3383665e23496bedd160675780c") // news/series/hsbc-files
       || hashedTagIds.contains("d36fa10d66bf5ff85894829d3829d9e1")      // news/series/panama-papers
       || hashedTagIds.contains("2920a7e21dc9f6fd0c008b50709c042f")      // us-news/homan-square
       || hashedTagIds.contains("ae4bd9f302c420d242a8da91a47a9ddd")      // ...
       || hashedTagIds.contains("f336cb0e0941d3d3d275e6451babca89")      // uk-news/series/the-new-world-of-work
       || hashedTagIds.contains("6f92a967c35b72ef4867f23ba88c95a1")      // world/series/the-new-arrivals
-      || hashedTagIds.contains("01c74eb3a6d3c978e26d2c8f19f9b6a3")      // ...
+      || hashedTagIds.contains("1c74eb3a6d3c978e26d2c8f19f9b6a3")       // ...
       || hashedTagIds.contains("4dae5700e6b6fdf66d1567769b41c1c2")      // news/series/nauru-files
       || hashedTagIds.contains("9d89e70b7d99e776ffb741c0b9ab8854")      // us-news/series/counted-us-police-killings
       || hashedTagIds.contains("7037b49de72275eb72b73a111da31849")      // australia-news/series/healthcare-in-detention


### PR DESCRIPTION
The way we translate the byte array to a string removes leading zeros.  For now I am just correcting the hash that is affected, but we should look at fixing the underlying issue soon.