### PR TITLE
Remove leading slash from capi id

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -49,7 +49,7 @@ object ContentApi extends StrictLogging {
 
   def buildBackfillQuery(apiQuery: String): Either[ItemQuery, SearchQuery] = {
     val uri = new URI(apiQuery.replaceAllLiterally("|", "%7C").replaceAllLiterally(" ", "%20"))
-    val path = uri.getPath
+    val path = uri.getPath.stripPrefix("/")
     val rawParams = Option(uri.getQuery).map(parseQueryString).getOrElse(Nil).map {
       // wrap backfill tags in parentheses in case the editors wrote a raw OR query
       // makes it possible to safely append additional tags

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -1,5 +1,7 @@
 package com.gu.facia.api.contentapi
 
+import java.net.URI
+
 import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.model.v1.{Content, ItemResponse, SearchResponse, Tag}
 import com.gu.contentapi.client.{ContentApiClientLogic, GuardianContentClient}
@@ -95,6 +97,10 @@ class ContentApiTest extends FreeSpec
       "will force editors picks to false if they are explicitly included on the query" in {
         val backfill = "lifeandstyle/food-and-drink?show-most-viewed=true&show-editors-picks=true&hide-recent-content=true"
         ContentApi.buildBackfillQuery(backfill).left.value.parameters.get("show-editors-picks").value should equal ("false")
+      }
+
+      "should trim slash" in {
+        ContentApi.buildBackfillQuery(s"/$backfill").left.value.pathSegment should equal (new URI(backfill).getPath)
       }
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -15,7 +15,7 @@ import play.api.libs.json.{JsArray, JsString, Json}
 
 // TODO: reinstate ignored tests when cmsFronts account has access to test fixtures
 class IntegrationTest extends FreeSpec with Matchers with ScalaFutures with OptionValues with IntegrationTestConfig {
-  implicit val patience = PatienceConfig(Span(5, Seconds), Span(50, Millis))
+  implicit val patience = PatienceConfig(Span(20, Seconds), Span(50, Millis))
 
   def makeCollectionJson(trails: Trail*) = CollectionJson(
     live = trails.toList,


### PR DESCRIPTION
Users sometimes add capi backfill paths with a leading-slash, and facia-tool allows this. This breaks requests to capi preview because it creates urls with a double slash in the path, and this causes issues with api-gateway authorisation.

I'm fixing it here because it's used by both facia-press and mapi, and it's too late to fix it in facia-tool.