### PR TITLE
Add two new tags to the Config model

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -39,6 +39,10 @@ case object Podcast extends Metadata
 
 case object UnknownMetadata extends Metadata
 
+case object LongRunningAltPalette extends Metadata
+
+case object SombreAltPalette extends Metadata
+
 object Metadata extends StrictLogging {
 
   val tags: Map[String, Metadata] = Map(
@@ -54,6 +58,8 @@ object Metadata extends StrictLogging {
     "EventPalette" -> EventPalette,
     "EventAltPalette" -> EventAltPalette,
     "Podcast" -> Podcast,
+    "LongRunningAltPalette" -> LongRunningAltPalette,
+    "SombreAltPalette" -> SombreAltPalette
   )
 
   implicit object MetadataFormat extends Format[Metadata] {
@@ -82,6 +88,8 @@ object Metadata extends StrictLogging {
       case EventPalette => JsObject(Seq("type" -> JsString("EventPalette")))
       case EventAltPalette => JsObject(Seq("type" -> JsString("EventAltPalette")))
       case Podcast => JsObject(Seq("type" -> JsString("Podcast")))
+      case LongRunningAltPalette => JsObject(Seq("type" -> JsString("LongRunningAltPalette")))
+      case SombreAltPalette => JsObject(Seq("type" -> JsString("SombreAltPalette")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }


### PR DESCRIPTION
_co-authored-by: @andrew-nowak_

## What does this change?

Adds two new tags to the Config model, `LongRunningAltPalette` and `SombreAltPalette`. 

## How to test

- Publish a snapshot locally and import in the Fronts tool. Do the new tags appear in the Config tool?

Tested in Fronts CODE and dotcom preview CODE.

## Screenshots

Locally testing the snapshot
![image](https://user-images.githubusercontent.com/10963046/157894493-341847ac-0e8c-4b9f-801b-32117bd80c50.png)
