### PR TITLE
Bump capiVersion to 17.11

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "17.1"
+  val capiVersion = "17.11"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?
Bump the `capiVersion` from 17.1 to 17.11. This is in preparation for https://github.com/guardian/facia-scala-client/pull/243.
