### PR TITLE
Add unsupported territory

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -134,6 +134,10 @@ case object AUNewSouthWalesTerritory extends TargetedTerritory {
   val id = "AU-NSW"
 }
 
+case object UnknownTerritory extends TargetedTerritory {
+  val id = "XX"
+}
+
 object TargetedTerritory {
   val allTerritories: List[TargetedTerritory] = List(
     NZTerritory,
@@ -154,7 +158,8 @@ object TargetedTerritory {
       case JsString(AUVictoriaTerritory.id) => JsSuccess(AUVictoriaTerritory)
       case JsString(AUQueenslandTerritory.id) => JsSuccess(AUQueenslandTerritory)
       case JsString(AUNewSouthWalesTerritory.id) => JsSuccess(AUNewSouthWalesTerritory)
-      case JsString(value) => JsError(s"'$value' is not a valid territory")
+      case JsString(UnknownTerritory.id) => JsSuccess(UnknownTerritory)
+      case JsString(value) => JsSuccess(UnknownTerritory)
       case _ => JsError("Territory must be a string")
     }
     def writes(territory: TargetedTerritory): JsString = territory match {
@@ -165,6 +170,7 @@ object TargetedTerritory {
       case AUVictoriaTerritory => JsString(AUVictoriaTerritory.id)
       case AUQueenslandTerritory => JsString(AUQueenslandTerritory.id)
       case AUNewSouthWalesTerritory => JsString(AUNewSouthWalesTerritory.id)
+      case _ => JsString(UnknownTerritory.id)
     }
   }
 }

--- a/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
@@ -33,6 +33,23 @@ class ConfigSpec extends Specification with ResourcesHelper {
         collection.targetedTerritory.get mustEqual(EU27Territory)
       })
     }
+    "deserialize unsupported territories as unknown" in {
+
+      val configJson = """{
+        |      "displayName" : "Golf",
+        |      "backfill" : {
+        |        "type" : "capi",
+        |        "query" : "sport/golf?edition=au"
+        |      },
+        |      "type" : "news/special",
+        |      "href" : "sport/golf",
+        |      "targetedTerritory": "Made-Up-Territory"
+        |    }""".stripMargin
+      val parsed = Json.fromJson[CollectionConfigJson](Json.parse(configJson))
+      parsed.asOpt must beSome.which({ config =>
+        config.targetedTerritory must beSome(UnknownTerritory)
+      })
+    }
 
     "serialize territories" in {
       val config = Json.fromJson[ConfigJson](Json.parse(slurpOrDie("DEV/frontsapi/config/config.json").get)).get


### PR DESCRIPTION
## What does this change?

We have previously encountered unexpected behaviour when new territories are added without updating all projects to use the latest version of the client.

Many consumers of this client do not care about the territories, but new territories mean old clients can no longer parse the config correctly.

This PR adds a new "Unsupported" territory that will be returned if the client cannot parse the a territory in the config.