### PR TITLE
Add support for play 2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ val sonatypeReleaseSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(faciaJson, faciaJson_play25, fapiClient, fapiClient_play25)
+  .aggregate(faciaJson, faciaJson_play25, faciaJson_play26, fapiClient, fapiClient_play25, fapiClient_play26)
   .settings(publishArtifact := false)
   .settings(sonatypeReleaseSettings: _*)
 
@@ -102,6 +102,28 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
       commonsIo,
       specs2,
       playJson25,
+      scalaLogging
+    ),
+    publishArtifact := true
+  )
+  .settings(sonatypeReleaseSettings: _*)
+
+lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
+  .settings(sonatypeReleaseSettings: _*)
+  .settings(
+    organization := "com.gu",
+    name := "facia-json-play26",
+    sourceDirectory := baseDirectory.value / "../facia-json/src",
+    resolvers ++= Seq(
+      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+    ),
+    scalacOptions := Seq("-feature", "-deprecation"),
+    libraryDependencies ++= Seq(
+      awsSdk,
+      commonsIo,
+      specs2,
+      playJson26,
       scalaLogging
     ),
     publishArtifact := true
@@ -150,3 +172,25 @@ lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
     publishArtifact := true
   )
   .dependsOn(faciaJson_play25)
+
+lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
+  .settings(sonatypeReleaseSettings: _*)
+  .settings(
+    organization := "com.gu",
+    name := "fapi-client-play26",
+    sourceDirectory := baseDirectory.value / "../fapi-client/src",
+    resolvers ++= Seq(
+      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
+      "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
+      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+    ),
+    scalacOptions := Seq("-feature", "-deprecation"),
+    libraryDependencies ++= Seq(
+      contentApi,
+      commercialShared,
+      scalaTest,
+      mockito
+    ),
+    publishArtifact := true
+  )
+  .dependsOn(faciaJson_play26)

--- a/facia-json/src/main/scala/com/gu/facia/client/json/JodaFormat.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/json/JodaFormat.scala
@@ -1,0 +1,40 @@
+package com.gu.facia.client.json
+
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.json._
+import scala.util.control.Exception.nonFatalCatch
+
+/*
+  joda support has been removed from play-json in v2.6.
+  Hence, we provides our own Format for joda.Datetime to ensure backward compatibility and cross play version compilation.
+ */
+
+object JodaWrites {
+  implicit object JodaDateTimeWrites extends Writes[DateTime] {
+    def writes(d: DateTime): JsValue = JsNumber(d.getMillis)
+  }
+}
+
+object JodaReads {
+
+  implicit val JodaDateTimeReads : Reads[DateTime] = new Reads[DateTime] {
+
+    val dateFormat = ISODateTimeFormat.dateOptionalTimeParser
+    def parse(s: String) = nonFatalCatch[DateTime] opt (DateTime.parse(s, dateFormat))
+
+    def reads(json: JsValue): JsResult[DateTime] = json match {
+      case JsNumber(d) => JsSuccess(new DateTime(d.toLong))
+      case JsString(s) => parse(s) match {
+        case Some(d) => JsSuccess(d)
+        case _ => JsError(JsPath(), s"error.expected.jodadate.format ${dateFormat.toString}")
+      }
+      case _ => JsError(JsPath(), "error.expected.date")
+    }
+  }
+
+}
+
+object JodaFormat {
+  implicit val JodaDateTimeFormat = Format(JodaReads.JodaDateTimeReads, JodaWrites.JodaDateTimeWrites)
+}

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -3,6 +3,7 @@ package com.gu.facia.client.models
 import play.api.libs.json._
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
+import com.gu.facia.client.json.JodaFormat._
 
 case class SlideshowAsset(src: String, width: String, height: String)
 object SlideshowAsset {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"
+  val playJson26 = "com.typesafe.play" %% "play-json" % "2.6.3"
   val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
   val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.1-SNAPSHOT"
+version in ThisBuild := "2.3"


### PR DESCRIPTION
Because joda support has been removed from play-json 2.6
we are now providing our own implicit Formats for joda.Datetime to
ensure backward compatibility and cross play version compilation