### PR TITLE
Improve link snap branding

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -199,5 +199,21 @@ class ContentApiTest extends FreeSpec
         result => result should be(empty)
       )
     }
+
+    "will use snap link stripped of '/all' to find branding" in {
+      val request = LinkSnapsRequest(Map("trailId" -> "/cities/all"))
+      ContentApi.linkSnapBrandingsByEdition(capiClient("cities"), request).asFuture.futureValue.fold(
+        err => fail(s"expected brandings result, got error $err"),
+        result => result.values.headOption should not be empty
+      )
+    }
+
+    "will use snap link stripped of '/latest' to find branding" in {
+      val request = LinkSnapsRequest(Map("trailId" -> "/cities/latest"))
+      ContentApi.linkSnapBrandingsByEdition(capiClient("cities"), request).asFuture.futureValue.fold(
+        err => fail(s"expected brandings result, got error $err"),
+        result => result.values.headOption should not be empty
+      )
+    }
   }
 }


### PR DESCRIPTION
By reducing the number of pointless capi lookups and considering a failed lookup to be a success.