### PR TITLE
Add tools settings

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -76,6 +76,13 @@ object CollectionPlatform {
   }
 }
 
+object FrontsToolSettings {
+  implicit val jsonFormat = Json.format[FrontsToolSettings]
+}
+
+case class FrontsToolSettings (
+  displayEditWarning: Option[Boolean])
+
 object DisplayHintsJson {
   implicit val jsonFormat = Json.format[DisplayHintsJson]
 }
@@ -105,7 +112,8 @@ object CollectionConfigJson {
     showTimestamps: Option[Boolean] = None,
     hideShowMore: Option[Boolean] = None,
     displayHints: Option[DisplayHintsJson] = None,
-    platform: Option[CollectionPlatform] = None
+    platform: Option[CollectionPlatform] = None,
+    frontsToolSettings: Option[FrontsToolSettings] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -125,7 +133,8 @@ object CollectionConfigJson {
     showTimestamps,
     hideShowMore,
     displayHints,
-    platform
+    platform,
+    frontsToolSettings
   )
 }
 
@@ -147,7 +156,8 @@ case class CollectionConfigJson(
   showTimestamps: Option[Boolean],
   hideShowMore: Option[Boolean],
   displayHints: Option[DisplayHintsJson],
-  platform: Option[CollectionPlatform]
+  platform: Option[CollectionPlatform],
+  frontsToolSettings: Option[FrontsToolSettings]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.models
 
-import com.gu.facia.client.models.{Backfill, CollectionConfigJson, CollectionPlatform, AnyPlatform, DisplayHintsJson, Metadata}
+import com.gu.facia.client.models.{AnyPlatform, Backfill, CollectionConfigJson, CollectionPlatform, DisplayHintsJson, FrontsToolSettings, Metadata}
 
 case class Groups(groups: List[String])
 
@@ -11,6 +11,8 @@ object DisplayHints {
     maxItemsToDisplay = displayHintsJson.maxItemsToDisplay
   )
 }
+
+
 case class CollectionConfig(
     displayName: Option[String],
     backfill: Option[Backfill],
@@ -29,7 +31,8 @@ case class CollectionConfig(
     showTimestamps: Boolean,
     hideShowMore: Boolean,
     displayHints: Option[DisplayHints],
-    platform: CollectionPlatform = AnyPlatform)
+    platform: CollectionPlatform = AnyPlatform,
+    frontsToolSettings: Option[FrontsToolSettings])
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-VI"
@@ -52,7 +55,8 @@ object CollectionConfig {
     showTimestamps = false,
     hideShowMore = false,
     displayHints = None,
-    platform = AnyPlatform)
+    platform = AnyPlatform,
+    frontsToolSettings = None)
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -73,5 +77,6 @@ object CollectionConfig {
       collectionJson.showTimestamps.exists(identity),
       collectionJson.hideShowMore.exists(identity),
       collectionJson.displayHints.map(DisplayHints.fromDisplayHintsJson),
-      collectionJson.platform.getOrElse(AnyPlatform))
+      collectionJson.platform.getOrElse(AnyPlatform),
+      collectionJson.frontsToolSettings)
 }


### PR DESCRIPTION
Adds a new tool settings field for collection config values which are only used by the fronts tool internally. This allows us to add the `displayEditWarning` to the collection config in the fronts tool.