### PR TITLE
Revert "🙈 Fix tests: Amend image default for comment pieces "

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ResolvedMetaDataTest.scala
@@ -51,11 +51,12 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
         'showByline (true))
     }
 
-    "Content with type comment should showByline and showQuotedHeadline" in {
+    "Content with type comment should showByline, showQuotedHeadline and imageCutoutReplace" in {
       val resolvedMetaData = ResolvedMetaData.fromContent(contentWithComment, Comment)
       resolvedMetaData should have (
         'showByline (true),
-        'showQuotedHeadline (true))
+        'showQuotedHeadline (true),
+        'imageCutoutReplace (true))
     }
 
     "Content with type video should showMainVideo" in {
@@ -130,7 +131,8 @@ class ResolvedMetaDataTest extends FreeSpec with Matchers with TestContent {
       val resolvedComment = ResolvedMetaData.fromContentAndTrailMetaData(contentWithComment, emptyTrailMetaData, Comment)
       resolvedComment should have (
         'showByline (true),
-        'showQuotedHeadline (true))
+        'showQuotedHeadline (true),
+        'imageCutoutReplace (true))
     }
 
     "should resolve correct for video when trailMetaData is not set" in {


### PR DESCRIPTION
Reverts guardian/facia-scala-client#230

A more substantial fix is required to do this in a more transparent way. 
ie Removing a default here removes all defaults in the tool.

This should be part of a wider fix which involves removing defaults (eg quote headline / cutout image) from this library and putting them in facia-tool as the source of truth. 