### PR TITLE
Bump capi to 12.7

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -34,7 +34,7 @@ object ContentApi extends StrictLogging {
   }
 
   def getHydrateResponse(client: ContentApiClient, searchQueries: Seq[SearchQuery])(implicit ec: ExecutionContext): Response[Seq[SearchResponse]] = {
-    Response.Async.Right(Future.traverse(searchQueries)(client.getResponse)) mapError { err =>
+    Response.Async.Right(Future.traverse(searchQueries)(client.getResponse(_))) mapError { err =>
       CapiError(s"Failed to hydrate content ${err.message}", err.cause)
     }
   }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,10 +1,12 @@
 import sbt._
 
 object Dependencies {
+  val capiVersion = "12.7"
+
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.154"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
-  val contentApi = "com.gu" %% "content-api-client" % "12.0"
-  val contentApiDefault = "com.gu" %% "content-api-client-default" % "12.0" % "test"
+  val contentApi = "com.gu" %% "content-api-client" % capiVersion
+  val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % "test"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
   val playJson24 = "com.typesafe.play" %% "play-json" % "2.4.6"
   val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"


### PR DESCRIPTION
The [change](https://github.com/guardian/content-api-scala-client/pull/262/files) to the `getResponse` method in content-api-client means that frontend needs this dependency to be updated at the same time