### PR TITLE
Add territories for Australia

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -125,15 +125,15 @@ case object EU27Territory extends TargetedTerritory {
   val id = "EU-27"
 }
 
-case object AUVictoria extends TargetedTerritory {
+case object AUVictoriaTerritory extends TargetedTerritory {
   val id = "AU-VIC"
 }
 
-case object AUQueensland extends TargetedTerritory {
+case object AUQueenslandTerritory extends TargetedTerritory {
   val id = "AU-QLD"
 }
 
-case object AUNewSouthWales extends TargetedTerritory {
+case object AUNewSouthWalesTerritory extends TargetedTerritory {
   val id = "AU-NSW"
 }
 
@@ -144,9 +144,9 @@ object TargetedTerritory {
     USEastCoastTerritory,
     USWestCoastTerritory,
     EU27Territory,
-    AUVictoria,
-    AUQueensland,
-    AUNewSouthWales
+    AUVictoriaTerritory,
+    AUQueenslandTerritory,
+    AUNewSouthWalesTerritory
   )
 
   implicit object TargetedTerritoryFormat extends Format[TargetedTerritory] {
@@ -155,18 +155,18 @@ object TargetedTerritory {
       case JsString(USEastCoastTerritory.id) => JsSuccess(USEastCoastTerritory)
       case JsString(USWestCoastTerritory.id) => JsSuccess(USWestCoastTerritory)
       case JsString(EU27Territory.id) => JsSuccess(EU27Territory)
-      case JsString(AUVictoria.id) => JsSuccess(AUVictoria)
-      case JsString(AUQueensland.id) => JsSuccess(AUQueensland)
-      case JsString(AUNewSouthWales.id) => JsSuccess(AUNewSouthWales)
+      case JsString(AUVictoriaTerritory.id) => JsSuccess(AUVictoriaTerritory)
+      case JsString(AUQueenslandTerritory.id) => JsSuccess(AUQueenslandTerritory)
+      case JsString(AUNewSouthWalesTerritory.id) => JsSuccess(AUNewSouthWalesTerritory)
     }
     def writes(territory: TargetedTerritory): JsString = territory match {
       case NZTerritory => JsString(NZTerritory.id)
       case USEastCoastTerritory => JsString(USEastCoastTerritory.id)
       case USWestCoastTerritory => JsString(USWestCoastTerritory.id)
       case EU27Territory => JsString(EU27Territory.id)
-      case AUVictoria => JsString(AUVictoria.id)
-      case AUQueensland => JsString(AUQueensland.id)
-      case AUNewSouthWales => JsString(AUNewSouthWales.id)
+      case AUVictoriaTerritory => JsString(AUVictoriaTerritory.id)
+      case AUQueenslandTerritory => JsString(AUQueenslandTerritory.id)
+      case AUNewSouthWalesTerritory => JsString(AUNewSouthWalesTerritory.id)
     }
   }
 }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -125,21 +125,48 @@ case object EU27Territory extends TargetedTerritory {
   val id = "EU-27"
 }
 
+case object AUVictoria extends TargetedTerritory {
+  val id = "AU-VIC"
+}
+
+case object AUQueensland extends TargetedTerritory {
+  val id = "AU-QLD"
+}
+
+case object AUNewSouthWales extends TargetedTerritory {
+  val id = "AU-NSW"
+}
+
 
 object TargetedTerritory {
-  val allTerritories: List[TargetedTerritory] = List(NZTerritory, USEastCoastTerritory, USWestCoastTerritory, EU27Territory)
+  val allTerritories: List[TargetedTerritory] = List(
+    NZTerritory,
+    USEastCoastTerritory,
+    USWestCoastTerritory,
+    EU27Territory,
+    AUVictoria,
+    AUQueensland,
+    AUNewSouthWales
+  )
+
   implicit object TargetedTerritoryFormat extends Format[TargetedTerritory] {
     def reads(json: JsValue): JsSuccess[TargetedTerritory] = json match {
       case JsString(NZTerritory.id) => JsSuccess(NZTerritory)
       case JsString(USEastCoastTerritory.id) => JsSuccess(USEastCoastTerritory)
       case JsString(USWestCoastTerritory.id) => JsSuccess(USWestCoastTerritory)
       case JsString(EU27Territory.id) => JsSuccess(EU27Territory)
+      case JsString(AUVictoria.id) => JsSuccess(AUVictoria)
+      case JsString(AUQueensland.id) => JsSuccess(AUQueensland)
+      case JsString(AUNewSouthWales.id) => JsSuccess(AUNewSouthWales)
     }
     def writes(territory: TargetedTerritory): JsString = territory match {
       case NZTerritory => JsString(NZTerritory.id)
       case USEastCoastTerritory => JsString(USEastCoastTerritory.id)
       case USWestCoastTerritory => JsString(USWestCoastTerritory.id)
       case EU27Territory => JsString(EU27Territory.id)
+      case AUVictoria => JsString(AUVictoria.id)
+      case AUQueensland => JsString(AUQueensland.id)
+      case AUNewSouthWales => JsString(AUNewSouthWales.id)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

This PR adds additional targeted territories to allow us to target containers at New South Wales, Queensland and Victoria, as requested by our Australian colleagues.

Once this is released:
* Composer will need to bump to the latest Facia Scala Client library but should need no other changes
* MAPI needs to update to the latest library and make a few minor code changes (probably just like https://github.com/guardian/mobile-apps-api/pull/1479)
* Frontend needs to update to the latest library and make a few minor code changes (See https://github.com/guardian/frontend/pull/21953)
* Mobile Fastly config needs to be updated to pass `X-GU-Territory` values for these AU regions
* Frontend Fastly config needs to be updated to pass `X-GU-Territory` values for these AU regions

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
