### PR TITLE
Add apple news to the list of downstream dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,4 +34,5 @@
 - [ ] Updated MAPI to use latest version
 - [ ] Updated Ophan to use latest version
 - [ ] Updated story-packages to use latest version
+- [ ] Updated apple-news to use latest version
 - [ ] Checked for other downstream dependencies (perhaps via snyk or github search)


### PR DESCRIPTION
## What does this change?

Adds Apple news to the list of downstream dependencies in the PR template