### PR TITLE
Compile against v19.0.3 of the CAPI client

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,15 +1,15 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.0.0"
+  val capiVersion = "19.0.3"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
   val contentApi = "com.gu" %% "content-api-client" % capiVersion
-  val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % "test"
-  val mockito = "org.mockito" % "mockito-all" % "1.10.19" % "test"
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
-  val specs2 = "org.specs2" %% "specs2-core" % "4.7.1" % "test"
+  val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % Test
+  val mockito = "org.mockito" % "mockito-all" % "1.10.19" % Test
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % Test
+  val specs2 = "org.specs2" %% "specs2-core" % "4.7.1" % Test
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.6"
 }


### PR DESCRIPTION
This is a relatively small update, just affected by this change to the CAPI client : https://github.com/guardian/content-api-scala-client/pull/363

It probably wouldn't have caused any problems, but the CAPI query class hierarchy has changed slightly, and it seemed safest to do a fresh release of the FAPI client compiled against that.

Will merge without review as low risk and not interesting!