### PR TITLE
Revert "Fix image override case: Change behaviour so fronts tool decides replacement image"

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -59,7 +59,8 @@ object ResolvedMetaData {
       cardStyle match {
         case com.gu.facia.api.utils.Comment => Default.copy(
           showByline = true,
-          showQuotedHeadline = true)
+          showQuotedHeadline = true,
+          imageCutoutReplace = true)
         case _ if isCartoonForContent(content) => Default.copy(showByline = true)
         case _ if isVideoForContent(content) => Default.copy(showMainVideo = true)
         case _ => Default


### PR DESCRIPTION
Reverts guardian/facia-scala-client#222

A more substantial fix is required to do this in a more transparent way. 
ie Removing a default here removes all defaults in the tool.

This should be part of a wider fix which involves removing defaults (eg quote headline / cutout image) from this library and putting them in facia-tool as the source of truth. 