### PR TITLE
Bump capi-client to 19.2.1

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -130,6 +130,7 @@ object TestModel {
     def shouldHideReaderRevenue: Option[Boolean] = None
     def internalCommissionedWordcount: Option[Int] = None
     def showAffiliateLinks: Option[Boolean] = None
+    def showTableOfContents: Option[Boolean] = None
   }
   implicit val stubFieldsFormat = Json.reads[StubFields]
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.0.5"
+  val capiVersion = "19.2.1"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.646"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

Bumps CAPI client to 19.2.1. We want to have access to an updated special report alt tag. PR that updated it here: https://github.com/guardian/content-api-scala-client/pull/380

We need this change for `facia-press` to be able to get the correct theme from the client:
* CAPI client [decides SpecialReportAlt theme based on the tag ](https://github.com/guardian/content-api-scala-client/blob/main/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala#L181)
* facia-client decides `CardStyle` based on the `content.theme` that's [coming from CAPI client](https://github.com/guardian/facia-scala-client/blob/main/fapi-client/src/main/scala/com/gu/facia/api/utils/CardStyle.scala#L33-L34)
* [`facia-press` uses `CardStyle`](https://github.com/guardian/frontend/blob/bc5d6427ef3e9a4f1c0026fac240689659c3ffa2/common/app/model/CardStylePicker.scala#L13-L15). This will affect the style of the cards on fronts rendered by frontend.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Tested successfully locally with the SNAPSHOT version in `facia-tool` and `frontend` by running:
* `compile`
* `Test / compile`
* `test`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
