### PR TITLE
proposal: Switch from manual `CHANGELOG.md` to GitHub Releases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,4 +92,7 @@ $ sbt
 sbt:facia-api-client> release
 ```
 
-4. When the release process has completed successfully, update the [change log](CHANGES.md).
+4. When the release process has completed successfully, document the new version with a GitHub Release note
+   ([guide](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository))
+   describing the change (the `Generate release notes` button can give you a good start!):
+   https://github.com/guardian/facia-scala-client/releases/new

--- a/docs/legacy.CHANGES.md
+++ b/docs/legacy.CHANGES.md
@@ -1,3 +1,12 @@
+# Latest information in GitHub Releases
+
+Check out **https://github.com/guardian/facia-scala-client/releases**
+for info on all releases from v4.0.0 onwards. For historical reference
+purposes, information on prior releases is included below.
+
+### Releases prior to v4.0.0...
+
+
 #### 3.3.6
   
   - Bump CAPI client to `v17.21`


### PR DESCRIPTION
A `CHANGELOG.md` file is nice & compact, but requires manual formatting and doesn't integrate with GitHub's UI. [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) notes have some advantages:

* handy automation for writing release notes!
* can be interrogated through the GitHub API
* have a standard url: https://github.com/guardian/facia-scala-client/releases
* have a standard place in the GitHub UI ![image](https://user-images.githubusercontent.com/52038/176918490-65ae763d-8e2f-4fcf-9401-440d0a6a46da.png)

![image](https://user-images.githubusercontent.com/52038/176918613-2707348c-ce28-42d2-a1e0-1d966011609b.png)

This matches a similar move made earlier today with https://github.com/guardian/content-api-scala-client/pull/361!
