### PR TITLE
Add Scala 2.13 support everywhere we can (ie play-json 2.7, but not 2.6)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,10 +73,9 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
     resolvers ++= Seq(
       Resolver.sonatypeRepo("releases"),
       Resolver.sonatypeRepo("public"),
-      Resolver.file("Local", file( Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.ivyStylePatterns),
-      "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+      Resolver.typesafeRepo("releases")
     ),
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.12.10",
     scalacOptions := Seq("-feature", "-deprecation"),
     publishTo := sonatypePublishTo.value,
     sonatypeReleaseSettings
@@ -104,8 +103,12 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
     )
   )
 
+lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.1")
+
+
 lazy val faciaJson_play26 = faciaJson_playJsonVersion("26")
-lazy val faciaJson_play27 = faciaJson_playJsonVersion("27")
+lazy val faciaJson_play27 = faciaJson_playJsonVersion("27").settings(crossCompileScala213)
 
 lazy val fapiClient_play26 = fapiClient_playJsonVersion("26").dependsOn(faciaJson_play26)
-lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27)
+lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27).settings(crossCompileScala213)
+

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -37,7 +37,7 @@ object CardStyle {
   def apply(content: Content, trailMetaData: MetaDataCommonFields): CardStyle = {
     val href = trailMetaData.href
 
-    val hashedTagIds: Seq[String] = content.tags.flatMap { tag =>
+    val hashedTagIds: Seq[String] = content.tags.toSeq.flatMap { tag =>
       md5(salt + tag.id)
     }
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
@@ -7,10 +7,10 @@ import com.gu.facia.api.models.BrandingByEdition
 object ContentApiUtils {
 
   implicit class RichContent(content: Content) {
-    private def tagsOfType(tagType: TagType): Seq[Tag] = content.tags.filter(_.`type` == tagType)
+    private def tagsOfType(tagType: TagType): Seq[Tag] = content.tags.toSeq.filter(_.`type` == tagType)
 
     lazy val keywords: Seq[Tag] = tagsOfType(TagType.Keyword)
-    lazy val nonKeywordTags: Seq[Tag] = content.tags.filterNot(_.`type` == TagType.Keyword)
+    lazy val nonKeywordTags: Seq[Tag] = content.tags.toSeq.filterNot(_.`type` == TagType.Keyword)
     lazy val contributors: Seq[Tag] = tagsOfType(TagType.Contributor)
     lazy val isContributorPage: Boolean = contributors.nonEmpty
     lazy val series: Seq[Tag] = tagsOfType(TagType.Series)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ItemKicker.scala
@@ -52,7 +52,7 @@ object ItemKicker {
     fromContentAndTrail(Option(content), trailMeta, resolvedMetaData, config)
 
   private[utils] def tonalKicker(content: Content, trailMeta: MetaDataCommonFields): Option[ItemKicker] = {
-    def tagsOfType(tagType: String): Seq[Tag] = content.tags.filter(_.`type` == tagType)
+    def tagsOfType(tagType: String): Seq[Tag] = content.tags.toSeq.filter(_.`type`.name == tagType)
     val types: Seq[Tag] = tagsOfType("type")
     val tones: Seq[Tag] = tagsOfType("tone")
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,15 +1,15 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "14.1"
+  val capiVersion = "15.4"
 
-  val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.154"
+  val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
   val contentApi = "com.gu" %% "content-api-client" % capiVersion
   val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % "test"
   val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"
-  val specs2 = "org.specs2" %% "specs2-core" % "4.0.0" % "test"
-  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+  val specs2 = "org.specs2" %% "specs2-core" % "4.7.1" % "test"
+  val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.6"
 }


### PR DESCRIPTION
This project compiles with Scala 2.12 by default, but now additionally can cross-compile to Scala 2.13 for the versions of `play-json` that support it (ie Play 2.7, but not Play 2.6).

### Dealing with scala.Seq becoming scala.collection.immutable.Seq

From https://docs.scala-lang.org/overviews/core/collections-migration-213.html#scalaseq-varargs-and-scalaindexedseq-migration

> `scala.Seq[+A]` is now an alias for `scala.collection.immutable.Seq[A]`
> (instead of `scala.collection.Seq[A]`)

For Scrooge v19.2.0 and above, given a thrift field of type `list<string>`, a Scala field of type `scala.collection.Seq[T]` is generated - so unfortunately such generated-CAPI fields like `content.tags` need to be suffixed with `.toSeq` before they can be allocated to the (now stricter, immutable) `Seq[_]` type.

### The already deprecated Future.onFailure method is now gone

See https://viktorklang.com/blog/Futures-in-Scala-2.12-part-5.html - as it mentions, we're now supposed to use `failed.foreach`: 

https://www.scala-lang.org/api/current/scala/concurrent/Future.html#failed:scala.concurrent.Future[Throwable]

### Dependencies

This update also required https://github.com/guardian/commercial-shared/pull/43 to provide a version of `"com.gu" %% "commercial-shared"` compatible with Scala 2.13.
