### PR TITLE
Fix image override case: Change behaviour so fronts tool decides replacement image

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -59,8 +59,7 @@ object ResolvedMetaData {
       cardStyle match {
         case com.gu.facia.api.utils.Comment => Default.copy(
           showByline = true,
-          showQuotedHeadline = true,
-          imageCutoutReplace = true)
+          showQuotedHeadline = true)
         case _ if isCartoonForContent(content) => Default.copy(showByline = true)
         case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
         case _ => Default


### PR DESCRIPTION
# The problem 
A rare problem came up on the UK front page where the imageReplace was not being shown as the thumbnail for a story. The default CAPI image was being used instead. 

*Features of the story*: 
-> Opinion/comment piece 
-> It had no cutout image supplied or available from TagManager
-> An imageReplace had been applied in the fronts tool overriding the default image from CAPI.

NB: The standard format for an opinion piece on fronts is to use a cutout image / quote headline / show byline. 

*Two opinion pieces on a front - 1st with cutout, 2nd with standard image* 
<img width="486" alt="Screenshot 2019-09-06 at 11 01 45" src="https://user-images.githubusercontent.com/10324129/64419972-f9bb0a80-d095-11e9-80c6-7b6c82ebdc99.png">
 
*Other aspects of the problem*
-> If a cutout image was added, even if it was not used, it solved the problem and image replace worked correctly. This is the normal case, as the vast majority of opinion pieces have a cutout available even if not used 
-> Fronts tool was correctly sending the data with the `imageReplace` property set to true and the new image supplied in the url. 
-> Frontend was correctly rendering what it received from facia-press.
-> Facia-press was correctly pressing the uk front. 
-> The same happens in v1, so this problem has obviously been around for a while, but only turns up infrequently because it applies to a small section of stories. 

## Suggested fix

From how I see it, the fronts tool should take the decision as to whether a cutout is used, rather than this being hardcoded as the default by this library. 

Therefore I am removing [line 62](https://github.com/guardian/facia-scala-client/pull/222/files#diff-28f7d5018617d6ae34f67050345e19e2R62) that hardcodes that for opinion/comment pieces. That should be set by [line 82](https://github.com/guardian/facia-scala-client/pull/222/files#diff-28f7d5018617d6ae34f67050345e19e2R82) taking it from the fronts tool trailMeta instead. 

This cedes control for setting the replaceImage and the cutoutImageReplace to the fronts tool metadata rather than guessing that an Opinion story will definitely have a cutout image. 

Setting it to true by default meant that it failed [this if statement](https://github.com/guardian/frontend/blob/88cfa609c73545085c3e5f3921631ec344a3eb83/common/app/model/ImageOverride.scala#L11) in facia press: 

```(scala)
val (maybeSrc, maybeWidth, maybeHeight) = image match {
      case cutout: Cutout => (Some(cutout.imageSrc), cutout.imageSrcHeight, cutout.imageSrcWidth)
      case replace: Replace => (Some(replace.imageSrc), Some(replace.imageSrcHeight), Some(replace.imageSrcWidth))
      case _ => (None, None, None)
    }
```


## Json produced by fronts

This image override worked because a cutout was present. 
```
"meta": {
"imageSrcWidth": "2625",
"headline": "It will wreck it: Boris Johnson’s electoral gamble risks wrecking the Tory party",
"imageSrcOrigin": "https://media.test.dev-gutools.co.uk/images/94b46e4078134a5b04a868c4054658a33348d5ec",
"imageSrcHeight": "1575",
"imageCutoutSrc": "https://uploads.guim.co.uk/2017/10/06/Jonathan-Freedland,-L.png",
"showByline": true,
"showQuotedHeadline": true,
"imageSrcThumb": "https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/94b46e4078134a5b04a868c4054658a33348d5ec/0_104_2625_1575/500.jpg",
"imageSrc": "https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/94b46e4078134a5b04a868c4054658a33348d5ec/0_104_2625_1575/master/2625.jpg",
"imageReplace": true,
"imageCutoutReplace": false,
"group": "1"
}
```

This one didn't because a cutout was not present:
```
"meta": {
"imageSrcWidth": "2595",
"headline": "It fell: Boris Johnson's blustering strategy has fallen at the first hurdle",
"imageSrcOrigin": "https://media.test.dev-gutools.co.uk/images/6d3a83433a65f38231d8455929ae5c6e47f55883",
"imageSrcHeight": "1558",
"showByline": true,
"showQuotedHeadline": true,
"imageSrcThumb": "https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/6d3a83433a65f38231d8455929ae5c6e47f55883/0_87_2595_1558/500.jpg",
"imageSrc": "https://s3-eu-west-1.amazonaws.com/media-origin.test.dev-guim.co.uk/6d3a83433a65f38231d8455929ae5c6e47f55883/0_87_2595_1558/master/2595.jpg",
"imageReplace": true,
"group": "1"
}
```

## Other issues with this library 

Variations of this problem have come up before. cf this trello card - 
https://trello.com/c/nwUyy7Lv/67-content-based-settings-do-not-get-saved-into-database-when-creating-skeleton 
@aug24 @akash1810 