### PR TITLE
bump CAPI

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "17.21"
+  val capiVersion = "17.24.1"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

Bumps the CAPI model for https://github.com/guardian/content-api-scala-client/pull/346
The versions are a little out of whack as I was learning how to release. 

You can see version 17.14.1 here: https://repo1.maven.org/maven2/com/gu/content-api-client_2.13/

