### PR TITLE
Add blockId to trail meta

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -53,6 +53,7 @@ sealed trait MetaDataCommonFields {
   lazy val imageSource: Option[ImageSourceAsset] = json.get("imageSource").flatMap(_.asOpt[ImageSourceAsset])
   lazy val hideShowMore: Option[Boolean] = json.get("hideShowMore").flatMap(_.asOpt[Boolean])
   lazy val atomId: Option[String] = json.get("atomId").flatMap(_.asOpt[String])
+  lazy val blockId: Option[String] = json.get("blockId").flatMap(_.asOpt[String])
 }
 
 object SupportingItemMetaData {


### PR DESCRIPTION
Adds an optional blockId property to our Trail objects.

Required to let [facia-tool](https://github.com/guardian/facia-tool) store block ids for breaking news notifications that refer to liveblogs, allowing notification clients to point the user to a specific block in a liveblog.