### PR TITLE
Pass in provided arguments in recursive call

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -47,7 +47,7 @@ object BackfillResolver {
             curatedCollection <- FAPI.liveCollectionContentWithSnaps(parentCollection, adjustSearchQuery, adjustItemQuery)
             nestedBackfill <- parentCollection.collectionConfig.backfill match {
               case Some(Backfill("capi", query)) =>
-                backfill(CapiBackfill(query, parentCollection.collectionConfig))
+                backfill(CapiBackfill(query, parentCollection.collectionConfig), adjustSearchQuery, adjustItemQuery)
               case _ => backfill(EmptyBackfill)
             }
           } yield {


### PR DESCRIPTION
Some editors picks are failing to be indexed in CAPI. We traced the origin back to the case where a collection is backfilled by its parent collection: in this case, the CAPI query does not request the required fields (`trailText`, etc.). Because of that, the generated JSON payload is incomplete.

Example [here](http://api.nextgen.guardianapps.co.uk/au/lifeandstyle/relationships/lite.json) (scroll down until you find two items with missing `trailText`)