### PR TITLE
Upgrade release pipeline

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ To run the tests you need to pass a content api key and facia client target url 
 
 ## Building a release
 
-[This document](https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit) is a good source of information about releasing Guardian artefacts generally.
+[This document](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit) is a good source of information about releasing Guardian artefacts generally.
 
 To release a new version of the client:  
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.8"
+version in ThisBuild := "3.0.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.8-SNAPSHOT"
+version in ThisBuild := "3.0.8"


### PR DESCRIPTION
I haven't fully tested it yet

If no one disagree, I'd like to do another release after this PR is merged, just to confirm that it works.
So 3.0.8 and 3.0.9 would functionally be the same, but I'd prove the pipeline still works.

This came about as I was trying to release 3.0.8 this morning and couldn't explain why it wouldn't work so I decided to upgrade all the release libraries. 

(it turns out my issue was unrelated but we may as well upgrade all the libraries)