### PR TITLE
Add `SpecialReportAlt` to `CardStyle`

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala
@@ -3,11 +3,13 @@ package com.gu.facia.api.utils
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
 import com.gu.contentapi.client.utils.format.SpecialReportTheme
+import com.gu.contentapi.client.utils.format.SpecialReportAltTheme
 import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.client.models.{MetaDataCommonFields, TrailMetaData}
 
 object CardStyle {
   val specialReport = "special-report"
+  val specialReportAlt = "special-report-alt"
   val live = "live"
   val dead = "dead"
   val feature = "feature"
@@ -28,6 +30,8 @@ object CardStyle {
       ExternalLink
     } else if (content.theme == SpecialReportTheme) {
       SpecialReport
+    } else if (content.theme == SpecialReportAltTheme) {
+      SpecialReportAlt
     } else if (content.isLiveBlog) {
       if (content.isLive) {
         LiveBlog
@@ -62,6 +66,10 @@ sealed trait CardStyle {
 
 case object SpecialReport extends CardStyle {
   val toneString = CardStyle.specialReport
+}
+
+case object SpecialReportAlt extends CardStyle {
+  val toneString = CardStyle.specialReportAlt
 }
 
 case object LiveBlog extends CardStyle {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.0.3"
+  val capiVersion = "19.0.5-SNAPSHOT"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.0.5-SNAPSHOT"
+  val capiVersion = "19.0.5"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.3-SNAPSHOT"
+ThisBuild / version := "4.0.4-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.4-SNAPSHOT"
+ThisBuild / version := "4.0.3-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Adds `SpecialReportAlt` to `Cardstyle`. We need this in order to be able to style the SpecialReportAlt cards in fronts rendered by `frontend` as [it relies on `CardStyle` to decide the class of the card](https://github.com/guardian/frontend/blob/ec7b2ec484a13a6a458c81b4686162fe3545a1e5/common/app/views/support/GetClasses.scala#L38). 

This PR is the 2nd in this series:
1. `content-api-scala-client`: Adds SpecialReportAltTheme and SpecialReportAlt hashed tag to content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/371 
2. `facia-scala-client`: Adds SpecialReportAlt to CardStyle: https://github.com/guardian/facia-scala-client/pull/280 (**current**)
3. `frontend`: Consumes the new clients and adds card styles for fronts rendered by frontend: https://github.com/guardian/frontend/pull/25602

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested in frontend locally using the SNAPSHOT version.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
