### PR TITLE
Map edition priorities to training priorities

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -34,6 +34,7 @@ object Front {
       case Some("commercial") => CommercialPriority
       case Some("training") => TrainingPriority
       case Some("email") => EmailPriority
+      case Some("edition") => TrainingPriority
       case _ => EditorialPriority}
 
   private def getImageUrl(frontJson: FrontJson): Option[FrontImage] =


### PR DESCRIPTION
Map new editions front priorities to training priorities to avoid them from being pressed at editions schedules.