### PR TITLE
Upgrade to play-json 3.x

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Facia Scala Client [![fapi-client-play28 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play28) [![Release](https://github.com/guardian/facia-scala-client/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/facia-scala-client/actions/workflows/release.yml)
+Facia Scala Client [![fapi-client-play30 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play30) [![Release](https://github.com/guardian/facia-scala-client/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/facia-scala-client/actions/workflows/release.yml)
 ==================
 
 Facia's Scala client is split into two parts.
@@ -11,13 +11,15 @@ easily-used types.
 
 ### Adding the dependency to SBT
 
+[![fapi-client-play30 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play30)
+
 [![fapi-client-play28 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play28)
 
 [![fapi-client-play27 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play27/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/fapi-client-play27)
 
 Add the following line to your [SBT build file](https://www.scala-sbt.org/1.0/docs/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "fapi-client-play28" % "3.3.3"
+    libraryDependencies += "com.gu" %% "fapi-client-play30" % "5.0.0"
 
 ### Using the library
 
@@ -36,6 +38,8 @@ The low-level Facia API client is designed to fetch and manipulate Facia's inter
 This library provides underlying behaviour for the main Fronts API client.
 
 ### Adding the dependency to SBT
+
+[![facia-json-play30 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/facia-json-play30/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/facia-json-play30)
 
 [![facia-json-play28 Scala version support](https://index.scala-lang.org/guardian/facia-scala-client/facia-json-play28/latest-by-scala-version.svg)](https://index.scala-lang.org/guardian/facia-scala-client/facia-json-play28)
 

--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ easily-used types.
 
 Add the following line to your [SBT build file](https://www.scala-sbt.org/1.0/docs/Basic-Def.html):
 
-    libraryDependencies += "com.gu" %% "fapi-client-play30" % "5.0.0"
+    libraryDependencies += "com.gu" %% "fapi-client-play30" % "x.y.z"
 
 ### Using the library
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-import Dependencies._
-import sbtrelease.ReleaseStateTransformations._
+import Dependencies.*
+import sbtrelease.ReleaseStateTransformations.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
 
 organization := "com.gu"
@@ -36,25 +36,13 @@ lazy val root = (project in file(".")).aggregate(
     sonatypeReleaseSettings
   )
 
-val exactPlayJsonVersions = Map(
-  "27" -> "2.7.4",
-  "28" -> "2.8.2",
-  "30" -> "3.0.1"
-)
-
-val playJsonGroupId = Map(
-  "27" -> "com.typesafe.play",
-  "28" -> "com.typesafe.play",
-  "30" -> "org.playframework"
-)
-
-def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-play$majorMinorVersion", file(s"$module-play$majorMinorVersion"))
+def baseProject(module: String, playJsonVersion: PlayJsonVersion) = Project(s"$module-${playJsonVersion.projectId}", file(s"$module-${playJsonVersion.projectId}"))
   .settings(
     sourceDirectory := baseDirectory.value / s"../$module/src",
     organization := "com.gu",
     resolvers ++= Resolver.sonatypeOssRepos("releases"),
     scalaVersion := "2.13.11",
-    crossScalaVersions := Seq(scalaVersion.value, "2.12.18"),
+    crossScalaVersions := Seq(scalaVersion.value, "2.12.18"), // ++ (if (playJsonVersion.supportsScala3) Seq("3.3.1") else Seq.empty),
     scalacOptions := Seq(
         "-release:11",
         "-feature",
@@ -65,18 +53,18 @@ def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-p
     sonatypeReleaseSettings
   )
 
-def faciaJson_playJsonVersion(majorMinorVersion: String) = baseProject("facia-json", majorMinorVersion)
+def faciaJson_playJsonVersion(playJsonVersion: PlayJsonVersion) = baseProject("facia-json", playJsonVersion)
   .settings(
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
-      playJsonGroupId(majorMinorVersion) %% "play-json" % exactPlayJsonVersions(majorMinorVersion),
+      playJsonVersion.lib,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
       scalaLogging
     )
   )
 
-def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-client", majorMinorVersion)
+def fapiClient_playJsonVersion(playJsonVersion: PlayJsonVersion) =  baseProject("fapi-client", playJsonVersion)
   .settings(
     libraryDependencies ++= Seq(
       contentApi,
@@ -87,13 +75,13 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
     )
   )
 
-lazy val faciaJson_play27 = faciaJson_playJsonVersion("27")
-lazy val faciaJson_play28 = faciaJson_playJsonVersion("28")
-lazy val faciaJson_play30 = faciaJson_playJsonVersion("30")
+lazy val faciaJson_play27 = faciaJson_playJsonVersion(PlayJsonVersion.V27)
+lazy val faciaJson_play28 = faciaJson_playJsonVersion(PlayJsonVersion.V28)
+lazy val faciaJson_play30 = faciaJson_playJsonVersion(PlayJsonVersion.V30)
 
-lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27)
-lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28)
-lazy val fapiClient_play30 = fapiClient_playJsonVersion("30").dependsOn(faciaJson_play30)
+lazy val fapiClient_play27 = fapiClient_playJsonVersion(PlayJsonVersion.V27).dependsOn(faciaJson_play27)
+lazy val fapiClient_play28 = fapiClient_playJsonVersion(PlayJsonVersion.V28).dependsOn(faciaJson_play28)
+lazy val fapiClient_play30 = fapiClient_playJsonVersion(PlayJsonVersion.V30).dependsOn(faciaJson_play30)
 
 Test/testOptions += Tests.Argument(
   TestFrameworks.ScalaTest,

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,10 @@ val sonatypeReleaseSettings = Seq(
 lazy val root = (project in file(".")).aggregate(
     faciaJson_play27,
     faciaJson_play28,
+    faciaJson_play30,
     fapiClient_play27,
-    fapiClient_play28
+    fapiClient_play28,
+    fapiClient_play30
   ).settings(
     publish / skip := true,
     sonatypeReleaseSettings
@@ -36,7 +38,14 @@ lazy val root = (project in file(".")).aggregate(
 
 val exactPlayJsonVersions = Map(
   "27" -> "2.7.4",
-  "28" -> "2.8.2"
+  "28" -> "2.8.2",
+  "30" -> "3.0.1"
+)
+
+val playJsonGroupId = Map(
+  "27" -> "com.typesafe.play",
+  "28" -> "com.typesafe.play",
+  "30" -> "org.playframework"
 )
 
 def baseProject(module: String, majorMinorVersion: String) = Project(s"$module-play$majorMinorVersion", file(s"$module-play$majorMinorVersion"))
@@ -61,7 +70,7 @@ def faciaJson_playJsonVersion(majorMinorVersion: String) = baseProject("facia-js
     libraryDependencies ++= Seq(
       awsSdk,
       commonsIo,
-      "com.typesafe.play" %% "play-json" % exactPlayJsonVersions(majorMinorVersion),
+      playJsonGroupId(majorMinorVersion) %% "play-json" % exactPlayJsonVersions(majorMinorVersion),
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
       scalaLogging
     )
@@ -80,9 +89,11 @@ def fapiClient_playJsonVersion(majorMinorVersion: String) =  baseProject("fapi-c
 
 lazy val faciaJson_play27 = faciaJson_playJsonVersion("27")
 lazy val faciaJson_play28 = faciaJson_playJsonVersion("28")
+lazy val faciaJson_play30 = faciaJson_playJsonVersion("30")
 
 lazy val fapiClient_play27 = fapiClient_playJsonVersion("27").dependsOn(faciaJson_play27)
 lazy val fapiClient_play28 = fapiClient_playJsonVersion("28").dependsOn(faciaJson_play28)
+lazy val fapiClient_play30 = fapiClient_playJsonVersion("30").dependsOn(faciaJson_play30)
 
 Test/testOptions += Tests.Argument(
   TestFrameworks.ScalaTest,

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -12,4 +12,21 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16" % Test
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.7"
+
+  case class PlayJsonVersion(
+    majorMinorVersion: String,
+    groupId: String,
+    exactPlayJsonVersion: String,
+    supportsScala3: Boolean = false
+  ) {
+    val projectId = s"play$majorMinorVersion"
+
+    val lib: ModuleID = groupId %% "play-json" % exactPlayJsonVersion
+  }
+
+  object PlayJsonVersion {
+    val V27 = PlayJsonVersion("27", "com.typesafe.play", "2.7.4")
+    val V28 = PlayJsonVersion("28", "com.typesafe.play", "2.8.2")
+    val V30 = PlayJsonVersion("30", "org.playframework", "3.0.1", supportsScala3 = true)
+  }
 }


### PR DESCRIPTION
Re-raising @mkurz's PR:
* https://github.com/guardian/facia-scala-client/pull/298

It has to be raised by someone in The Guardian organisation for the build to run.

It is required for:
* https://github.com/guardian/frontend/pull/26755 

## What does this change?
Adds fapi-client and facia-json Play 3 support.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Compiles successfully locally with the SNAPSHOT version in this frontend PR:
* https://github.com/guardian/frontend/pull/26755 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
