### PR TITLE
Ignore snaps with bad links, rather than throwing

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -203,6 +203,15 @@ class ContentApiTest extends FreeSpec
       )
     }
 
+    "will not make request when the external link is malformed" in {
+      val capiClient = mock[ContentApiClient]
+      val request = LinkSnapsRequest(Map("trailId" -> "javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://dashboard.ophan.co.uk/assets/js/heatmap-bookmarklet.js';})();"))
+      ContentApi.linkSnapBrandingsByEdition(capiClient, request).asFuture.futureValue.fold(
+        err => fail(s"expected brandings result, got error $err"),
+        result => result should be(empty)
+      )
+    }
+
     "will not make capi request for a link to a tag combiner" in {
       val capiClient = mock[ContentApiClient]
       val request = LinkSnapsRequest(Map("trailId" -> "/world/asia-pacific+world/south-and-central-asia"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.3.4-SNAPSHOT"
+version in ThisBuild := "3.3.4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.3.4"
+version in ThisBuild := "3.3.5-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

An attempt at a fix for #249. See that issue for details.

## Dev notes

Because the failure to parse the URL only occurs when we're attempting to recover the 'branding' for the snapLink (which I don't fully understand, but IIUC cannot possibly function with an invalid link!), I think we're safe to just move on and continue parsing the rest of the response. Hence we log this error, but convert to an option and continue – if anyone knows better, please say!

## How to test

- Do the automated tests pass, and are you satisfied that they're adequate?
- Is the logging on failure adequate?
- Import a local build or a snapshot of this library into a consumer, and attempt to press a snap link with an invalid link. Does the press now succeed?
