### PR TITLE
Support both play-json v2.6 and v2.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ name := "facia-api-client"
 
 description := "Scala client for The Guardian's Facia JSON API"
 
-val scala212 = "2.12.8"
-
 val sonatypeReleaseSettings = Seq(
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
   scmInfo := Some(ScmInfo(
@@ -52,65 +50,63 @@ val sonatypeReleaseSettings = Seq(
   )
 )
 
-val publishSettings = Seq(
-  publishArtifact := true,
-  publishTo := sonatypePublishTo.value
-)
-
-lazy val root = (project in file("."))
-  .aggregate(faciaJson_play26, fapiClient_play26)
-  .settings(sonatypeReleaseSettings: _*)
-  .settings(
+lazy val root = (project in file(".")).aggregate(
+    faciaJson_play26,
+    faciaJson_play27,
+    fapiClient_play26,
+    fapiClient_play27
+  ).settings(
     publishArtifact := false,
-    skip in publish := true
+    skip in publish := true,
+    sonatypeReleaseSettings
   )
 
-lazy val faciaJson_play26 = project.in(file("facia-json-play26"))
+val exactPlayJsonVersions = Map(
+  "26" -> "2.6.13",
+  "27" -> "2.7.4"
+)
+
+def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-play$majorMinorVersion", file(s"$module-play$majorMinorVersion"))
   .settings(
+    sourceDirectory := baseDirectory.value / s"../$module/src",
     organization := "com.gu",
-    name := "facia-json-play26",
-    sourceDirectory := baseDirectory.value / "../facia-json/src",
     resolvers ++= Seq(
       Resolver.sonatypeRepo("releases"),
       Resolver.sonatypeRepo("public"),
       Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
-    scalaVersion := scala212,
+    scalaVersion := "2.12.8",
     scalacOptions := Seq("-feature", "-deprecation"),
+    publishArtifact := true,
+    publishTo := sonatypePublishTo.value,
+    sonatypeReleaseSettings
+  )
+
+def faciaJson_playJsonVersion(majorMinorVersion: String) = baseProject("facia-json", majorMinorVersion)
+  .settings(
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
       specs2,
-      playJson26,
+      "com.typesafe.play" %% "play-json" % exactPlayJsonVersions(majorMinorVersion),
       scalaLogging
-    ),
-    publishSettings
+    )
   )
-  .settings(sonatypeReleaseSettings: _*)
 
-lazy val fapiClient_play26 = project.in(file("fapi-client-play26"))
+def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-client", majorMinorVersion)
   .settings(
-    organization := "com.gu",
-    name := "fapi-client-play26",
-    sourceDirectory := baseDirectory.value / "../fapi-client/src",
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend",
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
-    scalaVersion := scala212,
-    scalacOptions := Seq("-feature", "-deprecation"),
     libraryDependencies ++= Seq(
       contentApi,
       contentApiDefault,
       commercialShared,
       scalaTest,
       mockito
-    ),
-    publishSettings
+    )
   )
-  .dependsOn(faciaJson_play26)
-  .settings(sonatypeReleaseSettings: _*)
+
+lazy val faciaJson_play26 = faciaJson_playJsonVersion("26")
+lazy val faciaJson_play27 = faciaJson_playJsonVersion("27")
+
+lazy val fapiClient_play26 = fapiClient_playJsonVersion("26").dependsOn(faciaJson_play26)
+lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27)

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -8,9 +8,6 @@ object Dependencies {
   val contentApi = "com.gu" %% "content-api-client" % capiVersion
   val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % "test"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
-  val playJson24 = "com.typesafe.play" %% "play-json" % "2.4.6"
-  val playJson25 = "com.typesafe.play" %% "play-json" % "2.5.4"
-  val playJson26 = "com.typesafe.play" %% "play-json" % "2.6.3"
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"
   val specs2 = "org.specs2" %% "specs2-core" % "4.0.0" % "test"
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"


### PR DESCRIPTION
We're looking to [upgrade Ophan to Play 2.7](https://github.com/guardian/ophan/pull/3428) to stay on top of security updates, so we'd like to release `facia-json` & `fapi-client` for both versions of `play-json` (v2.6 & 2.7).

I've done a fair bit of DRY in the `build.sbt`to remove duplicated boilerplate, so that having two Play versions doesn't substantially increase the line-count... ✨ 

![image](https://user-images.githubusercontent.com/52038/64275940-9ff3fc80-cf3e-11e9-8e8a-fa11c0522de7.png)
