### PR TITLE
Transform optional caption on facia image (for slideshow images only)

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -9,7 +9,7 @@ import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Trail, 
 
 sealed trait FaciaImage
 case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
-case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String) extends FaciaImage
+case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String, imageCaption: Option[String]) extends FaciaImage
 case class ImageSlideshow(assets: List[Replace]) extends FaciaImage
 
 object FaciaImage {
@@ -44,19 +44,19 @@ object FaciaImage {
   def imageReplace(trailMeta: MetaDataCommonFields, resolvedMetaData: ResolvedMetaData): Option[FaciaImage] = {
     trailMeta.imageSource match {
       case Some(imageSource) =>
-        Some(Replace(imageSource.src, imageSource.width, imageSource.height))
+        Some(Replace(imageSource.src, imageSource.width, imageSource.height, None))
       case None =>
         for {
           src <- trailMeta.imageSrc
           width <- trailMeta.imageSrcWidth
           height <- trailMeta.imageSrcHeight
-        } yield Replace(src, width, height)
+        } yield Replace(src, width, height, None)
     }
   }
 
   def imageSlideshow(trailMeta: MetaDataCommonFields, resolvedMetaData: ResolvedMetaData): Option[FaciaImage] =
     trailMeta.slideshow.map { assets =>
-      val slideshowAssets = assets.map(asset => Replace(asset.src, asset.width, asset.height))
+      val slideshowAssets = assets.map(asset => Replace(asset.src, asset.width, asset.height, asset.caption))
       ImageSlideshow(slideshowAssets)}
 
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageReplaceTest.scala
@@ -44,11 +44,11 @@ class FaciaImageReplaceTest extends FlatSpec with Matchers {
 
   it should "give back an Image when true" in {
     val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageReplace)
-    FaciaImage.getFaciaImage(None, trailMetaDataWithImageReplace, resolvedMetaData) should be (Some(Replace("theImageSrc", "theImageSrcWidth", "theImageSrcHeight")))
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageReplace, resolvedMetaData) should be (Some(Replace("theImageSrc", "theImageSrcWidth", "theImageSrcHeight", None)))
   }
 
   it should "give back an ImageSource when imageSource present in metadata" in {
     val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSource)
-    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSource, resolvedMetaData) should be (Some(Replace("theImageSrcAsset", "500", "300")))
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSource, resolvedMetaData) should be (Some(Replace("theImageSrcAsset", "500", "300", None)))
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageSlideshowTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaImageSlideshowTest.scala
@@ -21,6 +21,13 @@ class FaciaImageSlideshowTest extends FlatSpec with Matchers {
     "width" -> JsString("theImageSrcWidthThree"),
     "height" -> JsString("theImageSrcHeightThree")))
 
+  val assetFourWithCaption = JsObject(List(
+    "src" -> JsString("theImageSrcFour"),
+    "width" -> JsString("theImageSrcWidthFour"),
+    "height" -> JsString("theImageSrcHeightFour"),
+    "caption" -> JsString("exampleCaption")
+  ))
+
   val trailMetaDataWithoutImageSlideshowReplace =
     TrailMetaData(Map(
       "imageSlideshowReplace" -> JsBoolean(value = false),
@@ -30,6 +37,11 @@ class FaciaImageSlideshowTest extends FlatSpec with Matchers {
     TrailMetaData(Map(
       "imageSlideshowReplace" -> JsBoolean(value = true),
       "slideshow" -> JsArray(List(assetOne, assetTwo, assetThree))))
+
+  val trailMetaDataWithImageSlideshowReplaceAndCaptionSetOnOneImage =
+    TrailMetaData(Map(
+      "imageSlideshowReplace" -> JsBoolean(value = true),
+      "slideshow" -> JsArray(List(assetOne, assetTwo, assetThree, assetFourWithCaption))))
 
   val trailMetaDataWithImageSlideshowReplaceAndNoAssets =
     TrailMetaData(Map(
@@ -43,7 +55,12 @@ class FaciaImageSlideshowTest extends FlatSpec with Matchers {
 
   it should "give back an ImageGallery when true" in {
     val resolvedMetaData =  ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSlideshowReplace)
-    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSlideshowReplace, resolvedMetaData) should be (Some(ImageSlideshow(List(Replace("theImageSrcOne", "theImageSrcWidthOne", "theImageSrcHeightOne"), Replace("theImageSrcTwo", "theImageSrcWidthTwo", "theImageSrcHeightTwo"), Replace("theImageSrcThree", "theImageSrcWidthThree", "theImageSrcHeightThree")))))
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSlideshowReplace, resolvedMetaData) should be (Some(ImageSlideshow(List(Replace("theImageSrcOne", "theImageSrcWidthOne", "theImageSrcHeightOne", None), Replace("theImageSrcTwo", "theImageSrcWidthTwo", "theImageSrcHeightTwo", None), Replace("theImageSrcThree", "theImageSrcWidthThree", "theImageSrcHeightThree", None)))))
+  }
+
+  it should "give back an ImageGallery when true, with caption set on one image" in {
+    val resolvedMetaData = ResolvedMetaData.fromTrailMetaData(trailMetaDataWithImageSlideshowReplaceAndCaptionSetOnOneImage)
+    FaciaImage.getFaciaImage(None, trailMetaDataWithImageSlideshowReplaceAndCaptionSetOnOneImage, resolvedMetaData) should be (Some(ImageSlideshow(List(Replace("theImageSrcOne", "theImageSrcWidthOne", "theImageSrcHeightOne", None), Replace("theImageSrcTwo", "theImageSrcWidthTwo", "theImageSrcHeightTwo", None), Replace("theImageSrcThree", "theImageSrcWidthThree", "theImageSrcHeightThree", None), Replace("theImageSrcFour", "theImageSrcWidthFour", "theImageSrcHeightFour", Some("exampleCaption"))))))
   }
 
   it should "give back a None when imageSlideshowReplace true with no assets" in {


### PR DESCRIPTION
## What does this change?

#264 added the caption to the slideshow asset. This PR ensures that when these assets are transformed, we handle the optional caption on the asset.

## How to test

A new test should pass, showing the caption is transformed when set. 

The edited tests should pass, showing that we can handle images without captions (both in a slideshow context, and in an 'image replace' context - where captions should never be set). This should ensure we are backwards compatible.

## How can we measure success?

The captions should now be passed all the way through to the tooling as intended in #264. 
