### PR TITLE
[WIP] Cross compile play 2.6 libs with scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,13 @@ organization := "com.gu"
 
 name := "facia-api-client"
 
-scalaVersion := "2.11.11"
+description := "Scala client for The Guardian's Facia JSON API"
 
+scalaVersion := "2.11.11"
 scalaVersion in ThisBuild := "2.11.11"
 
-description := "Scala client for The Guardian's Facia JSON API"
+val buildCrossList = Seq(scalaVersion.value, "2.12.4")
+releaseCrossBuild := true
 
 val sonatypeReleaseSettings = Seq(
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -119,6 +121,7 @@ lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
     scalacOptions := Seq("-feature", "-deprecation"),
+    crossScalaVersions := buildCrossList,
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
@@ -184,6 +187,7 @@ lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    crossScalaVersions := buildCrossList,
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContainerBrandingFinder.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContainerBrandingFinder.scala
@@ -1,0 +1,49 @@
+package com.gu.facia.api.utils
+
+import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
+import com.gu.facia.api.models.CollectionConfig
+import com.gu.facia.client.models.Branded
+import com.gu.commercial.branding.{BrandingFinder, Brandable, Branding, ContainerBranding, PaidMultiSponsorBranding, PaidContent}
+
+object ContainerBrandingFinder {
+
+  /**
+    * Finds branding of a set of content items, tags and sections in a container.
+    *
+    * @param config  Configuration of container holding this content
+    * @param items   Content items with <code>section</code>, <code>isInappropriateForSponsorship</code> field
+    *                and all <code>tags</code> populated
+    * @param edition in lowercase String format eg. <code>uk</code>
+    */
+  def findBranding(
+    config: CollectionConfig,
+    edition: String,
+    items: Set[Content],
+    tags: Set[Tag] = Set.empty,
+    sections: Set[Section] = Set.empty
+  ): Option[ContainerBranding] = {
+    def toBranding[T: Brandable](brandable: T) = BrandingFinder.findBranding(edition)(brandable)
+    findBranding(
+      isConfiguredForBranding = config.metadata.exists(_.contains(Branded)),
+      optBrandings = items.map(toBranding(_)) ++ tags.map(toBranding(_)) ++ sections.map(toBranding(_))
+    )
+  }
+
+  def findBranding(
+    isConfiguredForBranding: Boolean,
+    optBrandings: Set[Option[Branding]]
+  ): Option[ContainerBranding] = {
+
+    def findCommonBranding(brandings: Set[Branding]) = if (brandings.size == 1) brandings.headOption else None
+
+    def areAllPaidContent(brandings: Set[Branding]) = brandings.forall(_.brandingType == PaidContent)
+
+    if (isConfiguredForBranding && optBrandings.nonEmpty && optBrandings.forall(_.nonEmpty)) {
+      val brandings = optBrandings.flatten
+      findCommonBranding(brandings) orElse {
+        if (areAllPaidContent(brandings)) Some(PaidMultiSponsorBranding)
+        else None
+      }
+    } else None
+  }
+}

--- a/fapi-client/src/test/resources/branding/AfterDateTargetedTagBrandedContent.json
+++ b/fapi-client/src/test/resources/branding/AfterDateTargetedTagBrandedContent.json
@@ -1,0 +1,199 @@
+{
+  "id": "football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "typeName": "audio",
+  "sectionId": "football",
+  "sectionName": "Football",
+  "webPublicationDate": "2016-09-01T20:30:21Z",
+  "webTitle": "Transfer window special – Guardian Australia's Premier League podcast",
+  "webUrl": "https://www.theguardian.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "apiUrl": "https://content.guardianapis.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "tags": [
+    {
+      "id": "football/series/premier-league-the-view-from-australia",
+      "typeName": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Premier League: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/premier-league-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/premier-league-the-view-from-australia",
+      "references": [
+      ],
+      "description": "<p>A&nbsp;weekly view&nbsp;from Down Under of all things top flight football in England and Wales</p>",
+      "podcast": {
+        "linkUrl": "http://www.theguardian.com",
+        "copyright": "theguardian.com © 2016",
+        "author": "theguardian.com",
+        "subscriptionUrl": "https://itunes.apple.com/au/podcast/premier-league-view-from-australia/id1140387436?mt=2",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2016/08/03/Optus_PodcastBadge3.jpg",
+        "categories": [
+          {
+            "main": "Sports & Recreation",
+            "sub": "Professional"
+          }
+        ]
+      },
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "paid-content",
+          "sponsorName": "ING DIRECT",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/06/Oct/2016/d767ce82-0525-ING_dreamstarter_140.png",
+          "sponsorLink": "https://www.campaigns.ingdirect.com.au/dreamstarter",
+          "targeting": {
+            "publishedSince": "2016-07-04T01:57:12Z"
+          },
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 58
+          }
+        }
+      ]
+    },
+    {
+      "id": "football/football",
+      "typeName": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Football",
+      "webUrl": "https://www.theguardian.com/football/football",
+      "apiUrl": "https://content.guardianapis.com/football/football",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/series/epl-the-view-from-australia",
+      "typeName": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/epl-the-view-from-australia",
+      "typeName": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "sport/australia-sport",
+      "typeName": "keyword",
+      "sectionId": "sport",
+      "sectionName": "Sport",
+      "webTitle": "Australia sport",
+      "webUrl": "https://www.theguardian.com/sport/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/sport/australia-sport",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/audio",
+      "typeName": "type",
+      "webTitle": "Audio",
+      "webUrl": "https://www.theguardian.com/audio",
+      "apiUrl": "https://content.guardianapis.com/type/audio",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/podcast",
+      "typeName": "type",
+      "webTitle": "Podcast",
+      "webUrl": "https://www.theguardian.com/podcasts",
+      "apiUrl": "https://content.guardianapis.com/type/podcast",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/richard-parkin",
+      "typeName": "contributor",
+      "webTitle": "Richard Parkin",
+      "webUrl": "https://www.theguardian.com/profile/richard-parkin",
+      "apiUrl": "https://content.guardianapis.com/profile/richard-parkin",
+      "references": [
+      ],
+      "bio": "<p>Richard Parkin is a Sydney-based journalist and the casual sport editor at Guardian Australia. He was the football analyst on SBS's The Full Brazilian and is completing a PhD in Political Economy</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/30/1430357903733/140x140Richard_Parkin.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/5/1/1430441131977/Richard-Parkin-R.png",
+      "firstName": "richard",
+      "lastName": "parkin",
+      "twitterHandle": "rrjparkin",
+      "r2ContributorId": "56860"
+    },
+    {
+      "id": "profile/david-squires",
+      "typeName": "contributor",
+      "webTitle": "David Squires",
+      "webUrl": "https://www.theguardian.com/profile/david-squires",
+      "apiUrl": "https://content.guardianapis.com/profile/david-squires",
+      "references": [
+      ],
+      "firstName": "david",
+      "lastName": "squires",
+      "r2ContributorId": "67060"
+    },
+    {
+      "id": "profile/miketicher",
+      "typeName": "contributor",
+      "webTitle": "Mike Ticher",
+      "webUrl": "https://www.theguardian.com/profile/miketicher",
+      "apiUrl": "https://content.guardianapis.com/profile/miketicher",
+      "references": [
+      ],
+      "bio": "<p>Mike Ticher is Guardian Australia's news editor. He has worked for the Sydney Morning Herald, the Guardian sports desk in London and was founding editor of independent football magazine When Saturday Comes</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590280939/Mike-Ticher.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590298042/Mike-Ticher-L.png",
+      "firstName": "",
+      "lastName": "ticher",
+      "rcsId": "GNL271742",
+      "r2ContributorId": "16151"
+    },
+    {
+      "id": "profile/miles-martignoni",
+      "typeName": "contributor",
+      "webTitle": "Miles Martignoni",
+      "webUrl": "https://www.theguardian.com/profile/miles-martignoni",
+      "apiUrl": "https://content.guardianapis.com/profile/miles-martignoni",
+      "references": [
+      ],
+      "bio": "<p>Miles Martignoni is the Podcast Producer at Guardian Australia. Miles tweets at <a href=\" https://twitter.com/milesage\">@milesage</a>. You can email him at <a href=\"mailto:miles.martignoni@theguardian.com \"> miles.martignoni@theguardian.com </a></p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/22/1429700784680/Miles-Martignoni.jpg",
+      "firstName": "miles",
+      "lastName": "martignoni",
+      "twitterHandle": "milesage",
+      "r2ContributorId": "69123"
+    },
+    {
+      "id": "tracking/commissioningdesk/australia-sport",
+      "typeName": "tracking",
+      "webTitle": "Australia Sport",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/australia-sport",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "football",
+    "webTitle": "Football",
+    "webUrl": "https://www.theguardian.com/football",
+    "apiUrl": "https://content.guardianapis.com/football",
+    "editions": [
+      {
+        "id": "football",
+        "webTitle": "Football",
+        "webUrl": "https://www.theguardian.com/football",
+        "apiUrl": "https://content.guardianapis.com/football",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/resources/branding/FoundationTag.json
+++ b/fapi-client/src/test/resources/branding/FoundationTag.json
@@ -1,0 +1,33 @@
+{
+  "id": "sustainable-business/series/spotlight-on-commodities",
+  "typeName": "series",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webTitle": "Spotlight on commodities",
+  "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+  "activeSponsorships": [
+    {
+      "sponsorshipTypeName": "sponsored",
+      "sponsorName": "Fairtrade Foundation",
+      "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+      "sponsorLink": "http://www.fairtrade.org.uk/",
+      "aboutLink": "https://www.theguardian.com/uk"
+    },
+    {
+      "sponsorshipTypeName": "foundation",
+      "sponsorName": "Rockefeller Foundation",
+      "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+      "sponsorLink": "http://www.100resilientcities.org/",
+      "sponsorLogoDimensions": {
+        "width": 140,
+        "height": 37
+      },
+      "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+      "highContrastSponsorLogoDimensions": {
+        "width": 140,
+        "height": 47
+      }
+    }
+  ]
+}

--- a/fapi-client/src/test/resources/branding/FoundationTag2.json
+++ b/fapi-client/src/test/resources/branding/FoundationTag2.json
@@ -1,0 +1,18 @@
+{
+  "id": "sustainable-business/series/spotlight-on-candles",
+  "typeName": "series",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webTitle": "Spotlight on candles",
+  "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-candles",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-candles",
+  "activeSponsorships": [
+    {
+      "sponsorshipTypeName": "sponsored",
+      "sponsorName": "Fairtrade Foundation",
+      "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+      "sponsorLink": "http://www.fairtrade.org.uk/",
+      "aboutLink": "https://www.theguardian.com/uk"
+    }
+  ]
+}

--- a/fapi-client/src/test/resources/branding/InappropriateContent.json
+++ b/fapi-client/src/test/resources/branding/InappropriateContent.json
@@ -1,0 +1,179 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "typeName": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "fields": {
+    "isInappropriateForSponsorship": true
+  },
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "typeName": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "typeName": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/americas",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "typeName": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "typeName": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "typeName": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "typeName": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "typeName": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "typeName": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/resources/branding/PaidContent.json
+++ b/fapi-client/src/test/resources/branding/PaidContent.json
@@ -1,0 +1,96 @@
+{
+  "id": "marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "typeName": "article",
+  "sectionId": "marriott-travels",
+  "sectionName": "Marriott Travels",
+  "webPublicationDate": "2016-11-15T17:29:54Z",
+  "webTitle": "Seven surprising facts about the world's largest hotel group",
+  "webUrl": "https://www.theguardian.com/marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "apiUrl": "https://content.guardianapis.com/marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "fields": {
+    "isInappropriateForSponsorship": false
+  },
+  "tags": [
+    {
+      "id": "marriott-travels/marriott-travels",
+      "typeName": "paid-content",
+      "webTitle": "Marriott Travels",
+      "webUrl": "https://www.theguardian.com/marriott-travels/marriott-travels",
+      "apiUrl": "https://content.guardianapis.com/marriott-travels/marriott-travels",
+      "references": [
+
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "paid-content",
+          "sponsorName": "Marriott Hotels",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/09/Nov/2016/9d4910cd-55ed-42aa-92bc-5a4fce76dc53-Marriott_logo_2.png",
+          "sponsorLink": "http://www.marriott.co.uk/rewards/rewards-program.mi",
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 90
+          }
+        }
+      ],
+      "paidContentType": "Topic"
+    },
+    {
+      "id": "type/article",
+      "typeName": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "tone/advertisement-features",
+      "typeName": "tone",
+      "webTitle": "Advertisement features",
+      "webUrl": "https://www.theguardian.com/tone/advertisement-features",
+      "apiUrl": "https://content.guardianapis.com/tone/advertisement-features",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-labs",
+      "typeName": "tracking",
+      "webTitle": "UK Labs",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-labs",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-labs",
+      "references": [
+
+      ]
+    }
+  ],
+  "section": {
+    "id": "marriott-travels",
+    "webTitle": "Marriott Travels",
+    "webUrl": "https://www.theguardian.com/marriott-travels",
+    "apiUrl": "https://content.guardianapis.com/marriott-travels",
+    "editions": [
+      {
+        "id": "marriott-travels",
+        "webTitle": "Marriott Travels",
+        "webUrl": "https://www.theguardian.com/marriott-travels",
+        "apiUrl": "https://content.guardianapis.com/marriott-travels",
+        "code": "default"
+      }
+    ],
+    "activeSponsorships": [
+      {
+        "sponsorshipTypeName": "paid-content",
+        "sponsorName": "Marriott Hotels",
+        "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/09/Nov/2016/9d4910cd-55ed-42aa-92bc-5a4fce76dc53-Marriott_logo_2.png",
+        "sponsorLink": "http://www.marriott.co.uk/rewards/rewards-program.mi",
+        "sponsorLogoDimensions": {
+          "width": 140,
+          "height": 90
+        }
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/resources/branding/PaidTag.json
+++ b/fapi-client/src/test/resources/branding/PaidTag.json
@@ -1,0 +1,20 @@
+{
+  "id": "visit-las-vegas/visit-las-vegas",
+  "typeName": "paid-content",
+  "webTitle": "Visit Las Vegas",
+  "webUrl": "https://www.theguardian.com/visit-las-vegas/visit-las-vegas",
+  "apiUrl": "https://content.guardianapis.com/visit-las-vegas/visit-las-vegas",
+  "activeSponsorships": [
+    {
+      "sponsorshipTypeName": "paid-content",
+      "sponsorName": "Las Vegas Tourism",
+      "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/16/Mar/2017/8b15f5a5-7d9d-4c8f-ae1b-5ab72654fd15-LasVegas_4c_207_Red.png",
+      "sponsorLink": "http://viva.lasvegas.com",
+      "sponsorLogoDimensions": {
+        "width": 140,
+        "height": 90
+      }
+    }
+  ],
+  "paidContentType": "Topic"
+}

--- a/fapi-client/src/test/resources/branding/PaidTag2.json
+++ b/fapi-client/src/test/resources/branding/PaidTag2.json
@@ -1,0 +1,20 @@
+{
+  "id": "swiss-cities/swiss-cities",
+  "typeName": "paid-content",
+  "webTitle": "Swiss cities",
+  "webUrl": "https://www.theguardian.com/swiss-cities/swiss-cities",
+  "apiUrl": "https://content.guardianapis.com/swiss-cities/swiss-cities",
+  "activeSponsorships": [
+    {
+      "sponsorshipTypeName": "paid-content",
+      "sponsorName": "Switzerland Tourism",
+      "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/10/Mar/2017/916b37be-2f03-4b2a-b78e-25029ba0a52c-Logo_ST0031854_POS.png",
+      "sponsorLink": " https://www.swiss.com/gb/en?WT.mc_id=LXGUARDIANGB1711",
+      "sponsorLogoDimensions": {
+        "width": 140,
+        "height": 90
+      }
+    }
+  ],
+  "paidContentType": "Topic"
+}

--- a/fapi-client/src/test/resources/branding/SectionBrandedContent.json
+++ b/fapi-client/src/test/resources/branding/SectionBrandedContent.json
@@ -1,0 +1,176 @@
+{
+  "id": "cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "typeName": "article",
+  "sectionId": "cities",
+  "sectionName": "Cities",
+  "webPublicationDate": "2017-01-17T07:15:32Z",
+  "webTitle": "Face-off over the Congo: the long rivalry between Kinshasa and Brazzaville",
+  "webUrl": "https://www.theguardian.com/cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "apiUrl": "https://content.guardianapis.com/cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "tags": [
+    {
+      "id": "cities/cities",
+      "typeName": "keyword",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Cities",
+      "webUrl": "https://www.theguardian.com/cities/cities",
+      "apiUrl": "https://content.guardianapis.com/cities/cities",
+      "references": [
+      ]
+    },
+    {
+      "id": "cities/series/border-cities",
+      "typeName": "series",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Border cities",
+      "webUrl": "https://www.theguardian.com/cities/series/border-cities",
+      "apiUrl": "https://content.guardianapis.com/cities/series/border-cities",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/congo-brazzaville",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Congo-Brazzaville",
+      "webUrl": "https://www.theguardian.com/world/congo-brazzaville",
+      "apiUrl": "https://content.guardianapis.com/world/congo-brazzaville",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/congo",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Democratic Republic of the Congo",
+      "webUrl": "https://www.theguardian.com/world/congo",
+      "apiUrl": "https://content.guardianapis.com/world/congo",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/africa",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Africa",
+      "webUrl": "https://www.theguardian.com/world/africa",
+      "apiUrl": "https://content.guardianapis.com/world/africa",
+      "references": [
+      ]
+    },
+    {
+      "id": "politics/politics",
+      "typeName": "keyword",
+      "sectionId": "politics",
+      "sectionName": "Politics",
+      "webTitle": "Politics",
+      "webUrl": "https://www.theguardian.com/politics/politics",
+      "apiUrl": "https://content.guardianapis.com/politics/politics",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/conflict-and-development",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Conflict and development",
+      "webUrl": "https://www.theguardian.com/global-development/conflict-and-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/conflict-and-development",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on conflict, tribal conflict, war including civil war and violence in developing countries&nbsp;</p>"
+    },
+    {
+      "id": "type/article",
+      "typeName": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/features",
+      "typeName": "tone",
+      "webTitle": "Features",
+      "webUrl": "https://www.theguardian.com/tone/features",
+      "apiUrl": "https://content.guardianapis.com/tone/features",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/jasonburke",
+      "typeName": "contributor",
+      "webTitle": "Jason Burke",
+      "webUrl": "https://www.theguardian.com/profile/jasonburke",
+      "apiUrl": "https://content.guardianapis.com/profile/jasonburke",
+      "references": [
+      ],
+      "bio": "<p>Jason is the Africa&nbsp; correspondent of the Guardian, based in<br>\nJohannesburg, and reporting from across the continent. In 20 years as<br>\na foreign correspondent, he has covered stories throughout the Middle<br>\nEast, Europe and South Asia. He has written extensively on Islamic<br>\nextremism and, among numerous other conflicts, covered the wars of<br>\n2001 in Afghanistan and 2003 in Iraq. Jason is the author of four<br>\nbooks, most recently <a href=\"http://bookshop.theguardian.com/catalog/product/view/id/320779/bookshop.theguardian.com/catalog/product/view/id/320779/\">The New Threat</a>.</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/3/2/1267538178716/Jason-Burke.jpg",
+      "firstName": "",
+      "lastName": "burke",
+      "rcsId": "GNL001549",
+      "r2ContributorId": "15798"
+    },
+    {
+      "id": "tracking/commissioningdesk/cities",
+      "typeName": "tracking",
+      "webTitle": "Cities",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/cities",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/cities",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "cities",
+    "webTitle": "Cities",
+    "webUrl": "https://www.theguardian.com/cities",
+    "apiUrl": "https://content.guardianapis.com/cities",
+    "editions": [
+      {
+        "id": "cities",
+        "webTitle": "Cities",
+        "webUrl": "https://www.theguardian.com/cities",
+        "apiUrl": "https://content.guardianapis.com/cities",
+        "code": "default"
+      }
+    ],
+    "activeSponsorships": [
+      {
+        "sponsorshipTypeName": "foundation",
+        "sponsorName": "Rockefeller Foundation",
+        "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+        "sponsorLink": "http://www.100resilientcities.org/",
+        "sponsorLogoDimensions": {
+          "width": 140,
+          "height": 37
+        },
+        "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+        "highContrastSponsorLogoDimensions": {
+          "width": 140,
+          "height": 47
+        }
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/resources/branding/SeriesTag.json
+++ b/fapi-client/src/test/resources/branding/SeriesTag.json
@@ -1,0 +1,10 @@
+{
+  "id": "film/series/new-view-series",
+  "typeName": "series",
+  "sectionId": "theguardian",
+  "sectionName": "From the Guardian",
+  "webTitle": "New View series",
+  "webUrl": "https://www.theguardian.com/film/series/new-view-series",
+  "apiUrl": "https://content.guardianapis.com/film/series/new-view-series",
+  "description": "A series of videos commissioned and editorially controlled by Guardian Films, in association with Skoda "
+}

--- a/fapi-client/src/test/resources/branding/TagBrandedContent-MultipleBrands.json
+++ b/fapi-client/src/test/resources/branding/TagBrandedContent-MultipleBrands.json
@@ -1,0 +1,194 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "typeName": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "typeName": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "typeName": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/",
+          "aboutLink": "https://www.theguardian.com/uk"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "foundation",
+          "sponsorName": "Rockefeller Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+          "sponsorLink": "http://www.100resilientcities.org/",
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 37
+          },
+          "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+          "highContrastSponsorLogoDimensions": {
+            "width": 140,
+            "height": 47
+          }
+        }
+      ]
+    },
+    {
+      "id": "world/americas",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "typeName": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "typeName": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "typeName": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "typeName": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "typeName": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "typeName": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/resources/branding/TagBrandedContent.json
+++ b/fapi-client/src/test/resources/branding/TagBrandedContent.json
@@ -1,0 +1,200 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "typeName": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "typeName": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "typeName": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipTypeName": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/",
+          "aboutLink": "https://www.theguardian.com/uk"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/americas",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "typeName": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "typeName": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "typeName": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "typeName": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "typeName": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "typeName": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "typeName": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "typeName": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    },
+    {
+      "id": "politics/northernireland",
+      "typeName": "keyword",
+      "sectionId": "politics",
+      "sectionName": "Politics",
+      "webTitle": "Northern Irish politics",
+      "webUrl": "https://www.theguardian.com/politics/northernireland",
+      "apiUrl": "https://content.guardianapis.com/politics/northernireland",
+      "references": [
+      ]
+    },
+    {
+      "id": "uk/northernireland",
+      "typeName": "keyword",
+      "sectionId": "uk-news",
+      "sectionName": "UK news",
+      "webTitle": "Northern Ireland",
+      "webUrl": "https://www.theguardian.com/uk/northernireland",
+      "apiUrl": "https://content.guardianapis.com/uk/northernireland",
+      "references": [
+      ],
+      "description": "The latest news and comment on Northern Ireland"
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/ResponseTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ResponseTest extends FreeSpec with ShouldMatchers with ScalaFutures {
+class ResponseTest extends FreeSpec with Matchers with ScalaFutures {
 
   "Response.filter" - {
     "should return the same result if the filter function returns true" in {

--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -1,0 +1,206 @@
+package com.gu.facia.api
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+import com.gu.contentapi.client.model.v1._
+import play.api.libs.json._
+
+import scala.io.Source
+
+object TestModel {
+
+  private def getJson(fileName: String): JsValue =
+    Json.parse(Source.fromURL(getClass.getResource(s"/branding/$fileName")).mkString)
+
+  trait HasName[A] { def nameOf(a: A): String }
+
+  object HasName {
+    implicit object ContentType extends HasName[ContentType] {
+      def nameOf(t: ContentType): String = t.name
+    }
+    implicit object TagType extends HasName[TagType] {
+      def nameOf(t: TagType): String = t.name
+    }
+    implicit object ElementType extends HasName[ElementType] {
+      def nameOf(t: ElementType): String = t.name
+    }
+    implicit object SponsorshipType extends HasName[SponsorshipType] {
+      def nameOf(t: SponsorshipType): String = t.name
+    }
+  }
+
+  private def byName[A](otherName: String)(a: A)(implicit n: HasName[A]): Boolean =
+    n.nameOf(a).toLowerCase == otherName.replaceAll("-", "")
+
+  implicit val capiDateReads: Reads[CapiDateTime] = __.read[String] map { dateString =>
+    CapiDateTime(
+      LocalDateTime.parse(dateString, ISO_OFFSET_DATE_TIME).toInstant(UTC).toEpochMilli,
+      dateString
+    )
+  }
+
+  case class TestSponsorshipTargeting(
+    publishedSince: Option[CapiDateTime],
+    validEditions: Option[Seq[String]]
+  ) extends SponsorshipTargeting
+  implicit val testSponsorshipTargeting = Json.reads[TestSponsorshipTargeting]
+
+  case class TestLogoDimensions(width: Int, height: Int) extends SponsorshipLogoDimensions
+  implicit val testLogoDimensionsFormat = Json.reads[TestLogoDimensions]
+
+  case class TestSponsorship(
+    sponsorshipTypeName: String,
+    sponsorName: String,
+    sponsorLogo: String,
+    sponsorLink: String,
+    targeting: Option[TestSponsorshipTargeting],
+    aboutLink: Option[String],
+    sponsorLogoDimensions: Option[TestLogoDimensions],
+    highContrastSponsorLogo: Option[String],
+    highContrastSponsorLogoDimensions: Option[TestLogoDimensions]
+  ) extends Sponsorship {
+    def sponsorshipType: SponsorshipType =
+      SponsorshipType.list.find(byName(sponsorshipTypeName)(_)).get
+    def validFrom = None
+    def validTo = None
+  }
+  implicit val testSponsorShipFormat = Json.reads[TestSponsorship]
+
+  case class StubSection(
+    id: String,
+    webTitle: String,
+    activeSponsorships: Option[Seq[TestSponsorship]]
+  ) extends Section {
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def editions: Seq[Edition] = Nil
+  }
+  implicit val stubSectionFormat = Json.reads[StubSection]
+
+  case class StubFields(isInappropriateForSponsorship: Option[Boolean]) extends ContentFields {
+    def headline: Option[String] = None
+    def standfirst: Option[String] = None
+    def trailText: Option[String] = None
+    def byline: Option[String] = None
+    def main: Option[String] = None
+    def body: Option[String] = None
+    def newspaperPageNumber: Option[Int] = None
+    def starRating: Option[Int] = None
+    def contributorBio: Option[String] = None
+    def membershipAccess: Option[MembershipTier] = None
+    def wordcount: Option[Int] = None
+    def commentCloseDate: Option[CapiDateTime] = None
+    def commentable: Option[Boolean] = None
+    def creationDate: Option[CapiDateTime] = None
+    def displayHint: Option[String] = None
+    def firstPublicationDate: Option[CapiDateTime] = None
+    def hasStoryPackage: Option[Boolean] = None
+    def internalComposerCode: Option[String] = None
+    def internalOctopusCode: Option[String] = None
+    def internalPageCode: Option[Int] = None
+    def internalStoryPackageCode: Option[Int] = None
+    def isPremoderated: Option[Boolean] = None
+    def lastModified: Option[CapiDateTime] = None
+    def liveBloggingNow: Option[Boolean] = None
+    def newspaperEditionDate: Option[CapiDateTime] = None
+    def productionOffice: Option[Office] = None
+    def publication: Option[String] = None
+    def scheduledPublicationDate: Option[CapiDateTime] = None
+    def secureThumbnail: Option[String] = None
+    def shortUrl: Option[String] = None
+    def shouldHideAdverts: Option[Boolean] = None
+    def showInRelatedContent: Option[Boolean] = None
+    def thumbnail: Option[String] = None
+    def legallySensitive: Option[Boolean] = None
+    def allowUgc: Option[Boolean] = None
+    def sensitive: Option[Boolean] = None
+    def lang: Option[String] = None
+    def internalRevision: Option[Int] = None
+    def internalContentCode: Option[Int] = None
+    def isLive: Option[Boolean] = None
+    def internalShortId: Option[String] = None
+    def shortSocialShareText: Option[String] = None
+    def socialShareText: Option[String] = None
+    def bodyText: Option[String] = None
+    def charCount: Option[Int] = None
+    def internalVideoCode: Option[String] = None
+    def shouldHideReaderRevenue: Option[Boolean] = None
+  }
+  implicit val stubFieldsFormat = Json.reads[StubFields]
+
+  case class StubTag(
+    id: String,
+    typeName: String,
+    webTitle: String,
+    activeSponsorships: Option[Seq[TestSponsorship]]
+  ) extends Tag {
+    def `type`: TagType = TagType.list.find(byName(typeName)(_)).get
+    def sectionId: Option[String] = None
+    def sectionName: Option[String] = None
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def references: Seq[Reference] = Nil
+    def description: Option[String] = None
+    def bio: Option[String] = None
+    def bylineImageUrl: Option[String] = None
+    def bylineLargeImageUrl: Option[String] = None
+    def podcast: Option[Podcast] = None
+    def firstName: Option[String] = None
+    def lastName: Option[String] = None
+    def emailAddress: Option[String] = None
+    def twitterHandle: Option[String] = None
+    def paidContentType: Option[String] = None
+    def paidContentCampaignColour: Option[String] = None
+    def rcsId: Option[String] = None
+    def r2ContributorId: Option[String] = None
+    def entityIds: Option[scala.collection.Set[String]] = None
+    def tagCategories: Option[scala.collection.Set[String]] = None
+  }
+  implicit val stubTagFormat = Json.reads[StubTag]
+
+  case class StubElement(
+    id: String,
+    relation: String,
+    typeName: String
+  ) extends Element {
+    def `type`: ElementType = ElementType.list.find(byName(typeName)(_)).get
+    def galleryIndex: Option[Int] = None
+    def assets: Seq[Asset] = Nil
+  }
+  implicit val stubElementFormat = Json.reads[StubElement]
+
+  case class StubItem(
+    id: String,
+    typeName: String,
+    section: Option[StubSection],
+    fields: Option[StubFields],
+    tags: Seq[StubTag],
+    elements: Option[Seq[StubElement]]
+  ) extends Content {
+    def `type`: ContentType = ContentType.list.find(byName(typeName)(_)).get
+    def sectionId: Option[String] = None
+    def sectionName: Option[String] = None
+    def webPublicationDate: Option[CapiDateTime] = None
+    def webTitle: String = ""
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def references: Seq[Reference] = Nil
+    def isExpired: Option[Boolean] = None
+    def blocks: Option[Blocks] = None
+    def rights: Option[Rights] = None
+    def crossword: Option[Crossword] = None
+    def atoms: Option[Atoms] = None
+    def stats: Option[ContentStats] = None
+    def debug: Option[Debug] = None
+    def isGone: Option[Boolean] = None
+    def isHosted: Boolean = false
+  }
+  implicit val stubItemFormat = Json.reads[StubItem]
+
+  def getContentItem(fileName: String): Content = getJson(fileName).validate[StubItem].get
+  def getTag(fileName: String): Tag = getJson(fileName).validate[StubTag].get
+
+}
+

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.mock.MockitoSugar
 import scala.concurrent.Future
 
 class ContentApiTest extends FreeSpec
-  with ShouldMatchers
+  with Matchers
   with OptionValues
   with EitherValues
   with TryValues

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/IdsSearchQueriesTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/IdsSearchQueriesTest.scala
@@ -1,8 +1,8 @@
 package com.gu.facia.api.contentapi
 
-import org.scalatest.{ShouldMatchers, FreeSpec}
+import org.scalatest.{Matchers, FreeSpec}
 
-class IdsSearchQueriesTest extends FreeSpec with ShouldMatchers {
+class IdsSearchQueriesTest extends FreeSpec with Matchers {
 
   "limit batches" - {
     val fifty = List.fill(50)("abc").toSeq

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -10,11 +10,11 @@ import lib.IntegrationTestConfig
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, OptionValues, ShouldMatchers}
+import org.scalatest.{FreeSpec, OptionValues, Matchers}
 import play.api.libs.json.{Json, JsArray, JsString}
 
 // TODO: reinstate ignored tests when cmsFronts account has access to test fixtures
-class IntegrationTest extends FreeSpec with ShouldMatchers with ScalaFutures with OptionValues with IntegrationTestConfig {
+class IntegrationTest extends FreeSpec with Matchers with ScalaFutures with OptionValues with IntegrationTestConfig {
   implicit val patience = PatienceConfig(Span(5, Seconds), Span(50, Millis))
 
   def makeCollectionJson(trails: Trail*) = CollectionJson(

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -7,10 +7,10 @@ import com.gu.facia.client.models.{Branded, CollectionConfigJson, CollectionJson
 import org.joda.time.DateTime
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{FreeSpec, OneInstancePerTest, ShouldMatchers}
+import org.scalatest.{FreeSpec, OneInstancePerTest, Matchers}
 import play.api.libs.json.{JsArray, JsString, Json}
 
-class CollectionTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneInstancePerTest {
+class CollectionTest extends FreeSpec with Matchers with MockitoSugar with OneInstancePerTest {
   val trailMetadata = spy(TrailMetaData.empty)
   val trail = Trail("internal-code/page/123", 1, None, Some(trailMetadata))
   val collectionJson = CollectionJson(

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -4,7 +4,7 @@ import com.gu.facia.client.models.FrontJson
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 
-class FrontTest extends FreeSpec with ShouldMatchers with MockitoSugar with OneInstancePerTest {
+class FrontTest extends FreeSpec with Matchers with MockitoSugar with OneInstancePerTest {
   "fromFrontJson" - {
     "when generating the canonical field" - {
       val frontJson = FrontJson(

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ContainerBrandingFinderTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ContainerBrandingFinderTest.scala
@@ -1,0 +1,159 @@
+package com.gu.facia.api.utils
+
+import com.gu.facia.api.TestModel.{getContentItem, getTag}
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.facia.api.models.CollectionConfig
+import com.gu.facia.client.models.Branded
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import com.gu.commercial.branding.{Branding, BrandingFinder, Sponsored, Logo, PaidMultiSponsorBranding}
+import com.gu.facia.api.utils.ContainerBrandingFinder._
+
+class ContainerBrandingFinderTest extends FlatSpec with Matchers with OptionValues {
+
+  private def getTagBrandedItem = getContentItem("TagBrandedContent.json")
+  private def getMultipleTagBrandedItem = getContentItem("TagBrandedContent-MultipleBrands.json")
+  private def getSectionBrandedItem = getContentItem("SectionBrandedContent.json")
+  private def getAfterDateTargetedTagBrandedItem = getContentItem("AfterDateTargetedTagBrandedContent.json")
+  private def getInappropriateItem = getContentItem("InappropriateContent.json")
+  private def getPaidItem = getContentItem("PaidContent.json")
+  private def getFoundationTag = getTag("FoundationTag.json")
+  private def getFoundationTag2 = getTag("FoundationTag2.json")
+  private def getPaidTag = getTag("PaidTag.json")
+  private def getPaidTag2 = getTag("PaidTag2.json")
+  private def getSeriesTag = getTag("SeriesTag.json")
+
+  private val brandedContainerConfig = CollectionConfig.empty.copy(metadata = Some(List(Branded)))
+
+  "findBranding: content" should "give branding if all items in set have same branding" in {
+    val items = Set(
+      getTagBrandedItem,
+      getMultipleTagBrandedItem
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items)
+    branding.value should be(
+      Branding(
+        brandingType = Sponsored,
+        sponsorName = "Fairtrade Foundation",
+        logo = Logo(
+          src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          dimensions = None,
+          link = "http://www.fairtrade.org.uk/",
+          label = "Supported by"
+        ),
+        logoForDarkBackground = None,
+        aboutThisLink = "https://www.theguardian.com/uk",
+        hostedCampaignColour = None
+      ))
+  }
+
+  it should "give no branding if any item in set has different branding" in {
+    val items = Set(
+      getTagBrandedItem,
+      getSectionBrandedItem
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items)
+    branding should be(None)
+  }
+
+  it should "give no branding if any item in set has no branding" in {
+    val items = Set(
+      getTagBrandedItem,
+      getMultipleTagBrandedItem,
+      getInappropriateItem
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items)
+    branding should be(None)
+  }
+
+  it should "give no branding for an empty set" in {
+    val branding = findBranding(brandedContainerConfig, "uk", Set.empty[Content])
+    branding should be(None)
+  }
+
+  it should "give no branding for a container without branded config" in {
+    val items = Set(
+      getTagBrandedItem,
+      getMultipleTagBrandedItem
+    )
+    val branding = findBranding(CollectionConfig.empty, "uk", items)
+    branding should be(None)
+  }
+
+  it should "give paid container branding for a multi-sponsor paid container" in {
+    val items = Set(
+      getAfterDateTargetedTagBrandedItem,
+      getPaidItem
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items)
+    branding.value should be(PaidMultiSponsorBranding)
+  }
+
+  "findBranding: tags" should "give branding if all tags have same branding" in {
+    val tags = Set(
+      getFoundationTag,
+      getFoundationTag2
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items = Set.empty, tags)
+    branding.value should be(
+      Branding(
+        brandingType = Sponsored,
+        sponsorName = "Fairtrade Foundation",
+        logo = Logo(
+          src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          dimensions = None,
+          link = "http://www.fairtrade.org.uk/",
+          label = "Supported by"
+        ),
+        logoForDarkBackground = None,
+        aboutThisLink = "https://www.theguardian.com/uk",
+        hostedCampaignColour = None
+      )
+    )
+  }
+
+  it should "give no branding if any tag in set has no branding" in {
+    val tags = Set(
+      getFoundationTag,
+      getSeriesTag
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items = Set.empty, tags)
+    branding should be(None)
+  }
+
+  it should "give paid container branding for a multi-sponsor paid container full of tags" in {
+    val tags = Set(
+      getPaidTag,
+      getPaidTag2
+    )
+    val branding = findBranding(brandedContainerConfig, "uk", items = Set.empty, tags)
+    branding.value should be(PaidMultiSponsorBranding)
+  }
+
+  "findBranding: mixed" should "give branding if all tags and content in set have same branding" in {
+    val items = Set(getTagBrandedItem)
+    val tags = Set(getFoundationTag)
+    val branding = findBranding(brandedContainerConfig, "uk", items, tags)
+    branding.value should be(
+      Branding(
+        brandingType = Sponsored,
+        sponsorName = "Fairtrade Foundation",
+        logo = Logo(
+          src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          dimensions = None,
+          link = "http://www.fairtrade.org.uk/",
+          label = "Supported by"
+        ),
+        logoForDarkBackground = None,
+        aboutThisLink = "https://www.theguardian.com/uk",
+        hostedCampaignColour = None
+      )
+    )
+  }
+
+  "findBranding: mixed" should "give paid container branding for a multi-sponsor paid container holding a combination of tags and content" in {
+    val items = Set(getPaidItem)
+    val tags = Set(getPaidTag, getPaidTag2)
+    val branding = findBranding(brandedContainerConfig, "uk", items, tags)
+    branding.value should be(PaidMultiSponsorBranding)
+  }
+}

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -5,11 +5,11 @@ import com.gu.facia.api.models.CollectionConfig
 import com.gu.facia.client.models.{CollectionConfigJson, TrailMetaData}
 import org.mockito.Mockito
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{OneInstancePerTest, OptionValues, ShouldMatchers, FreeSpec}
+import org.scalatest.{OneInstancePerTest, OptionValues, Matchers, FreeSpec}
 import org.mockito.Mockito._
 
 
-class ItemKickerTest extends FreeSpec with ShouldMatchers with MockitoSugar with OptionValues with OneInstancePerTest {
+class ItemKickerTest extends FreeSpec with Matchers with MockitoSugar with OptionValues with OneInstancePerTest {
   val trailMetadata = Mockito.spy(TrailMetaData.empty)
   val content = mock[Content]
   val collectionConfig = Mockito.spy(CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
   val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"
   val playJson26 = "com.typesafe.play" %% "play-json" % "2.6.3"
-  val scalaTest = "org.scalatest" %% "scalatest" % "2.2.5" % "test"
-  val specs2 = "org.specs2" %% "specs2" % "3.7" % "test"
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0"
-  val commercialShared = "com.gu" %% "commercial-shared" % "4.0.1"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  val specs2 = "org.specs2" %% "specs2-core" % "4.0.0" % "test"
+  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
+  val commercialShared = "com.gu" %% "commercial-shared" % "6.1.2"
 }


### PR DESCRIPTION
This PR is also bringing `ContainerBrandingFinder` into `fapi-client` since it has been removed from the latest version of `commercial-shared` (6.1.2)