### PR TITLE
Upgrade to CAPI Scala client v12

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-#### 2.5.5
+#### 2.6
   
   - Upgrade Content API dependency to `12.0`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 2.5.5
+  
+  - Upgrade Content API dependency to `12.0`
+
 #### 2.4
   
   - Upgrade Content API dependency to `11.33`

--- a/build.sbt
+++ b/build.sbt
@@ -154,6 +154,7 @@ lazy val fapiClient = project.in(file("fapi-client"))
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
+      contentApiDefault,
       commercialShared,
       scalaTest,
       mockito
@@ -178,6 +179,7 @@ lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
+      contentApiDefault,
       commercialShared,
       scalaTest,
       mockito
@@ -203,6 +205,7 @@ lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
+      contentApiDefault,
       commercialShared,
       scalaTest,
       mockito

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api
 
-import com.gu.contentapi.client.ContentApiClientLogic
+import com.gu.contentapi.client.ContentApiClient
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.ContentApi.{AdjustItemQuery, AdjustSearchQuery}
 import com.gu.facia.api.contentapi.{ContentApi, LatestSnapsRequest, LinkSnapsRequest}
@@ -12,13 +12,13 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 object FAPI {
-  def getFronts()(implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[Set[Front]] = {
+  def getFronts()(implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[Set[Front]] = {
     for {
       config <- Response.Async.Right(faciaClient.config)
     } yield Front.frontsFromConfig(config)
   }
 
-  def frontForPath(path: String)(implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[Front] = {
+  def frontForPath(path: String)(implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[Front] = {
     for {
       fronts <- getFronts
       front <- Response.fromOption(fronts.find(_.id == path), NotFound(s"Not front found for $path"))
@@ -30,7 +30,7 @@ object FAPI {
    * and the collection's own config JSON.
    */
   def getCollection(collectionId: String)
-                   (implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[Collection] = {
+                   (implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[Collection] = {
     val fCollectionJson = faciaClient.collection(collectionId)
     val fConfigJson = faciaClient.config
     for {
@@ -47,7 +47,7 @@ object FAPI {
    * Fetch all the collections for a front in one go
    */
   def frontCollections(frontId: String)
-                      (implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[List[Collection]] = {
+                      (implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[Collection]] = {
     for {
       configJson <- Response.Async.Right(faciaClient.config)
       frontJson <- Response.fromOption(configJson.fronts.get(frontId), NotFound(s"No front found for $frontId"))
@@ -65,7 +65,7 @@ object FAPI {
   }
 
   private def getLiveContentForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                                   (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[Set[Content]] = {
+                                   (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[Set[Content]] = {
     val itemIdsForRequest = Collection.liveIdsWithoutSnaps(collection)
     val supportingIdsForRequest = Collection.liveSupportingIdsWithoutSnaps(collection)
     val allItemIdsForRequest = itemIdsForRequest ::: supportingIdsForRequest
@@ -77,7 +77,7 @@ object FAPI {
   }
 
   private def getDraftContentForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                                   (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[Set[Content]] = {
+                                   (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[Set[Content]] = {
     val itemIdsForRequest =
       Collection.draftIdsWithoutSnaps(collection)
         .getOrElse(Collection.liveIdsWithoutSnaps(collection))
@@ -93,7 +93,7 @@ object FAPI {
   }
 
   private def getLiveLatestSnapContentForCollection(collection: Collection, adjustItemQuery: AdjustItemQuery)
-                      (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext) = {
+                      (implicit capiClient: ContentApiClient, ec: ExecutionContext) = {
     val latestSnapsRequest: LatestSnapsRequest = Collection.liveLatestSnapsRequestFor(collection)
     val latestSupportingSnaps: LatestSnapsRequest = Collection.liveSupportingSnaps(collection)
     val allSnaps = latestSnapsRequest.join(latestSupportingSnaps)
@@ -101,7 +101,7 @@ object FAPI {
       yield snapContent}
 
   private def getDraftLatestSnapContentForCollection(collection: Collection, adjustItemQuery: AdjustItemQuery)
-                      (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
+                      (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[Map[String, Option[Content]]] = {
     val latestSnapsRequest: LatestSnapsRequest =
       Collection.draftLatestSnapsRequestFor(collection)
         .getOrElse(Collection.liveLatestSnapsRequestFor(collection))
@@ -114,14 +114,14 @@ object FAPI {
 
   private def getLiveLinkSnapBrandingsForCollection(collection: Collection)
     (
-      implicit capiClient: ContentApiClientLogic,
+      implicit capiClient: ContentApiClient,
       ec: ExecutionContext
     ): Response[Map[String, BrandingByEdition]] =
     getLinkSnapBrandings(Collection.liveLinkSnapsRequestFor(collection))
 
   private def getDraftLinkSnapBrandingsForCollection(collection: Collection)
     (
-      implicit capiClient: ContentApiClientLogic,
+      implicit capiClient: ContentApiClient,
       ec: ExecutionContext
     ): Response[Map[String, BrandingByEdition]] =
     getLinkSnapBrandings(
@@ -129,12 +129,12 @@ object FAPI {
     )
 
   private def getLinkSnapBrandings(request: LinkSnapsRequest)(
-    implicit capiClient: ContentApiClientLogic, ec: ExecutionContext
+    implicit capiClient: ContentApiClient, ec: ExecutionContext
   ): Response[Map[String, BrandingByEdition]] =
     for (snapContent <- ContentApi.linkSnapBrandingsByEdition(capiClient, request)) yield snapContent
 
   def getTreatsForCollection(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-                            (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext) = {
+                            (implicit capiClient: ContentApiClient, ec: ExecutionContext) = {
     val (treatIds, treatsSnapsRequest) = Collection.treatsRequestFor(collection)
       for {
         hydrateQueries <- ContentApi.buildHydrateQueries(capiClient, treatIds, adjustSearchQuery)
@@ -145,14 +145,14 @@ object FAPI {
   }
 
   def liveCollectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                                (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[List[FaciaContent]] = {
+                                (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     val collectionWithoutSnaps = Collection.withoutSnaps(collection)
     for(setOfContent <- getLiveContentForCollection(collection, adjustSearchQuery))
       yield Collection.liveContent(collectionWithoutSnaps, setOfContent)
   }
 
   def liveCollectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
-                                   (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[List[FaciaContent]] = {
+                                   (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     for {
       setOfContent <- getLiveContentForCollection(collection, adjustSearchQuery)
       snapContent <- getLiveLatestSnapContentForCollection(collection, adjustSnapItemQuery)
@@ -161,14 +161,14 @@ object FAPI {
   }
 
   def draftCollectionContentWithoutSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity)
-                                (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[List[FaciaContent]] = {
+                                (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     val collectionWithoutSnaps = Collection.withoutSnaps(collection)
     for(setOfContent <- getDraftContentForCollection(collection, adjustSearchQuery))
       yield Collection.draftContent(collectionWithoutSnaps, setOfContent)
   }
 
   def draftCollectionContentWithSnaps(collection: Collection, adjustSearchQuery: AdjustSearchQuery = identity, adjustSnapItemQuery: AdjustItemQuery = identity)
-                                   (implicit capiClient: ContentApiClientLogic, ec: ExecutionContext): Response[List[FaciaContent]] = {
+                                   (implicit capiClient: ContentApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     for {
       setOfContent <- getDraftContentForCollection(collection, adjustSearchQuery)
       snapContent <- getDraftLatestSnapContentForCollection(collection, adjustSnapItemQuery)
@@ -183,7 +183,7 @@ object FAPI {
     */
   def backfillFromConfig(collectionConfig: CollectionConfig,
                          adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-                        (implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+                        (implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
 
     val backfillRequest = BackfillResolver.resolveFromConfig(collectionConfig)
     BackfillResolver.backfill(backfillRequest, adjustSearchQuery, adjustItemQuery)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.utils
 
-import com.gu.contentapi.client.ContentApiClientLogic
+import com.gu.contentapi.client.ContentApiClient
 import com.gu.facia.api.contentapi.ContentApi
 import com.gu.facia.api.contentapi.ContentApi._
 import com.gu.facia.api.models.{CollectionConfig, CuratedContent, FaciaContent}
@@ -28,7 +28,7 @@ object BackfillResolver {
   }
 
   def backfill(resolver: BackfillResolver, adjustSearchQuery: AdjustSearchQuery = identity, adjustItemQuery: AdjustItemQuery = identity)
-              (implicit capiClient: ContentApiClientLogic, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
+              (implicit capiClient: ContentApiClient, faciaClient: ApiClient, ec: ExecutionContext): Response[List[FaciaContent]] = {
     resolver match {
       case CapiBackfill(query, collectionConfig) =>
         val capiQuery = ContentApi.buildBackfillQuery(query)

--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -127,6 +127,8 @@ object TestModel {
     def charCount: Option[Int] = None
     def internalVideoCode: Option[String] = None
     def shouldHideReaderRevenue: Option[Boolean] = None
+    def internalCommissionedWordcount: Option[Int] = None
+    def showAffiliateLinks: Option[Boolean] = None
   }
   implicit val stubFieldsFormat = Json.reads[StubFields]
 
@@ -196,6 +198,8 @@ object TestModel {
     def debug: Option[Debug] = None
     def isGone: Option[Boolean] = None
     def isHosted: Boolean = false
+    def pillarId: Option[String] = None
+    def pillarName: Option[String] = None
   }
   implicit val stubItemFormat = Json.reads[StubItem]
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -4,7 +4,7 @@ import java.net.URI
 
 import com.gu.contentapi.client.model.ItemQuery
 import com.gu.contentapi.client.model.v1.{Content, ItemResponse, SearchResponse, Tag}
-import com.gu.contentapi.client.{ContentApiClientLogic, GuardianContentClient}
+import com.gu.contentapi.client.{ContentApiClient, GuardianContentClient}
 import com.gu.facia.api.Response
 import lib.ExecutionContext
 import org.mockito.Mockito._
@@ -146,7 +146,7 @@ class ContentApiTest extends FreeSpec
 
   "linkSnapBrandingsByEdition" - {
 
-    def capiClient(id: String): ContentApiClientLogic = {
+    def capiClient(id: String): ContentApiClient = {
       val query = ItemQuery(id)
 
       val tag = mock[Tag]
@@ -156,8 +156,8 @@ class ContentApiTest extends FreeSpec
       when(response.section) thenReturn None
       when(response.tag) thenReturn Some(tag)
 
-      val capiClient = mock[ContentApiClientLogic]
-      when(capiClient.item(id)) thenReturn query
+      val capiClient = mock[ContentApiClient]
+      when(ContentApiClient.item(id)) thenReturn query
       when(capiClient.getResponse(query.pageSize(1))) thenReturn Future.successful(response)
 
       capiClient
@@ -189,7 +189,7 @@ class ContentApiTest extends FreeSpec
     }
 
     "will not make capi request for an external link" in {
-      val capiClient = mock[ContentApiClientLogic]
+      val capiClient = mock[ContentApiClient]
       val request = LinkSnapsRequest(Map("trailId" -> "http://www.bbc.co.uk/news/election-2017-39966615"))
       ContentApi.linkSnapBrandingsByEdition(capiClient, request).asFuture.futureValue.fold(
         err => fail(s"expected brandings result, got error $err"),
@@ -198,7 +198,7 @@ class ContentApiTest extends FreeSpec
     }
 
     "will not make capi request for a link to a tag combiner" in {
-      val capiClient = mock[ContentApiClientLogic]
+      val capiClient = mock[ContentApiClient]
       val request = LinkSnapsRequest(Map("trailId" -> "/world/asia-pacific+world/south-and-central-asia"))
       ContentApi.linkSnapBrandingsByEdition(capiClient, request).asFuture.futureValue.fold(
         err => fail(s"expected brandings result, got error $err"),

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,8 @@ import sbt._
 object Dependencies {
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.154"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "11.33"
+  val contentApi = "com.gu" %% "content-api-client" % "12.0"
+  val contentApiDefault = "com.gu" %% "content-api-client-default" % "12.0" % "test"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson24 = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"


### PR DESCRIPTION
There has been several breaking changes in v12:

- the default http client has been moved into a separate project (`content-api-client-default`), users must either switch to that package or provide their own implementation (see [here](https://github.com/guardian/content-api-scala-client/blob/master/README.md))
- `ContentApiClientLogic` has become `ContentApiClient`
- utility functions have moved to the companion of that trait
