### PR TITLE
Deduce SpecialReport from CAPI client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### 3.3.6
+  
+  - Bump CAPI client to `v17.21`
+  - Push special report logic into CAPI client
+
 #### 3.3.5
 
   - Bump CAPI client to `v17.20`

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -1,10 +1,10 @@
 package com.gu.facia.api.utils
 
 import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
+import com.gu.contentapi.client.utils.format.SpecialReportTheme
 import com.gu.facia.api.utils.ContentApiUtils._
-import com.gu.facia.client.models.{TrailMetaData, MetaDataCommonFields}
-import java.security.MessageDigest
-import java.math.BigInteger
+import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 
 object CardStyle {
   val specialReport = "special-report"
@@ -21,40 +21,12 @@ object CardStyle {
   val external = "external"
   val news = "news"
 
-  private val salt = "a-public-salt3W#ywHav!p+?r+W2$E6="
-  private val digest = MessageDigest.getInstance("MD5")
-
-  private def md5(input: String): Option[String] = {
-    try {
-      digest.update(input.getBytes(), 0, input.length)
-
-      Option(new BigInteger(1, digest.digest()).toString(16))
-    } catch {
-      case _: Throwable => None
-    }
-  }
-
   def apply(content: Content, trailMetaData: MetaDataCommonFields): CardStyle = {
     val href = trailMetaData.href
 
-    val hashedTagIds: Seq[String] = content.tags.toSeq.flatMap { tag =>
-      md5(salt + tag.id)
-    }
-
     if (trailMetaData.snapType.contains("link") && href.exists(ExternalLinks.external)) {
       ExternalLink
-    } else if ( // Note: if adding a hash use the same md5 implementation as above
-         hashedTagIds.contains("344ce3383665e23496bedd160675780c") // news/series/hsbc-files
-      || hashedTagIds.contains("d36fa10d66bf5ff85894829d3829d9e1")      // news/series/panama-papers
-      || hashedTagIds.contains("2920a7e21dc9f6fd0c008b50709c042f")      // us-news/homan-square
-      || hashedTagIds.contains("ae4bd9f302c420d242a8da91a47a9ddd")      // ...
-      || hashedTagIds.contains("f336cb0e0941d3d3d275e6451babca89")      // uk-news/series/the-new-world-of-work
-      || hashedTagIds.contains("6f92a967c35b72ef4867f23ba88c95a1")      // world/series/the-new-arrivals
-      || hashedTagIds.contains("1c74eb3a6d3c978e26d2c8f19f9b6a3")       // ...
-      || hashedTagIds.contains("4dae5700e6b6fdf66d1567769b41c1c2")      // news/series/nauru-files
-      || hashedTagIds.contains("9d89e70b7d99e776ffb741c0b9ab8854")      // us-news/series/counted-us-police-killings
-      || hashedTagIds.contains("7037b49de72275eb72b73a111da31849")      // australia-news/series/healthcare-in-detention
-      || hashedTagIds.contains("efb4e63b9a3a926314724b45764a5a5a") ) {  // society/series/this-is-the-nhs
+    } else if (content.theme == SpecialReportTheme) {
       SpecialReport
     } else if (content.isLiveBlog) {
       if (content.isLive) {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "17.20"
+  val capiVersion = "17.21"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

We currently store a hardcoded list of tags which are `Special Reports` in multiple locations.  This PR removes some of the duplication by relying on the CAPI client to identify special reports.