### PR TITLE
Add palette metadata types for US Election

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -24,6 +24,18 @@ case object Branded extends Metadata
 
 case object DynamoLike extends Metadata
 
+case object LongRunningPalette extends Metadata
+
+case object SombrePalette extends Metadata
+
+case object InvestigationPalette extends Metadata
+ 
+case object BreakingPalette extends Metadata
+
+case object EventPalette extends Metadata
+
+case object EventAltPalette extends Metadata
+
 case object UnknownMetadata extends Metadata
 
 object Metadata extends StrictLogging {
@@ -33,7 +45,13 @@ object Metadata extends StrictLogging {
     "Special" -> Special,
     "Breaking" -> Breaking,
     "Branded" -> Branded,
-    "DynamoLike" -> DynamoLike
+    "DynamoLike" -> DynamoLike,
+    "LongRunningPalette" -> LongRunningPalette,
+    "SombrePalette" -> SombrePalette,
+    "InvestigationPalette" -> InvestigationPalette,
+    "BreakingPalette" -> BreakingPalette,
+    "EventPalette" -> EventPalette,
+    "EventAltPalette" -> EventAltPalette,
   )
 
   implicit object MetadataFormat extends Format[Metadata] {
@@ -55,6 +73,12 @@ object Metadata extends StrictLogging {
       case Breaking => JsObject(Seq("type" -> JsString("Breaking")))
       case Branded => JsObject(Seq("type" -> JsString("Branded")))
       case DynamoLike => JsObject(Seq("type" -> JsString("DynamoLike")))
+      case LongRunningPalette => JsObject(Seq("type" -> JsString("LongRunningPalette")))
+      case SombrePalette => JsObject(Seq("type" -> JsString("SombrePalette")))
+      case InvestigationPalette => JsObject(Seq("type" -> JsString("InvestigationPalette")))
+      case BreakingPalette => JsObject(Seq("type" -> JsString("BreakingPalette")))
+      case EventPalette => JsObject(Seq("type" -> JsString("EventPalette")))
+      case EventAltPalette => JsObject(Seq("type" -> JsString("EventAltPalette")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }
@@ -240,5 +264,3 @@ case class ConfigJson(
   fronts: Map[String, FrontJson],
   collections: Map[String, CollectionConfigJson]
 )
-
-


### PR DESCRIPTION
Co-authored-by: Jonathon Herbert <jonathon.herbert@guardian.co.uk>

## What does this change?
This adds the following palette metadata to the config:
- LongRunningPalette
- SombrePalette
- InvestigationPalette
- BreakingPalette
- EventPalette
- EventAltPalette

## How to test
Release local version and consume in a downstream project such as [Fronts Config tool](https://github.com/guardian/facia-tool). The new metadata should be available in the project.

We've tested this with Fronts locally.

## How can we measure success?
Consuming projects are able to access the new metadata.

## Have we considered potential risks?
Risks have been mitigated by presence of the `UnknownMetadata` metadata which makes this PR backwards-compatible with old versions.