### PR TITLE
Fix Podcast kicker

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
@@ -10,7 +10,7 @@ object ContentApiUtils {
     private def tagsOfType(tagType: TagType): Seq[Tag] = content.tags.filter(_.`type` == tagType)
 
     lazy val keywords: Seq[Tag] = tagsOfType(TagType.Keyword)
-    lazy val nonKeywordTags: Seq[Tag] = content.tags.filterNot(_.`type` == "keyword")
+    lazy val nonKeywordTags: Seq[Tag] = content.tags.filterNot(_.`type` == TagType.Keyword)
     lazy val contributors: Seq[Tag] = tagsOfType(TagType.Contributor)
     lazy val isContributorPage: Boolean = contributors.nonEmpty
     lazy val series: Seq[Tag] = tagsOfType(TagType.Series)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -1,6 +1,6 @@
 package com.gu.facia.api.utils
 
-import com.gu.contentapi.client.model.v1.{ContentFields, Element, Tag, Content}
+import com.gu.contentapi.client.model.v1._
 import com.gu.facia.api.models._
 import org.joda.time.DateTime
 
@@ -195,13 +195,13 @@ object FaciaContentUtils {
     linkSnap => linkSnap.properties.showByline,
     latestSnap => latestSnap.properties.showByline)
 
-  private def tagsOfType(fc: FaciaContent)(tagType: String): Seq[Tag] = tags(fc).filter(_.`type` == tagType)
-  def nonKeywordTags(fc: FaciaContent): Seq[Tag] = tags(fc).filterNot(_.`type` == "keyword")
-  def keywords(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("keyword")
-  def series(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("series")
-  def blogs(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("blog")
-  def tones(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("tone")
-  def types(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)("type")
+  private def tagsOfType(fc: FaciaContent)(tagType: TagType): Seq[Tag] = tags(fc).filter(_.`type` == tagType)
+  def nonKeywordTags(fc: FaciaContent): Seq[Tag] = tags(fc).filterNot(_.`type` == TagType.Keyword)
+  def keywords(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)(TagType.Keyword)
+  def series(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)(TagType.Series)
+  def blogs(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)(TagType.Blog)
+  def tones(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)(TagType.Tone)
+  def types(fc: FaciaContent): Seq[Tag] = tagsOfType(fc)(TagType.Type)
 
   def contributors(fc: FaciaContent): Seq[Tag] = maybeContent(fc).map(_.contributors).getOrElse(Nil)
   def isContributorPage(fc: FaciaContent): Boolean = maybeContent(fc).exists(_.contributors.nonEmpty)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -64,7 +64,7 @@ object ItemKicker {
     if (content.fields.flatMap(_.liveBloggingNow).exists(identity)) {
       Some(LiveKicker)
     } else if (isPodcast) {
-      val series = content.tags.find(_.`type` == "series") map { seriesTag =>
+      val series = content.tags.find(_.`type` == TagType.Series) map { seriesTag =>
         Series(seriesTag.webTitle, seriesTag.webUrl)
       }
       Some(PodcastKicker(series))


### PR DESCRIPTION
The result of this change will be that podcasts with series tags will display a kicker in mobile apps.  This is particularly desired for the "Today in Focus" series.

The `type` field on `Tag` is now a TagType, and stringifies to "Series" so "series" doesn't match.

As part of this PR I've removed any other string comparisons based on tag `type` that I could find.