### PR TITLE
Sbt 1.0 and crossScalaVersions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,8 @@ name := "facia-api-client"
 
 description := "Scala client for The Guardian's Facia JSON API"
 
-scalaVersion := "2.11.11"
-scalaVersion in ThisBuild := "2.11.11"
-
-val buildCrossList = Seq("2.11.11", "2.12.4")
-releaseCrossBuild := true
+val scala211 = "2.11.11"
+val scala212 = "2.12.4"
 
 val sonatypeReleaseSettings = Seq(
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -76,12 +73,14 @@ lazy val faciaJson = project.in(file("facia-json"))
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211),
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
       specs2,
-      playJson,
+      playJson24,
       scalaLogging
     ),
     publishArtifact := true
@@ -98,6 +97,8 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211),
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       awsSdk,
@@ -120,8 +121,10 @@ lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211, scala212),
+    releaseCrossBuild := true,
     scalacOptions := Seq("-feature", "-deprecation"),
-    crossScalaVersions := buildCrossList,
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
@@ -143,6 +146,8 @@ lazy val fapiClient = project.in(file("fapi-client"))
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211),
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
@@ -165,6 +170,8 @@ lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211),
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
@@ -187,7 +194,9 @@ lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
-    crossScalaVersions := buildCrossList,
+    scalaVersion := scala211,
+    crossScalaVersions:= Seq(scala211, scala212),
+    releaseCrossBuild := true,
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.3

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
   val contentApi = "com.gu" %% "content-api-client" % "11.33"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
-  val playJson = "com.typesafe.play" %% "play-json" % "2.4.6"
+  val playJson24 = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"
   val playJson26 = "com.typesafe.play" %% "play-json" % "2.6.3"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 


### PR DESCRIPTION
Upgrade to sbt 1.0
An issue in sbt 0.13.5 prevented us to crosscompile some libs aggregated
in a root project (See: sbt/sbt#1448)
This issue has been fixed in sbt 1.0 (See: sbt/sbt#3698)

Also explicitely set scalaVersion and crossScalaVersions on every project