### PR TITLE
Geotargeting collections: add 'TargetedTerritory' to CollectionConfigJson 

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -76,6 +76,26 @@ object CollectionPlatform {
   }
 }
 
+sealed trait TargetedTerritory
+case object NZTerritory extends TargetedTerritory
+case object USEastCoastTerritory extends TargetedTerritory
+case object EU27Territory extends TargetedTerritory
+
+object TargetedTerritory {
+  implicit object TargetedTerritoryFormat extends Format[TargetedTerritory] {
+    def reads(json: JsValue): JsSuccess[TargetedTerritory] = json match {
+      case JsString("NZ") => JsSuccess(NZTerritory)
+      case JsString("US-East-Coast") => JsSuccess(USEastCoastTerritory)
+      case JsString("EU-27") => JsSuccess(EU27Territory)
+    }
+    def writes(territory: TargetedTerritory): JsString = territory match {
+      case NZTerritory => JsString("NZ")
+      case USEastCoastTerritory => JsString("US-East-Coast")
+      case EU27Territory => JsString("EU-27")
+    }
+  }
+}
+
 object FrontsToolSettings {
   implicit val jsonFormat = Json.format[FrontsToolSettings]
 }
@@ -113,6 +133,7 @@ object CollectionConfigJson {
     hideShowMore: Option[Boolean] = None,
     displayHints: Option[DisplayHintsJson] = None,
     userVisibility: Option[String] = None,
+    targetedTerritory: Option[TargetedTerritory] = None,
     platform: Option[CollectionPlatform] = None,
     frontsToolSettings: Option[FrontsToolSettings] = None
   ): CollectionConfigJson
@@ -135,6 +156,7 @@ object CollectionConfigJson {
     hideShowMore,
     displayHints,
     userVisibility,
+    targetedTerritory,
     platform,
     frontsToolSettings
   )
@@ -159,8 +181,10 @@ case class CollectionConfigJson(
   hideShowMore: Option[Boolean],
   displayHints: Option[DisplayHintsJson],
   userVisibility: Option[String],
+  targetedTerritory: Option[TargetedTerritory],
   platform: Option[CollectionPlatform],
-  frontsToolSettings: Option[FrontsToolSettings]
+  frontsToolSettings: Option[FrontsToolSettings],
+
   ) {
   val collectionType = `type`
 }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -76,22 +76,31 @@ object CollectionPlatform {
   }
 }
 
-sealed trait TargetedTerritory
-case object NZTerritory extends TargetedTerritory
-case object USEastCoastTerritory extends TargetedTerritory
-case object EU27Territory extends TargetedTerritory
+sealed trait TargetedTerritory {
+  val id: String
+}
+case object NZTerritory extends TargetedTerritory {
+  val id = "NZ"
+}
+case object USEastCoastTerritory extends TargetedTerritory {
+  val id = "US-East-Coast"
+}
+case object EU27Territory extends TargetedTerritory {
+  val id = "EU-27"
+}
 
 object TargetedTerritory {
+  val allTerritories: List[TargetedTerritory] = List(NZTerritory, USEastCoastTerritory, EU27Territory)
   implicit object TargetedTerritoryFormat extends Format[TargetedTerritory] {
     def reads(json: JsValue): JsSuccess[TargetedTerritory] = json match {
-      case JsString("NZ") => JsSuccess(NZTerritory)
-      case JsString("US-East-Coast") => JsSuccess(USEastCoastTerritory)
-      case JsString("EU-27") => JsSuccess(EU27Territory)
+      case JsString(NZTerritory.id) => JsSuccess(NZTerritory)
+      case JsString(USEastCoastTerritory.id) => JsSuccess(USEastCoastTerritory)
+      case JsString(EU27Territory.id) => JsSuccess(EU27Territory)
     }
     def writes(territory: TargetedTerritory): JsString = territory match {
-      case NZTerritory => JsString("NZ")
-      case USEastCoastTerritory => JsString("US-East-Coast")
-      case EU27Territory => JsString("EU-27")
+      case NZTerritory => JsString(NZTerritory.id)
+      case USEastCoastTerritory => JsString(USEastCoastTerritory.id)
+      case EU27Territory => JsString(EU27Territory.id)
     }
   }
 }

--- a/facia-json/src/test/resources/DEV/frontsapi/config/config.json
+++ b/facia-json/src/test/resources/DEV/frontsapi/config/config.json
@@ -2854,7 +2854,8 @@
         "query" : "sport/golf?edition=au"
       },
       "type" : "news/special",
-      "href" : "sport/golf"
+      "href" : "sport/golf",
+      "targetedTerritory": "EU-27"
     },
     "c45f-d5fc-39b6-bd7d" : {
       "displayName" : "Reviews",

--- a/facia-json/src/test/resources/PROD/frontsapi/collection/uk-alpha/news/regular-stories/collection-with-territory.json
+++ b/facia-json/src/test/resources/PROD/frontsapi/collection/uk-alpha/news/regular-stories/collection-with-territory.json
@@ -1,0 +1,221 @@
+{
+  "targetedTerritory": "EU-27",
+  "live" : [ {
+    "id" : "internal-code/content/443689143",
+    "frontPublicationDate" : 1407142932141,
+    "meta" : {
+      "headline" : "Israel declares seven-hour partial ceasefire in Gaza",
+      "imageAdjust" : "boost",
+      "group" : "2",
+      "supporting" : [ {
+        "id" : "internal-code/content/443689915",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "Gaza refugee camp struck after Israel calls temporary ceasefire",
+          "imageAdjust" : "boost",
+          "group" : "2"
+        }
+      }, {
+        "id" : "internal-code/content/443703787",
+        "frontPublicationDate" : 1405936947582
+      } ]
+    }
+  }, {
+    "id" : "internal-code/content/443419941",
+    "frontPublicationDate" : 1407139271933,
+    "meta" : {
+      "imageSrcWidth" : "940",
+      "trailText" : "On this day 100 years ago, Britain declared war after Germany invaded neutral Belgium. Follow the day's events live",
+      "headline" : "First world war commemorations",
+      "imageSrcHeight" : "564",
+      "supporting" : [ {
+        "id" : "internal-code/content/443704054",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "A time of decadence as well as death"
+        }
+      }, {
+        "id" : "internal-code/content/443711599",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "Cameron: principles at stake then still relevant"
+        }
+      } ],
+      "imageAdjust" : "boost",
+      "imageSrc" : "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407146294410/PrinceWilliamCatherineDuche.jpg",
+      "group" : "1"
+    }
+  }, {
+    "id" : "internal-code/content/442049202",
+    "frontPublicationDate" : 1407091813090,
+    "meta" : {
+      "headline" : "Domestic violence refuge provision at crisis point",
+      "imageAdjust" : "boost",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443701563",
+    "frontPublicationDate" : 1407141690881,
+    "meta" : {
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443677820",
+    "frontPublicationDate" : 1407132471164,
+    "meta" : {
+      "headline" : "Isis 'seize Iraq's biggest dam' and Kurdish towns",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443708468",
+    "frontPublicationDate" : 1407147950006,
+    "meta" : {
+      "headline" : "Brick shortage as building booms",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443653854",
+    "frontPublicationDate" : 1407087060585,
+    "meta" : {
+      "headline" : "Loss of medics worsens Ebola crisis",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443656156",
+    "frontPublicationDate" : 1407108058111,
+    "meta" : {
+      "headline" : "Clegg to call for tighter controls on immigration",
+      "group" : "0",
+      "supporting" : [ {
+        "id" : "internal-code/content/443646514",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "Reducing immigration would slow UK economy and lead to tax rises, says thinktank"
+        }
+      }, {
+        "id" : "internal-code/content/443660696",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "Labour must seize agenda on EU, or risk exit",
+          "group" : "0"
+        }
+      } ]
+    }
+  }, {
+    "id" : "internal-code/content/443692606",
+    "frontPublicationDate" : 1407135428174,
+    "meta" : {
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443688172",
+    "frontPublicationDate" : 1407132426618,
+    "meta" : {
+      "headline" : "Conflicting reports about 'abandoned' boy in Thailand",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443692154",
+    "frontPublicationDate" : 1407146751402,
+    "meta" : {
+      "headline" : "Markets tense after Portugal bank bailout",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443670471",
+    "frontPublicationDate" : 1407140408640,
+    "meta" : {
+      "imageSrcWidth" : "940",
+      "headline" : "Glasgow basks in Games' success",
+      "imageSrcHeight" : "564",
+      "imageSrc" : "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407140556976/AustraliansingerKylieMinogu.jpg",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443643292",
+    "frontPublicationDate" : 1407076075385,
+    "meta" : {
+      "headline" : "Earthquake kills hundreds in China",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443697859",
+    "frontPublicationDate" : 1407140270730,
+    "meta" : {
+      "headline" : "Gay priest takes on Church over job",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443658749",
+    "frontPublicationDate" : 1407108143486,
+    "meta" : {
+      "headline" : "Primary school after-school activities 'have slumped'",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443633653",
+    "frontPublicationDate" : 1407060270281,
+    "meta" : {
+      "headline" : "Royal Navy ship arrives in Libya to evacuate Britons",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443655894",
+    "frontPublicationDate" : 1407090448515,
+    "meta" : {
+      "headline" : "Blair lambasted over charity role",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443684608",
+    "frontPublicationDate" : 1407140665746,
+    "meta" : {
+      "headline" : "No hope for 150 buried in Nepal slide",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443643987",
+    "frontPublicationDate" : 1407077000441,
+    "meta" : {
+      "headline" : "Ukrainian army closes in on Donetsk",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443700072",
+    "frontPublicationDate" : 1407142216027,
+    "meta" : {
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443633554",
+    "frontPublicationDate" : 1407147932241,
+    "meta" : {
+      "headline" : "Tulisa Contostavlos 'planning to sue Mazher Mahmood'",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443707330",
+    "frontPublicationDate" : 1407145626987,
+    "meta" : {
+      "headline" : "Police sniffer dogs deployed in new search for teen",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443646888",
+    "frontPublicationDate" : 1407140355365,
+    "meta" : {
+      "headline" : "Ukip youth wing in fighting form",
+      "group" : "0"
+    }
+  }, {
+    "id" : "internal-code/content/443641500",
+    "frontPublicationDate" : 1407140367636,
+    "meta" : {
+      "headline" : "Nice beach erosion draws complaints",
+      "group" : "0"
+    }
+  } ],
+  "lastUpdated" : "2014-08-04T10:48:07.834Z",
+  "updatedBy" : "Tash Banks",
+  "updatedEmail" : "tash.banks@guardian.co.uk"
+}

--- a/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
@@ -26,5 +26,22 @@ class ConfigSpec extends Specification with ResourcesHelper {
           "decorating and gardening from the Guardian, the world's leading liberal voice"))
       })
     }
+    "deserialize territories" in {
+      val config = Json.fromJson[ConfigJson](Json.parse(slurpOrDie("DEV/frontsapi/config/config.json").get)).get
+
+      config.collections.get("au/sport/golf/regular-stories") must beSome.which({ collection =>
+        collection.targetedTerritory.get mustEqual(EU27Territory)
+      })
+    }
+
+    "serialize territories" in {
+      val config = Json.fromJson[ConfigJson](Json.parse(slurpOrDie("DEV/frontsapi/config/config.json").get)).get
+
+      config.collections.get("uk/commentisfree/most-viewed/regular-stories") must beSome.which({ collection =>
+        val collectionWithTerritory = collection.copy(targetedTerritory = Some(NZTerritory))
+        val json = Json.toJson(collectionWithTerritory).toString()
+        json mustEqual """{"displayName":"Most popular","backfill":{"type":"capi","query":"uk/commentisfree?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true"},"type":"news/most-popular","uneditable":true,"targetedTerritory":"NZ"}"""
+      })
+    }
   }
 }


### PR DESCRIPTION
This PR adds an optional 'TargetedTerritory' property to the CollectionConfigJson class, allowing us to specify a targeted territory on a per-Collection basis.

It's needed to support the upcoming work targeting containers to specific geographic regions.

At the moment, we only support a single territory per Collection -- let me know if this should be a `List[TargetedTerritory]`!