### PR TITLE
Add caption to slideshow asset

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -5,7 +5,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
 import com.gu.facia.client.json.JodaFormat._
 
-case class SlideshowAsset(src: String, width: String, height: String)
+case class SlideshowAsset(src: String, width: String, height: String, caption: Option[String] = None)
 object SlideshowAsset {
   implicit val slideshowAssetFormat = Json.format[SlideshowAsset]
 }

--- a/facia-json/src/test/resources/PROD/frontsapi/collection/uk-alpha/news/regular-stories/collection-with-captions.json
+++ b/facia-json/src/test/resources/PROD/frontsapi/collection/uk-alpha/news/regular-stories/collection-with-captions.json
@@ -1,0 +1,36 @@
+{
+  "live" : [ {
+    "id" : "internal-code/content/443689143",
+    "frontPublicationDate" : 1407142932141,
+    "meta" : {
+      "headline" : "The best slideshows in showbiz – ranked!",
+      "imageAdjust" : "boost",
+      "group" : "3",
+      "slideshow": [{
+        "src": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407146294410/PrinceWilliamCatherineDuche.jpg",
+        "width": "940",
+        "height": "720"
+      }, {
+        "src": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407140556976/AustraliansingerKylieMinogu.jpg",
+        "width": "940",
+        "height": "720",
+        "caption": "Kylie Minogue"
+      }],
+      "supporting" : [ {
+        "id" : "internal-code/content/443689915",
+        "frontPublicationDate" : 1405936947582,
+        "meta" : {
+          "headline" : "What do these people do everyday, anyhow?",
+          "imageAdjust" : "boost",
+          "group" : "2"
+        }
+      }, {
+        "id" : "internal-code/content/443703787",
+        "frontPublicationDate" : 1405936947582
+      } ]
+    }
+  }],
+  "lastUpdated" : "2014-08-04T10:48:07.834Z",
+  "updatedBy" : "Tash Banks",
+  "updatedEmail" : "tash.banks@guardian.co.uk"
+}

--- a/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
@@ -43,6 +43,28 @@ class CollectionSpec extends Specification with ResourcesHelper {
       })
     }
 
+    "deserialize content with slideshows, where captions are optional" in {
+      val collection = getCollectionFixture("PROD/frontsapi/collection/uk-alpha/news/regular-stories/collection-with-captions.json")
+
+      collection.live.lift(0) must beSome.which({ item =>
+        item.safeMeta.slideshow mustEqual Some(
+          List(
+            SlideshowAsset(
+              "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407146294410/PrinceWilliamCatherineDuche.jpg",
+              "940",
+              "720"
+            ),
+            SlideshowAsset(
+              "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2014/8/4/1407140556976/AustraliansingerKylieMinogu.jpg",
+              "940",
+              "720",
+              Some("Kylie Minogue")
+            )
+          )
+        )
+      })
+    }
+
     "deserialize content without metadata" in {
       val collection = getCollectionFixture("PROD/frontsapi/collection/754c-8e8c-fad9-a927/collection.json")
 


### PR DESCRIPTION
## What does this change?

Adds a `caption` property to the slideshow asset.

## How to test

- The automated tests should pass, showing we're happy that this field is optional, and we're backwards compatible with our current data

## How can we measure success?

We should be able to add captions in our tooling, and pass them through to platforms.