### PR TITLE
Update to version of sbt that supports M1 hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.bsp
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
       Resolver.sonatypeRepo("public"),
       Resolver.typesafeRepo("releases")
     ),
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.12.16",
     scalacOptions := Seq(
         "-feature",
         "-deprecation",
@@ -92,7 +92,7 @@ def faciaJson_playJsonVersion(majorMinorVersion: String) = baseProject("facia-js
       commonsIo,
       specs2,
       "com.typesafe.play" %% "play-json" % exactPlayJsonVersions(majorMinorVersion),
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
       scalaLogging
     )
   )
@@ -108,7 +108,7 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
     )
   )
 
-lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.4")
+lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.8")
 
 
 lazy val faciaJson_play26 = faciaJson_playJsonVersion("26")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.6.2


### PR DESCRIPTION
We'll need to be able to compile this project on M1 hardware sooner or later!

This PR also updates the Scala language versions to the latest maintenance releases.

I've checked, and the tests run fine locally (note there's no CI set on this project, probably because the tests require [`cmsFronts-s3-read`](https://janus.gutools.co.uk/credentials?permissionId=cmsFronts-s3-read) AWS Credentials to pass.

See also https://github.com/guardian/ophan/pull/4383
