### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,11 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
       Resolver.typesafeRepo("releases")
     ),
     scalaVersion := "2.12.12",
-    scalacOptions := Seq("-feature", "-deprecation"),
+    scalacOptions := Seq(
+        "-feature",
+        "-deprecation",
+        "-Xfatal-warnings"
+    ),
     publishTo := sonatypePublishToBundle.value,
     sonatypeReleaseSettings
   )

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -10,7 +10,7 @@ import lib.ExecutionContext
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.Future
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -6,7 +6,7 @@ import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{Branded, CollectionConfigJson, CollectionJson, Trail, TrailMetaData}
 import org.joda.time.DateTime
 import org.mockito.Mockito._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FreeSpec, OneInstancePerTest, Matchers}
 import play.api.libs.json.{JsArray, JsString, Json}
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -2,7 +2,7 @@ package com.gu.facia.api.models
 
 import com.gu.facia.client.models.FrontJson
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class FrontTest extends FreeSpec with Matchers with MockitoSugar with OneInstancePerTest {
   "fromFrontJson" - {

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/ItemKickerTest.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.model.v1.{ContentFields, Content}
 import com.gu.facia.api.models.CollectionConfig
 import com.gu.facia.client.models.{CollectionConfigJson, TrailMetaData}
 import org.mockito.Mockito
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{OneInstancePerTest, OptionValues, Matchers, FreeSpec}
 import org.mockito.Mockito._
 

--- a/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
+++ b/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
@@ -2,9 +2,10 @@ package lib
 
 import com.amazonaws.auth._
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.contentapi.client.GuardianContentClient
 import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
+import com.amazonaws.regions.Regions.EU_WEST_1
 
 private case class TestContentApiClient(override val apiKey: String, override val targetUrl: String)
   extends GuardianContentClient(apiKey)
@@ -27,7 +28,10 @@ trait IntegrationTestConfig extends ExecutionContext {
       new SystemPropertiesCredentialsProvider(),
       new ProfileCredentialsProvider(awsProfileName)
     )
-    val amazonS3Client = new AmazonS3Client(credentialsProvider)
+    val amazonS3Client = AmazonS3ClientBuilder.standard()
+      .withRegion(EU_WEST_1)
+      .withCredentials(credentialsProvider)
+      .build()
     ApiClient("facia-tool-store", "DEV", AmazonSdkS3Client(amazonS3Client))
   }
 }


### PR DESCRIPTION
## What does this change?

Enables the warnings-as-errors compiler flag, and fixes all warnings.

This is primarily to ensure that that non-exhaustive matches are considered an error.