### PR TITLE
Enable branding of snaps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-import sbtrelease._
-import ReleaseStateTransformations._
 import Dependencies._
+import sbtrelease.ReleaseStateTransformations._
+import sbtrelease._
 
 organization := "com.gu"
 
@@ -117,6 +117,7 @@ lazy val fapiClient = project.in(file("fapi-client"))
     ),
     libraryDependencies ++= Seq(
       contentApi,
+      commercialShared,
       scalaTest,
       mockito
     ),
@@ -136,6 +137,7 @@ lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
     ),
     libraryDependencies ++= Seq(
       contentApi,
+      commercialShared,
       scalaTest,
       mockito
     ),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -59,11 +59,9 @@ object FaciaImage {
 
 }
 
-sealed trait BrandableContent {
+sealed trait FaciaContent {
   def brandingByEdition: BrandingByEdition = Map.empty
 }
-
-sealed trait FaciaContent extends BrandableContent
 
 object Snap {
   val LatestType = "latest"

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -159,13 +159,16 @@ case class LatestSnap(
   image: Option[FaciaImage],
   properties: ContentProperties,
   byline: Option[String],
-  kicker: Option[ItemKicker]) extends Snap
+  kicker: Option[ItemKicker],
+  override val brandingByEdition: BrandingByEdition
+) extends Snap
 
 object LatestSnap {
   def fromTrailAndContent(trail: Trail, maybeContent: Option[Content]): LatestSnap = {
     val cardStyle: CardStyle = maybeContent.map(CardStyle.apply(_, trail.safeMeta)).getOrElse(DefaultCardstyle)
     val resolvedMetaData: ResolvedMetaData =
       maybeContent.fold(ResolvedMetaData.fromTrailMetaData(trail.safeMeta))(ResolvedMetaData.fromContentAndTrailMetaData(_, trail.safeMeta, cardStyle))
+    val brandingByEdition = maybeContent map (_.brandingByEdition) getOrElse Map.empty
     LatestSnap(
       trail.id,
       Option(trail.frontPublicationDate),
@@ -180,7 +183,8 @@ object LatestSnap {
       FaciaImage.getFaciaImage(maybeContent, trail.safeMeta, resolvedMetaData),
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
       trail.safeMeta.byline.orElse(maybeContent.flatMap(_.fields.flatMap(_.byline))),
-      ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData)
+      ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData),
+      brandingByEdition
     )
   }
 
@@ -188,6 +192,7 @@ object LatestSnap {
     val cardStyle: CardStyle = maybeContent.map(CardStyle.apply(_, supportingItem.safeMeta)).getOrElse(DefaultCardstyle)
     val resolvedMetaData: ResolvedMetaData =
       maybeContent.fold(ResolvedMetaData.fromTrailMetaData(supportingItem.safeMeta))(ResolvedMetaData.fromContentAndTrailMetaData(_, supportingItem.safeMeta, cardStyle))
+    val brandingByEdition = maybeContent map (_.brandingByEdition) getOrElse Map.empty
     LatestSnap(
       supportingItem.id,
       supportingItem.frontPublicationDate,
@@ -202,7 +207,8 @@ object LatestSnap {
       FaciaImage.getFaciaImage(maybeContent, supportingItem.safeMeta, resolvedMetaData),
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
       supportingItem.safeMeta.byline.orElse(maybeContent.flatMap(_.fields.flatMap(_.byline))),
-      ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData)
+      ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData),
+      brandingByEdition
     )
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/package.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/package.scala
@@ -1,0 +1,7 @@
+package com.gu.facia.api
+
+import com.gu.commercial.branding.Branding
+
+package object models {
+  type BrandingByEdition = Map[String, Option[Branding]]
+}

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
@@ -1,6 +1,8 @@
 package com.gu.facia.api.utils
 
-import com.gu.contentapi.client.model.v1.{TagType, Tag, Content}
+import com.gu.commercial.branding.{Brandable, BrandingFinder}
+import com.gu.contentapi.client.model.v1.{Content, Section, Tag, TagType}
+import com.gu.facia.api.models.BrandingByEdition
 
 object ContentApiUtils {
 
@@ -38,5 +40,22 @@ object ContentApiUtils {
     lazy val isInteractive: Boolean = content.tags.exists { _.id == Tags.Interactive }
 
     lazy val isLive: Boolean = content.fields.flatMap(_.liveBloggingNow).exists(identity)
+
+    lazy val brandingByEdition: BrandingByEdition = findBranding(content)
+  }
+
+  implicit class RichSection(section: Section) {
+    lazy val brandingByEdition: BrandingByEdition = findBranding(section)
+  }
+
+  implicit class RichTag(tag: Tag) {
+    lazy val brandingByEdition: BrandingByEdition = findBranding(tag)
+  }
+
+  private def findBranding[T: Brandable](brandable: T): BrandingByEdition = {
+    val editions = Seq("uk", "us", "au", "int")
+    editions.map { edition =>
+      edition -> BrandingFinder.findBranding(edition)(brandable)
+    }.toMap
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -1,6 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.v1.{Content, ContentFields, ContentType}
+import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{Branded, CollectionConfigJson, CollectionJson, Trail, TrailMetaData}
 import org.joda.time.DateTime
@@ -81,7 +82,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       image,
       contentProperties,
       byline,
-      kicker)
+      kicker,
+      latestContent map (_.brandingByEdition) getOrElse Map.empty
+    )
 
   def makeLinkSnap(
     id: String = "id",

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -110,7 +110,9 @@ class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with
       image,
       contentProperties,
       byline,
-      kicker)
+      kicker,
+      Map.empty
+    )
 
 
   "fromCollectionJson" - {

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -1,8 +1,8 @@
 package com.gu.facia.api.models
 
-import com.gu.contentapi.client.model.v1.{ContentFields, Content}
+import com.gu.contentapi.client.model.v1.ContentFields
 import com.gu.facia.api.utils.{ContentProperties, DefaultCardstyle, FaciaContentUtils}
-import com.gu.facia.client.models.{TrailMetaData, Trail}
+import com.gu.facia.client.models.{Trail, TrailMetaData}
 import lib.TestContent
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -30,13 +30,13 @@ class FaciaContentHelperTest extends FreeSpec with Matchers with TestContent {
 
   "should return the headline for a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty)
     FaciaContentUtils.headlineOption(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty)
     FaciaContentUtils.href(cc) should equal(None)
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -24,7 +24,22 @@ class FaciaContentHelperTest extends FreeSpec with Matchers with TestContent {
       imageSlideshowReplace = false)
 
   "should return 'Missing Headline' when the headline is None in a Snaps" in {
-    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, None, None, None, None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap("myId",
+      None,
+      DefaultCardstyle,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      "myGroup",
+      None,
+      emptyContentProperties,
+      None,
+      None,
+      Map.empty
+    )
     FaciaContentUtils.headlineOption(snap) should equal(None)
   }
 
@@ -41,7 +56,22 @@ class FaciaContentHelperTest extends FreeSpec with Matchers with TestContent {
   }
 
   "should return a href for a LatestSnap" in {
-    val snap = LatestSnap("myId", None, DefaultCardstyle, None, None, None, None, Some("The href"), None, "myGroup", None, emptyContentProperties, None, None)
+    val snap = LatestSnap("myId",
+      None,
+      DefaultCardstyle,
+      None,
+      None,
+      None,
+      None,
+      Some("The href"),
+      None,
+      "myGroup",
+      None,
+      emptyContentProperties,
+      None,
+      None,
+      Map.empty
+    )
     FaciaContentUtils.href(snap) should equal(Some("The href"))
   }
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -46,7 +46,9 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers with TestContent {
     image = None,
     properties = emptyProperties,
     byline = None,
-    kicker = None)
+    kicker = None,
+    brandingByEdition = Map.empty
+  )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
     content = content,

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -24,7 +24,9 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers with TestContent {
     image = None,
     ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
     byline = None,
-    kicker = None)
+    kicker = None,
+    brandingByEdition = Map.empty
+  )
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
 
@@ -61,7 +63,9 @@ class FaciaContentUtilsTest extends FreeSpec with Matchers with TestContent {
     kicker = None,
     embedType = None,
     embedUri = None,
-    embedCss = None)
+    embedCss = None,
+    brandingByEdition = Map.empty
+  )
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
     content = content,

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -10,4 +10,5 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "4.0.1"
 }


### PR DESCRIPTION
This change adds branding to any `FaciaContent`.

I've tested it in frontend on my machine, by pressing fronts in draft and live mode, and the results are as expected.
