### PR TITLE
Remove Scala 2.11 and Play 2.5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,9 +11,9 @@ easily-used types.
 
 ### Adding the dependency to SBT
 
-Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
+Add the following line to your [SBT build file](https://www.scala-sbt.org/1.0/docs/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "fapi-client" % "1.5.3"
+    libraryDependencies += "com.gu" %% "fapi-client-play26" % "3.0.2"
 
 ### Using the library
 
@@ -33,9 +33,9 @@ This library provides underlying behaviour for the main Fronts API client.
 
 ### Adding the dependency to SBT
 
-Add the following line to your [SBT build file] (http://www.scala-sbt.org/0.13.5/docs/Getting-Started/Basic-Def.html):
+Add the following line to your [SBT build file](https://www.scala-sbt.org/1.0/docs/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "facia-json" % "0.65"
+    libraryDependencies += "com.gu" %% "facia-json-play26" % "3.0.2"
 
 ### Making calls to the API
 
@@ -71,11 +71,10 @@ To release a new version of the client:
 
 1. Ensure you have a GPG key listed on a public key server.
 2. Ensure you are registered on Sonatype for Guardian projects.
-3. Open sbt and run the [sbt release](https://github.com/sbt/sbt-release) task, ensuring that the scala version is 2.12:
+3. Open sbt and run the [sbt release](https://github.com/sbt/sbt-release) task:
 
 ```
 $ sbt
-sbt:facia-api-client> ++ 2.12.4
 sbt:facia-api-client> release
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,6 @@ name := "facia-api-client"
 
 description := "Scala client for The Guardian's Facia JSON API"
 
-val scala211 = "2.11.12"
 val scala212 = "2.12.8"
 
 val sonatypeReleaseSettings = Seq(
@@ -59,61 +58,12 @@ val publishSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(faciaJson, faciaJson_play25, faciaJson_play26, fapiClient, fapiClient_play25, fapiClient_play26)
+  .aggregate(faciaJson_play26, fapiClient_play26)
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     publishArtifact := false,
     skip in publish := true
   )
-
-lazy val faciaJson = project.in(file("facia-json"))
-  .settings(
-    organization := "com.gu",
-    name := "facia-json",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211),
-    scalacOptions := Seq("-feature", "-deprecation"),
-    libraryDependencies ++= Seq(
-      awsSdk,
-      commonsIo,
-      specs2,
-      playJson24,
-      scalaLogging
-    ),
-    publishSettings
-  )
-  .settings(sonatypeReleaseSettings: _*)
-
-lazy val faciaJson_play25 = project.in(file("facia-json-play25"))
-  .settings(
-    organization := "com.gu",
-    name := "facia-json-play25",
-    sourceDirectory := baseDirectory.value / "../facia-json/src",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211),
-    scalacOptions := Seq("-feature", "-deprecation"),
-    libraryDependencies ++= Seq(
-      awsSdk,
-      commonsIo,
-      specs2,
-      playJson25,
-      scalaLogging
-    ),
-    publishSettings
-  )
-  .settings(sonatypeReleaseSettings: _*)
 
 lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
   .settings(
@@ -126,9 +76,7 @@ lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211, scala212),
-    releaseCrossBuild := true,
+    scalaVersion := scala212,
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       awsSdk,
@@ -139,59 +87,6 @@ lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
     ),
     publishSettings
   )
-  .settings(sonatypeReleaseSettings: _*)
-
-lazy val fapiClient = project.in(file("fapi-client"))
-  .settings(
-    organization := "com.gu",
-    name := "fapi-client",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211),
-    scalacOptions := Seq("-feature", "-deprecation"),
-    libraryDependencies ++= Seq(
-      contentApi,
-      contentApiDefault,
-      commercialShared,
-      scalaTest,
-      mockito
-    ),
-    publishSettings
-  )
-  .dependsOn(faciaJson)
-  .settings(sonatypeReleaseSettings: _*)
-
-lazy val fapiClient_play25 = project.in(file("fapi-client-play25"))
-  .settings(
-    organization := "com.gu",
-    name := "fapi-client-play25",
-    sourceDirectory := baseDirectory.value / "../fapi-client/src",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211),
-    scalacOptions := Seq("-feature", "-deprecation"),
-    libraryDependencies ++= Seq(
-      contentApi,
-      contentApiDefault,
-      commercialShared,
-      scalaTest,
-      mockito
-    ),
-    publishSettings
-  )
-  .dependsOn(faciaJson_play25)
   .settings(sonatypeReleaseSettings: _*)
 
 lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
@@ -206,9 +101,7 @@ lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
       "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
-    scalaVersion := scala211,
-    crossScalaVersions:= Seq(scala211, scala212),
-    releaseCrossBuild := true,
+    scalaVersion := scala212,
     scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,


### PR DESCRIPTION
We only want to release for Scala 2.12 and Play 2.6, and not for any older versions. 