### PR TITLE
Add platform field to collection model

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -54,6 +54,28 @@ object Metadata extends StrictLogging {
   }
 }
 
+sealed trait CollectionPlatform
+case object AnyPlatform extends CollectionPlatform
+case object WebCollection extends CollectionPlatform
+case object AppCollection extends CollectionPlatform
+
+object CollectionPlatform {
+  implicit object CollectionPlatformFormat extends Format[CollectionPlatform] {
+    def reads(json: JsValue) = json match {
+      case JsString("Web") => JsSuccess(WebCollection)
+      case JsString("App") => JsSuccess(AppCollection)
+      case JsString("Any") => JsSuccess(AnyPlatform)
+      case other => JsError(s"Could not deserialize to a CollectionPlatform type: $other")
+    }
+
+    def writes(platform: CollectionPlatform): JsString = platform match {
+      case AnyPlatform => JsString("Any")
+      case WebCollection => JsString("Web")
+      case AppCollection => JsString("App")
+    }
+  }
+}
+
 object DisplayHintsJson {
   implicit val jsonFormat = Json.format[DisplayHintsJson]
 }
@@ -82,7 +104,8 @@ object CollectionConfigJson {
     excludeFromRss: Option[Boolean] = None,
     showTimestamps: Option[Boolean] = None,
     hideShowMore: Option[Boolean] = None,
-    displayHints: Option[DisplayHintsJson] = None
+    displayHints: Option[DisplayHintsJson] = None,
+    platform: Option[CollectionPlatform] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -101,7 +124,8 @@ object CollectionConfigJson {
     excludeFromRss,
     showTimestamps,
     hideShowMore,
-    displayHints
+    displayHints,
+    platform
   )
 }
 
@@ -122,7 +146,8 @@ case class CollectionConfigJson(
   excludeFromRss: Option[Boolean],
   showTimestamps: Option[Boolean],
   hideShowMore: Option[Boolean],
-  displayHints: Option[DisplayHintsJson]
+  displayHints: Option[DisplayHintsJson],
+  platform: Option[CollectionPlatform]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.models
 
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, DisplayHintsJson, Metadata}
+import com.gu.facia.client.models.{Backfill, CollectionConfigJson, CollectionPlatform, AnyPlatform, DisplayHintsJson, Metadata}
 
 case class Groups(groups: List[String])
 
@@ -28,7 +28,8 @@ case class CollectionConfig(
     excludeFromRss: Boolean,
     showTimestamps: Boolean,
     hideShowMore: Boolean,
-    displayHints: Option[DisplayHints])
+    displayHints: Option[DisplayHints],
+    platform: CollectionPlatform = AnyPlatform)
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-VI"
@@ -50,7 +51,8 @@ object CollectionConfig {
     excludeFromRss = false,
     showTimestamps = false,
     hideShowMore = false,
-    displayHints = None)
+    displayHints = None,
+    platform = AnyPlatform)
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -70,5 +72,6 @@ object CollectionConfig {
       collectionJson.excludeFromRss.exists(identity),
       collectionJson.showTimestamps.exists(identity),
       collectionJson.hideShowMore.exists(identity),
-      collectionJson.displayHints.map(DisplayHints.fromDisplayHintsJson))
+      collectionJson.displayHints.map(DisplayHints.fromDisplayHintsJson),
+      collectionJson.platform.getOrElse(AnyPlatform))
 }


### PR DESCRIPTION
The fronts tool will soon be able to create collections that are app-only and web-only.
If the `platform` field is not set then collections are considered `AnyPlatform` by default.