### PR TITLE
Prioritise replacement images over cutouts

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -19,10 +19,10 @@ object FaciaImage {
       None
     else if (resolvedMetadata.imageSlideshowReplace)
       imageSlideshow(trailMeta, resolvedMetadata)
-    else if (resolvedMetadata.imageCutoutReplace)
-      imageCutout(trailMeta) orElse maybeContent.flatMap(fromContentTags(_, trailMeta))
     else if (resolvedMetadata.imageReplace)
       imageReplace(trailMeta, resolvedMetadata)
+    else if (resolvedMetadata.imageCutoutReplace)
+      imageCutout(trailMeta) orElse maybeContent.flatMap(fromContentTags(_, trailMeta))
     else None}
 
   def fromContentTags(content: Content, trailMeta: MetaDataCommonFields): Option[FaciaImage] = {

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -7,11 +7,13 @@ import lib.TestContent
 import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.{JsBoolean, JsString}
 import org.scalatest.OptionValues._
+import com.gu.facia.api.utils.ResolvedMetaData
 
 class CuratedContentTest extends FreeSpec with Matchers with TestContent {
 
+  val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
+
   "CuratedContent headline" - {
-    val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
 
     val contentWithFieldHeadline = baseContent.copy(fields = Some(ContentFields(headline = Some("Content headline"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
     val contentWithoutFieldHeadline = baseContent.copy(webTitle = "contentWithoutFieldHeadlineHeadline", fields = Some(ContentFields(trailText = Some("Content trailtext"), byline = Some("Content byline"))))
@@ -115,6 +117,41 @@ class CuratedContentTest extends FreeSpec with Matchers with TestContent {
       val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
       val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags)
       supportingCuratedContent.kicker.value shouldBe a [TagKicker]
+    }
+  }
+
+  "CuratedContent images" - {
+    "should default to the replacement image, not the cutout image, when `imageReplace` is true for content with the Comment tone" in {
+      val replaceSrc = "https://somewhere-on-the-internet/replace-image.jpg"
+      val replaceDimensions = "100"
+
+      val cutoutSrc = "https://somewhere-on-the-internet/cutout-image.jpg"
+      val cutoutDimensions = "200"
+
+      val trailMetadata = TrailMetaData(Map(
+        "imageReplace" -> JsBoolean(true),
+        "imageSrc" -> JsString(replaceSrc),
+        "imageSrcWidth" -> JsString(replaceDimensions),
+        "imageSrcHeight" -> JsString(replaceDimensions),
+        "imageCutoutSrc" -> JsString(cutoutSrc),
+        "imageCutoutSrcWidth" -> JsString(cutoutDimensions),
+        "imageCutoutSrcHeight" -> JsString(cutoutDimensions)
+      ))
+
+      val contentWithCommentTone = baseContent.copy(
+        fields = Some(ContentFields(headline = Some("Content headline"), trailText = Some("Content trailtext"), byline = Some("Content byline"))),
+        tags = List(Tag(ResolvedMetaData.Comment, TagType.Tone, None, None, "", "", ""))
+      )
+
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig)
+      val expectedImage = Some(Replace(
+        replaceSrc,
+        replaceDimensions,
+        replaceDimensions,
+        None
+      ))
+
+      curatedContent.image shouldBe expectedImage
     }
   }
 }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -121,13 +121,33 @@ class CuratedContentTest extends FreeSpec with Matchers with TestContent {
   }
 
   "CuratedContent images" - {
+    val replaceSrc = "https://somewhere-on-the-internet/replace-image.jpg"
+    val replaceDimensions = "100"
+    val cutoutSrc = "https://somewhere-on-the-internet/cutout-image.jpg"
+    val cutoutDimensions = "200"
+    val contentWithCommentTone = baseContent.copy(
+      fields = Some(ContentFields(headline = Some("Content headline"), trailText = Some("Content trailtext"), byline = Some("Content byline"))),
+      tags = List(Tag(ResolvedMetaData.Comment, TagType.Tone, None, None, "", "", ""))
+    )
+
+    "should default the cutout image for content with the Comment tone" in {
+      val trailMetadata = TrailMetaData(Map(
+        "imageCutoutSrc" -> JsString(cutoutSrc),
+        "imageCutoutSrcWidth" -> JsString(cutoutDimensions),
+        "imageCutoutSrcHeight" -> JsString(cutoutDimensions)
+      ))
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig)
+
+      val expectedImage = Some(Cutout(
+        cutoutSrc,
+        Some(cutoutDimensions),
+        Some(cutoutDimensions)
+      ))
+
+      curatedContent.image shouldBe expectedImage
+    }
+
     "should default to the replacement image, not the cutout image, when `imageReplace` is true for content with the Comment tone" in {
-      val replaceSrc = "https://somewhere-on-the-internet/replace-image.jpg"
-      val replaceDimensions = "100"
-
-      val cutoutSrc = "https://somewhere-on-the-internet/cutout-image.jpg"
-      val cutoutDimensions = "200"
-
       val trailMetadata = TrailMetaData(Map(
         "imageReplace" -> JsBoolean(true),
         "imageSrc" -> JsString(replaceSrc),
@@ -137,13 +157,8 @@ class CuratedContentTest extends FreeSpec with Matchers with TestContent {
         "imageCutoutSrcWidth" -> JsString(cutoutDimensions),
         "imageCutoutSrcHeight" -> JsString(cutoutDimensions)
       ))
-
-      val contentWithCommentTone = baseContent.copy(
-        fields = Some(ContentFields(headline = Some("Content headline"), trailText = Some("Content trailtext"), byline = Some("Content byline"))),
-        tags = List(Tag(ResolvedMetaData.Comment, TagType.Tone, None, None, "", "", ""))
-      )
-
       val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig)
+
       val expectedImage = Some(Replace(
         replaceSrc,
         replaceDimensions,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.2-SNAPSHOT"
+ThisBuild / version := "4.0.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.2"
+ThisBuild / version := "4.0.3-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Per @davidfurey's suggestion in an out-of-band discussion, this PR prioritises resolving image replacements over cutouts when we're getting images from trail meta.

This solves a problem where, for content with the Comment tone, replacement images are being ignored in favour of cutouts. This happens because we set `imageCutoutReplace` automatically when we encounter that tone.

AFAICS we don't set `imageReplace` automatically within this repo, and `facia-tool` sets that value exclusively of `imageCutoutReplace` [(when one image value is `true`, the others are not)](https://github.com/guardian/facia-tool/blob/3ff159815477af3f53e52624c2c44c81b85744a6/fronts-client/src/components/FrontsEdit/CardFormInline.tsx#L915), so we should not run into problems where this priority is incorrect.

## Dev notes

It's worth noting that this might not be the most comprehensive way of solving this problem – I'm fairly convinced it'd be better to make the decision about tags and defaults in the Fronts tool, and pass those decisions down as data –

- It puts the decision making for this sort of thing in one place
- It makes it clear what's going to happen in the UI of the Fronts tool, which will display the cutout if applied, etc.

A previous PR attempting to solve this problem [took the above approach](https://github.com/guardian/facia-scala-client/pull/222), but was [reverted](https://github.com/guardian/facia-scala-client/pull/233) as the changes required were more involved and would have required some co-ordination.

This codebase moves slowly, and this is a problem that's come up a few times recently, so I think this is a good patch even if we end taking the above approach in the future.

## How to test

- I've added a unit test which will fail with the old code in place.
- Import this library into [facia-press](https://github.com/guardian/frontend/tree/main/facia-press), perhaps via a snapshot release, deploy, and add [a piece with a Comment tone](https://composer.gutools.co.uk/content/631878878f08aab4f5b4cabd) to a front in CODE. Prior to this change, you will not be able to replace the image in the fronts tool. After it, that should work.

## How can we measure success?

Fewer editorial complaints about unexpected behaviour.