### PR TITLE
fix: Items queries starting with 'search' will be wrongly-run as search queries

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -60,7 +60,7 @@ object ContentApi extends StrictLogging {
 
     val paramsWithEditorsPicks = paramsWithFields :+ ("show-editors-picks" -> "false")
 
-    if (path.startsWith("search")) {
+    if (path == "search") {
       val searchQuery = SearchQuery()
       val queryWithParams = searchQuery.withParameters(paramsWithEditorsPicks.map { case (k, v) => k -> searchQuery.StringParameter(k, Some(v)) }.toMap)
       Right(queryWithParams)

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -71,6 +71,10 @@ class ContentApiTest extends FreeSpec
         ContentApi.buildBackfillQuery(backfill).isLeft should equal(true)
       }
 
+      "should produce an itemQuery instance for an item query starting with 'search'" in {
+        ContentApi.buildBackfillQuery("searchlight-pictures-nightmare-alley").isLeft should equal(true)
+      }
+
       "should use the given path for the itemQuery" in {
         ContentApi.buildBackfillQuery(backfill).left.value.id should equal("lifeandstyle/food-and-drink")
       }


### PR DESCRIPTION
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?

Switch from checking with 'startsWith' to checking a full equals of 'search' for the path. The previous 'startsWith' method was mis-classifying queries such as 'searchlight-pictures-the-banshees-of-inisherin', causing bugs for some backfilled containers.

Search queries look like:
`search?tag=...&stuff=...`

The broken item queries are
`searchlight-pictures-the-banshees-of-inisherin`

Because the item path becomes `search` in the first instance, and stays as `searchlight-pictures-the-banshees-of-inisherin` in the second, using .startsWith was capture both instances. This PR fixes that

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

We've added a test to cover this case for the future

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

We checked the full fronts tool config file, all the cases of using the `search?...` parameter would still work, and the remaining are the 'searchlight' type backfills which are currently broken 


## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
