### PR TITLE
add podcast tag to config fields

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -1,6 +1,5 @@
 package com.gu.facia.client.models
 
-import com.sun.corba.se.spi.legacy.interceptor.UnknownType
 import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json._
 
@@ -29,12 +28,14 @@ case object LongRunningPalette extends Metadata
 case object SombrePalette extends Metadata
 
 case object InvestigationPalette extends Metadata
- 
+
 case object BreakingPalette extends Metadata
 
 case object EventPalette extends Metadata
 
 case object EventAltPalette extends Metadata
+
+case object Podcast extends Metadata
 
 case object UnknownMetadata extends Metadata
 
@@ -52,6 +53,7 @@ object Metadata extends StrictLogging {
     "BreakingPalette" -> BreakingPalette,
     "EventPalette" -> EventPalette,
     "EventAltPalette" -> EventAltPalette,
+    "Podcast" -> Podcast,
   )
 
   implicit object MetadataFormat extends Format[Metadata] {
@@ -79,6 +81,7 @@ object Metadata extends StrictLogging {
       case BreakingPalette => JsObject(Seq("type" -> JsString("BreakingPalette")))
       case EventPalette => JsObject(Seq("type" -> JsString("EventPalette")))
       case EventAltPalette => JsObject(Seq("type" -> JsString("EventAltPalette")))
+      case Podcast => JsObject(Seq("type" -> JsString("Podcast")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Within Fronts we currently have various options in tags to help define the type of article, or to associate an apt tag to an article.

In this PR we are adding a `Podcast` field to the tags so that users can select this as a type of article.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This can be tested using publishLocal and then running the facia-tool locally to check for changes


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

| Before  | After |
| --- | --- |
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132672841-fa4f7210-d7dd-4ac3-959b-bebfd995f95a.png">| <img width="300" alt="image" src="https://user-images.githubusercontent.com/49187886/132671922-67a37892-841b-46e7-9c69-5a994b861533.png">|

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
