### PR TITLE
Compile against v19 of the CAPI client (incompatible with versions prior to v19)

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "17.24.1"
+  val capiVersion = "19.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

This updates the FAPI client to be compiled against the latest version of the CAPI client, v19.0.0. Due to https://github.com/guardian/content-api-scala-client/pull/359 the latest version of the CAPI client is [binary-incompatible](https://stackoverflow.com/a/14973523/438886) with versions of the CAPI client prior to v19, so users of the FAPI library can not use CAPI client v19 without _also_ using a version of the FAPI library that has been compiled with the latest version. Without updating, the users will see a [`java.lang.NoSuchMethodError` exception](https://github.com/guardian/frontend/pull/25139#issuecomment-1163407402).

See https://github.com/guardian/content-api-scala-client/pull/359#issuecomment-1171311303 for further details - although the change is _binary_-incompatible, the change is not _source_-incompatible, so updating to the latest version of CAPI and recompiling is enough to solve the problem.

I've deployed a beta version of the `facia-scala-client` to CODE Frontend, and verified that Frontend's `facia-press`, which depends on FAPI & CAPI, [works correctly](https://github.com/guardian/frontend/pull/25139#issuecomment-1171075395).

I've also added a new `FaciaClientTest` to both https://github.com/guardian/frontend/pull/25139/ & https://github.com/guardian/ophan/pull/4719 - these tests specifically check that this specific `java.lang.NoSuchMethodError` does **not** occur, and will fail the build if someone tries to update the FAPI or CAPI library to an incompatible combination.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
