### PR TITLE
Prevent runtime incompatibility with 'early-semver' `content-api-scala-client`

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -185,6 +185,7 @@ object TestModel {
     tags: Seq[StubTag],
     elements: Option[Seq[StubElement]]
   ) extends Content {
+    val channels: Option[Seq[ContentChannel]] = None // alternatively, create StubContentChannel
     def `type`: ContentType = ContentType.list.find(byName(typeName)(_)).get
     def sectionId: Option[String] = None
     def sectionName: Option[String] = None

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.2.3"
+  val capiVersion = "20.0.2"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.524"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
Now that both `content-api-models` and `content-api-scala-client` are both using 'early-semver' and adhering to it (thanks to [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) and `sbt-version-policy`) this should mean that it is **no longer possible** for a single project that depends on `content-api-scala-client`, `content-api-models` and `facia-scala-client` to have _incompatible_ versions of those artifacts.

This should prevent **horrible runtime compatibility errors** like https://github.com/guardian/facia-scala-client/issues/301, which occurred with the rollout of the innocent-looking changes in `facia-scala-client` [v4.0.6](https://github.com/guardian/facia-scala-client/releases/tag/v4.0.6).

# `sbt` messaging when incompatibility is introduced 

As ana example, this is the _"suspected to be binary incompatible"_ compile time error you'll get in [`facia-tool`](https://github.com/guardian/facia-tool/) if you try to upgrade the FAPI client library to 5.0.0, without also upgrading the version of the CAPI client to match:

```
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* com.gu:content-api-client_2.13:20.0.2 (early-semver) is selected over 19.2.1
[error] 	    +- com.gu:fapi-client-play28_2.13:5.0.0               (depends on 20.0.2)
[error] 	    +- com.gu:content-api-client-default_2.13:19.2.1      (depends on 19.2.1)
```

Just upgrading the CAPI client version to the ultimately-selected version (`20.0.2`) will fix the problem here.

In general, you want to upgrade any related library to be compiled against the _selected_ library version - so in the example above, any library we're using in `facia-tool` that depends on the CAPI client, needs to have been compiled against CAPI client version `20.0.x` (the `x` there is because we can tolerate PATCH level version differences).