### PR TITLE
🙈 Fix tests: Amend image default for comment pieces 

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -51,12 +51,11 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
         'showByline (true))
     }
 
-    "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
+    "Content with type comment should showByline and showQuotedHeadline" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithComment, Comment)
       resolvedMetaData should have (
         'showByline (true),
-        'showQuotedHeadline (true),
-        'imageCutoutReplace (true))
+        'showQuotedHeadline (true))
     }
 
     "Content with type video should showMainVideo" in {
@@ -131,8 +130,7 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData, Comment)
       resolvedComment should have (
         'showByline (true),
-        'showQuotedHeadline (true),
-        'imageCutoutReplace (true))
+        'showQuotedHeadline (true))
     }
 
     "should resolve correct for video when trailMetaData is not set" in {


### PR DESCRIPTION
Fixes the tests for the change made in: https://github.com/guardian/facia-scala-client/pull/222

The image default for comment pieces has changed (this library should no longer assume that a cutout image is the norm).

I'm removing this in the two places it is referenced. 

