### PR TITLE
Update CAPI client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+#### 2.6.8
+
+  - CAPI client update: brings it up to date with other libraries to avoid inconsistencies and fix a leaking dependency version mismatch
+
 #### 2.6.7
 
   - Bug fix: Compare tag `type` field with `TagType`s rather than `String`s

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ lazy val faciaJson = project.in(file("facia-json"))
     organization := "com.gu",
     name := "facia-json",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
@@ -99,6 +100,7 @@ lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
     name := "facia-json-play25",
     sourceDirectory := baseDirectory.value / "../facia-json/src",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
@@ -122,6 +124,7 @@ lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
     name := "facia-json-play26",
     sourceDirectory := baseDirectory.value / "../facia-json/src",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
@@ -145,6 +148,7 @@ lazy val fapiClient = project.in(file("fapi-client"))
     organization := "com.gu",
     name := "fapi-client",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
@@ -170,6 +174,7 @@ lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
     name := "fapi-client-play25",
     sourceDirectory := baseDirectory.value / "../fapi-client/src",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
@@ -195,6 +200,7 @@ lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
     name := "fapi-client-play26",
     sourceDirectory := baseDirectory.value / "../fapi-client/src",
     resolvers ++= Seq(
+      Resolver.sonatypeRepo("releases"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"

--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -84,6 +84,7 @@ object TestModel {
     def standfirst: Option[String] = None
     def trailText: Option[String] = None
     def byline: Option[String] = None
+    def bylineHtml: Option[String] = None
     def main: Option[String] = None
     def body: Option[String] = None
     def newspaperPageNumber: Option[Int] = None
@@ -160,6 +161,7 @@ object TestModel {
     def entityIds: Option[scala.collection.Set[String]] = None
     def tagCategories: Option[scala.collection.Set[String]] = None
     def campaignInformationType: Option[String] = None
+    def internalName: Option[String] = None
   }
   implicit val stubTagFormat = Json.reads[StubTag]
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "12.10"
+  val capiVersion = "12.18"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.154"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
Updates to v12.18, which includes an [important fix to content-atom](https://github.com/guardian/content-atom/pull/128).

This brings several updates to the model, plus an important change where a transitive dependency with a wrong version leaked downstream.