### PR TITLE
Add DynamoLike metadata type to CollectionConfig

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -34,7 +34,7 @@ object Metadata extends StrictLogging {
     "Breaking" -> Breaking,
     "Branded" -> Branded,
     "DynamoLike" -> DynamoLike
- )
+  )
 
   implicit object MetadataFormat extends Format[Metadata] {
     def reads(json: JsValue) = {
@@ -54,6 +54,7 @@ object Metadata extends StrictLogging {
       case Special => JsObject(Seq("type" -> JsString("Special")))
       case Breaking => JsObject(Seq("type" -> JsString("Breaking")))
       case Branded => JsObject(Seq("type" -> JsString("Branded")))
+      case DynamoLike => JsObject(Seq("type" -> JsString("DynamoLike")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -22,14 +22,19 @@ case object Breaking extends Metadata
 
 case object Branded extends Metadata
 
-case object UnknownMetadata extends Metadata
+case object DynamoLike extends Metadata
 
+case object UnknownMetadata extends Metadata
 
 object Metadata extends StrictLogging {
 
   val tags: Map[String, Metadata] = Map(
-    ("Canonical", Canonical), ("Special", Special), ("Breaking", Breaking), ("Branded", Branded)
-  )
+    "Canonical" -> Canonical,
+    "Special" -> Special,
+    "Breaking" -> Breaking,
+    "Branded" -> Branded,
+    "DynamoLike" -> DynamoLike
+ )
 
   implicit object MetadataFormat extends Format[Metadata] {
     def reads(json: JsValue) = {


### PR DESCRIPTION
Adds a DynamoLike metadata type to the CollectionConfig model.

This will be used on platforms to apply Dynamo-like styling to containers that aren't dynamos – currently achieved with ad-hoc styling on Dotcom, and unavailable on mobile platforms.

Tested in the Fronts tool, which populates available metadata tags automatically. The change is backwards compatible with the old tooling, and hopefully downstream on platforms, with the `UnknownMetadata` type.