### PR TITLE
Remind developers to update Ophan when releasing this library

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## What does this change?
+
+<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
+
+## How to test
+
+<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
+
+## How can we measure success?
+
+<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
+
+## Have we considered potential risks?
+
+<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
+
+## Images
+
+<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
+
+## Accessibility
+
+<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->
+
+- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
+- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
+- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
+- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
+
+## Deployment
+
+- [ ] Updated facia-tool to use latest version
+- [ ] Updated frontend to use latest version
+- [ ] Updated MAPI to use latest version
+- [ ] Updated Ophan to use latest version
+- [ ] Updated story-packages to use latest version
+- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)


### PR DESCRIPTION
## What does this change?

Adds a checklist to the PR template to remind developers of the places this library is used to avoid breaking Ophan.