### PR TITLE
adds specialReport palette to fronts

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -42,6 +42,7 @@ case object UnknownMetadata extends Metadata
 case object LongRunningAltPalette extends Metadata
 
 case object SombreAltPalette extends Metadata
+case object SpecialReportAlt extends Metadata
 
 object Metadata extends StrictLogging {
 
@@ -59,7 +60,8 @@ object Metadata extends StrictLogging {
     "EventAltPalette" -> EventAltPalette,
     "Podcast" -> Podcast,
     "LongRunningAltPalette" -> LongRunningAltPalette,
-    "SombreAltPalette" -> SombreAltPalette
+    "SombreAltPalette" -> SombreAltPalette,
+    "SpecialReportAlt" -> SpecialReportAlt
   )
 
   implicit object MetadataFormat extends Format[Metadata] {
@@ -90,6 +92,7 @@ object Metadata extends StrictLogging {
       case Podcast => JsObject(Seq("type" -> JsString("Podcast")))
       case LongRunningAltPalette => JsObject(Seq("type" -> JsString("LongRunningAltPalette")))
       case SombreAltPalette => JsObject(Seq("type" -> JsString("SombreAltPalette")))
+      case SpecialReportAlt => JsObject(Seq("type" -> JsString("SpecialReportAlt")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -42,7 +42,7 @@ case object UnknownMetadata extends Metadata
 case object LongRunningAltPalette extends Metadata
 
 case object SombreAltPalette extends Metadata
-case object SpecialReportAlt extends Metadata
+case object SpecialReportAltPalette extends Metadata
 
 object Metadata extends StrictLogging {
 
@@ -61,7 +61,7 @@ object Metadata extends StrictLogging {
     "Podcast" -> Podcast,
     "LongRunningAltPalette" -> LongRunningAltPalette,
     "SombreAltPalette" -> SombreAltPalette,
-    "SpecialReportAlt" -> SpecialReportAlt
+    "SpecialReportAltPalette" -> SpecialReportAltPalette
   )
 
   implicit object MetadataFormat extends Format[Metadata] {
@@ -92,7 +92,7 @@ object Metadata extends StrictLogging {
       case Podcast => JsObject(Seq("type" -> JsString("Podcast")))
       case LongRunningAltPalette => JsObject(Seq("type" -> JsString("LongRunningAltPalette")))
       case SombreAltPalette => JsObject(Seq("type" -> JsString("SombreAltPalette")))
-      case SpecialReportAlt => JsObject(Seq("type" -> JsString("SpecialReportAlt")))
+      case SpecialReportAltPalette => JsObject(Seq("type" -> JsString("SpecialReportAltPalette")))
       case UnknownMetadata => JsObject(Seq("type" -> JsString("UnknownMetadata")))
     }
   }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

In preparation for the release of a new type of special report a new Palette is required to facilitate this.
In this PR we are adding a `SpecialReportAlt` field to the tags so that users can select this as a type of article.

Name: SpecialReportAlt (TBC)

Tested Locally by `+publishLocal` and added to the lib in `facia-tool`. 


## How to test
Tested Locally by `+publishLocal` and added to the lib in `facia-tool` and check: https://fronts.local.dev-gutools.co.uk/v2

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This can be tested using publishLocal and then running the facia-tool locally to check for changes

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

|Name Here|
|--|
![2022-10-27 16 00 43](https://user-images.githubusercontent.com/49187886/198714308-5ed2606d-eb0d-4e04-aa3d-71a6bac1ee25.gif)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
