### PR TITLE
Drop support for no-longer-used Play version v2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,10 +47,8 @@ val sonatypeReleaseSettings = Seq(
 )
 
 lazy val root = (project in file(".")).aggregate(
-    faciaJson_play26,
     faciaJson_play27,
     faciaJson_play28,
-    fapiClient_play26,
     fapiClient_play27,
     fapiClient_play28
   ).settings(
@@ -60,7 +58,6 @@ lazy val root = (project in file(".")).aggregate(
   )
 
 val exactPlayJsonVersions = Map(
-  "26" -> "2.6.13",
   "27" -> "2.7.4",
   "28" -> "2.8.1"
 )
@@ -110,11 +107,9 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
 lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.11")
 
 
-lazy val faciaJson_play26 = faciaJson_playJsonVersion("26")
 lazy val faciaJson_play27 = faciaJson_playJsonVersion("27").settings(crossCompileScala213)
 lazy val faciaJson_play28 = faciaJson_playJsonVersion("28").settings(crossCompileScala213)
 
-lazy val fapiClient_play26 = fapiClient_playJsonVersion("26").dependsOn(faciaJson_play26)
 lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27).settings(crossCompileScala213)
 lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28).settings(crossCompileScala213)
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,6 +72,7 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
       Resolver.typesafeRepo("releases")
     ),
     scalaVersion := "2.12.18",
+    crossScalaVersions := Seq(scalaVersion.value, "2.13.11"),
     scalacOptions := Seq(
         "-feature",
         "-deprecation",
@@ -104,12 +105,9 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
     )
   )
 
-lazy val crossCompileScala213 = crossScalaVersions := Seq(scalaVersion.value, "2.13.11")
+lazy val faciaJson_play27 = faciaJson_playJsonVersion("27")
+lazy val faciaJson_play28 = faciaJson_playJsonVersion("28")
 
-
-lazy val faciaJson_play27 = faciaJson_playJsonVersion("27").settings(crossCompileScala213)
-lazy val faciaJson_play28 = faciaJson_playJsonVersion("28").settings(crossCompileScala213)
-
-lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27).settings(crossCompileScala213)
-lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28).settings(crossCompileScala213)
+lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27)
+lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28)
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val root = (project in file(".")).aggregate(
 
 val exactPlayJsonVersions = Map(
   "27" -> "2.7.4",
-  "28" -> "2.8.1"
+  "28" -> "2.8.2"
 )
 
 def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-play$majorMinorVersion", file(s"$module-play$majorMinorVersion"))
@@ -68,8 +68,7 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
     organization := "com.gu",
     resolvers ++= Seq(
       Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("public"),
-      Resolver.typesafeRepo("releases")
+      Resolver.sonatypeRepo("public")
     ),
     scalaVersion := "2.12.18",
     crossScalaVersions := Seq(scalaVersion.value, "2.13.11"),

--- a/fapi-client/src/test/scala/demo.sc
+++ b/fapi-client/src/test/scala/demo.sc
@@ -8,6 +8,8 @@ import com.gu.facia.client.{AmazonSdkS3Client, ApiClient}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+implicit val executionContext = scala.concurrent.ExecutionContext.global
+
 // demo config
 val apiKey = "INSERT_CONTENT_API_KEY_HERE"
 val awsProfileName = "cmsFronts"
@@ -24,7 +26,6 @@ implicit val apiClient: ApiClient = {
   }
   ApiClient("aws-frontend-store", "DEV", AmazonSdkS3Client(amazonS3Client))
 }
-implicit val executionContext = scala.concurrent.ExecutionContext.global
 
 val frontResult = FAPI.frontForPath("uk/business").fold(
   { err => s"error: $err"},

--- a/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
+++ b/fapi-client/src/test/scala/lib/IntegrationTestConfig.scala
@@ -18,7 +18,7 @@ trait IntegrationTestConfig extends ExecutionContext {
 
   implicit val capiClient: GuardianContentClient = {
     targetUrl.fold(ifEmpty = new GuardianContentClient(apiKey)) { targetUrl =>
-      new TestContentApiClient(apiKey, targetUrl)
+      TestContentApiClient(apiKey, targetUrl)
     }
   }
 


### PR DESCRIPTION
No Guardian projects are currently using the legacy `play-json` v2.6 artifacts...

### fapi-client
* [`fapi-client-play26`](https://github.com/search?q=org%3Aguardian+%22fapi-client-play26%22&type=code) - no uses
* [`fapi-client-play27`](https://github.com/search?q=org%3Aguardian+%22fapi-client-play27%22&type=code) - [guardian/frontend](https://github.com/guardian/frontend/blob/2406876dd02560fb1848117ba8494724e5b7bd62/project/Dependencies.scala#L38) , [guardian/apple-news](https://github.com/guardian/apple-news/blob/75d87e7e22d7c9c7c673b77ae9f18d269b631656/build.sbt#L116)
* [`fapi-client-play28`](https://github.com/search?q=org%3Aguardian+%22fapi-client-play28%22&type=code) - [guardian/facia-tool](https://github.com/guardian/facia-tool/blob/a2288afa79b5f40cb45afbef12289c34749f01ce/build.sbt#L97) , [guardian/mobile-apps-api](https://github.com/guardian/mobile-apps-api/blob/80874a25540ed92805a2aa3f9ce6f2bd2f3591a3/project/Dependencies.scala#L75) , [guardian/story-packages](https://github.com/guardian/story-packages/blob/1703cd2ee5f093fc769ddf168702d92bf5e9d8c0/build.sbt#L84)

### facia-json
* [`facia-json-play26`](https://github.com/search?q=org%3Aguardian+%22facia-json-play26%22&type=code) - no uses
* [`facia-json-play27`](https://github.com/search?q=org%3Aguardian+%22facia-json-play27%22&type=code) - [guardian/editors-picks-uploader](https://github.com/guardian/editors-picks-uploader/blob/70562ef76fd24af1a682096eea47d3b75605002f/build.sbt#L17)
* [`facia-json-play28`](https://github.com/search?q=org%3Aguardian+%22facia-json-play28%22&type=code) - no uses


...so we can stop releasing them!