### PR TITLE
Bump capi client

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -127,6 +127,8 @@ object TestModel {
     def charCount: Option[Int] = None
     def internalVideoCode: Option[String] = None
     def shouldHideReaderRevenue: Option[Boolean] = None
+    def internalCommissionedWordcount: Option[Int] = None
+    def showAffiliateLinks: Option[Boolean] = None
   }
   implicit val stubFieldsFormat = Json.reads[StubFields]
 
@@ -196,6 +198,8 @@ object TestModel {
     def debug: Option[Debug] = None
     def isGone: Option[Boolean] = None
     def isHosted: Boolean = false
+    def pillarId: Option[String] = None
+    def pillarName: Option[String] = None
   }
   implicit val stubItemFormat = Json.reads[StubItem]
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.154"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "11.33"
+  val contentApi = "com.gu" %% "content-api-client" % "11.55"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson24 = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"


### PR DESCRIPTION
And fix compilation errors.

This is because the newest scala client breaks compilation compatibility with the one imported here.
Recompiling and republishing the library should be enough to fix the runtime error I'm observing in MAPI