### PR TITLE
Add support for Play v2.8 (maintaining support for v2.6 & v2.7)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,10 @@ val sonatypeReleaseSettings = Seq(
 lazy val root = (project in file(".")).aggregate(
     faciaJson_play26,
     faciaJson_play27,
+    faciaJson_play28,
     fapiClient_play26,
-    fapiClient_play27
+    fapiClient_play27,
+    fapiClient_play28
   ).settings(
     publishArtifact := false,
     skip in publish := true,
@@ -60,7 +62,8 @@ lazy val root = (project in file(".")).aggregate(
 
 val exactPlayJsonVersions = Map(
   "26" -> "2.6.13",
-  "27" -> "2.7.4"
+  "27" -> "2.7.4",
+  "28" -> "2.8.1"
 )
 
 def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-play$majorMinorVersion", file(s"$module-play$majorMinorVersion"))
@@ -72,7 +75,7 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
       Resolver.sonatypeRepo("public"),
       Resolver.typesafeRepo("releases")
     ),
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.12",
     scalacOptions := Seq("-feature", "-deprecation"),
     publishTo := sonatypePublishToBundle.value,
     sonatypeReleaseSettings
@@ -100,12 +103,14 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
     )
   )
 
-lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.1")
+lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.4")
 
 
 lazy val faciaJson_play26 = faciaJson_playJsonVersion("26")
 lazy val faciaJson_play27 = faciaJson_playJsonVersion("27").settings(crossCompileScala213)
+lazy val faciaJson_play28 = faciaJson_playJsonVersion("28").settings(crossCompileScala213)
 
 lazy val fapiClient_play26 = fapiClient_playJsonVersion("26").dependsOn(faciaJson_play26)
 lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27).settings(crossCompileScala213)
+lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28).settings(crossCompileScala213)
 


### PR DESCRIPTION
## What does this change?

The library is now compiled and tested against Play v2.6, v2.7, and v2.8 - see also https://github.com/guardian/facia-scala-client/pull/221 for the prior change that supported v2.7 as well as v2.6. We're looking to consume this in the Ophan project.

Note that when we say it 'supports Play version X', we really just mean that it is compiled against the compatible version of `play-json` for that version of Play - and as it happens, no code changes are necessary between Play v2.6, v2.7, and v2.8 (we should probably drop Play 2.6 support soon [as it's EOL](https://www.playframework.com/security/vulnerability/CVE-2020-12480-CsrfBlacklistBypass)).