### PR TITLE
Fixes #218: populates displayName from collectionConfig

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -23,8 +23,8 @@ object Collection {
   def fromCollectionJsonConfigAndContent(collectionId: String, collectionJson: Option[CollectionJson], collectionConfig: CollectionConfig): Collection = {
     Collection(
       collectionId,
-      collectionJson.flatMap(_.displayName).orElse(collectionConfig.displayName).getOrElse("untitled"),
-      collectionJson.flatMap(_.href).orElse(collectionConfig.href),
+      collectionConfig.displayName.orElse(collectionJson.flatMap(_.displayName)).getOrElse("untitled"),
+      collectionConfig.href.orElse(collectionJson.flatMap(_.href)),
       collectionJson.map(_.live).getOrElse(Nil),
       collectionJson.flatMap(_.draft),
       collectionJson.flatMap(_.treats).getOrElse(Nil),

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -126,7 +126,7 @@ class CollectionTest extends FreeSpec with Matchers with MockitoSugar with OneIn
       collection should have(
         'id("id"),
         'draft(None),
-        'href(Some("collectionHref")),
+        'href(Some("collectionConfigHref")),
         'lastUpdated(Some(new DateTime(1))),
         'updatedBy(Some("test")),
         'updatedEmail(Some("test@example.com")),


### PR DESCRIPTION
@rtyley and I have discussed this with @Reettaphant, and have agreed that we should be checking the `collectionConfig` first for the `displayName` and `href`. It seems that neither of these fields are being written into collection content any more - they are only configured through collection config. 

cc @jonathonherbert 