### PR TITLE
Territory exhaustive match

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -124,19 +124,15 @@ case object USWestCoastTerritory extends TargetedTerritory {
 case object EU27Territory extends TargetedTerritory {
   val id = "EU-27"
 }
-
 case object AUVictoriaTerritory extends TargetedTerritory {
   val id = "AU-VIC"
 }
-
 case object AUQueenslandTerritory extends TargetedTerritory {
   val id = "AU-QLD"
 }
-
 case object AUNewSouthWalesTerritory extends TargetedTerritory {
   val id = "AU-NSW"
 }
-
 
 object TargetedTerritory {
   val allTerritories: List[TargetedTerritory] = List(

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -150,7 +150,7 @@ object TargetedTerritory {
   )
 
   implicit object TargetedTerritoryFormat extends Format[TargetedTerritory] {
-    def reads(json: JsValue): JsSuccess[TargetedTerritory] = json match {
+    def reads(json: JsValue): JsResult[TargetedTerritory] = json match {
       case JsString(NZTerritory.id) => JsSuccess(NZTerritory)
       case JsString(USEastCoastTerritory.id) => JsSuccess(USEastCoastTerritory)
       case JsString(USWestCoastTerritory.id) => JsSuccess(USWestCoastTerritory)
@@ -158,6 +158,8 @@ object TargetedTerritory {
       case JsString(AUVictoriaTerritory.id) => JsSuccess(AUVictoriaTerritory)
       case JsString(AUQueenslandTerritory.id) => JsSuccess(AUQueenslandTerritory)
       case JsString(AUNewSouthWalesTerritory.id) => JsSuccess(AUNewSouthWalesTerritory)
+      case JsString(value) => JsError(s"'$value' is not a valid territory")
+      case _ => JsError("Territory must be a string")
     }
     def writes(territory: TargetedTerritory): JsString = territory match {
       case NZTerritory => JsString(NZTerritory.id)


### PR DESCRIPTION
## What does this change?

When preparing to release this library I noticed a warning about a non-exhaustive pattern match.  This PR makes the match exhaustive, returning a JSON parse error instead of throwing an exception if asked to parse an unknown territory.