### PR TITLE
Bump CAPI scala client

### DIFF
--- a/fapi-client/src/test/resources/branding/FoundationTag.json
+++ b/fapi-client/src/test/resources/branding/FoundationTag.json
@@ -9,6 +9,7 @@
   "activeSponsorships": [
     {
       "sponsorshipTypeName": "sponsored",
+      "sponsorshipPackageName": "default",
       "sponsorName": "Fairtrade Foundation",
       "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
       "sponsorLink": "http://www.fairtrade.org.uk/",

--- a/fapi-client/src/test/resources/branding/FoundationTag2.json
+++ b/fapi-client/src/test/resources/branding/FoundationTag2.json
@@ -9,6 +9,7 @@
   "activeSponsorships": [
     {
       "sponsorshipTypeName": "sponsored",
+      "sponsorshipPackageName": "default",
       "sponsorName": "Fairtrade Foundation",
       "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
       "sponsorLink": "http://www.fairtrade.org.uk/",

--- a/fapi-client/src/test/resources/branding/InappropriateContent.json
+++ b/fapi-client/src/test/resources/branding/InappropriateContent.json
@@ -35,6 +35,7 @@
       "activeSponsorships": [
         {
           "sponsorshipTypeName": "sponsored",
+          "sponsorshipPackageName": "default",
           "sponsorName": "Fairtrade Foundation",
           "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
           "sponsorLink": "http://www.fairtrade.org.uk/"

--- a/fapi-client/src/test/resources/branding/PaidTag.json
+++ b/fapi-client/src/test/resources/branding/PaidTag.json
@@ -7,6 +7,7 @@
   "activeSponsorships": [
     {
       "sponsorshipTypeName": "paid-content",
+      "sponsorshipPackage": "default",
       "sponsorName": "Las Vegas Tourism",
       "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/16/Mar/2017/8b15f5a5-7d9d-4c8f-ae1b-5ab72654fd15-LasVegas_4c_207_Red.png",
       "sponsorLink": "http://viva.lasvegas.com",

--- a/fapi-client/src/test/resources/branding/TagBrandedContent-MultipleBrands.json
+++ b/fapi-client/src/test/resources/branding/TagBrandedContent-MultipleBrands.json
@@ -32,6 +32,7 @@
       "activeSponsorships": [
         {
           "sponsorshipTypeName": "sponsored",
+          "sponsorshipPackageName": "default",
           "sponsorName": "Fairtrade Foundation",
           "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
           "sponsorLink": "http://www.fairtrade.org.uk/",

--- a/fapi-client/src/test/resources/branding/TagBrandedContent.json
+++ b/fapi-client/src/test/resources/branding/TagBrandedContent.json
@@ -32,6 +32,7 @@
       "activeSponsorships": [
         {
           "sponsorshipTypeName": "sponsored",
+          "sponsorshipPackageName": "default",
           "sponsorName": "Fairtrade Foundation",
           "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
           "sponsorLink": "http://www.fairtrade.org.uk/",

--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -29,6 +29,9 @@ object TestModel {
     implicit object SponsorshipType extends HasName[SponsorshipType] {
       def nameOf(t: SponsorshipType): String = t.name
     }
+    implicit object SponsorshipPackage extends HasName[SponsorshipPackage] {
+      def nameOf(t: SponsorshipPackage): String = t.name
+    }
   }
 
   private def byName[A](otherName: String)(a: A)(implicit n: HasName[A]): Boolean =
@@ -52,6 +55,7 @@ object TestModel {
 
   case class TestSponsorship(
     sponsorshipTypeName: String,
+    sponsorshipPackageName: Option[String],
     sponsorName: String,
     sponsorLogo: String,
     sponsorLink: String,
@@ -63,6 +67,8 @@ object TestModel {
   ) extends Sponsorship {
     def sponsorshipType: SponsorshipType =
       SponsorshipType.list.find(byName(sponsorshipTypeName)(_)).get
+    def sponsorshipPackage: Option[SponsorshipPackage] =
+      sponsorshipPackageName.flatMap(p => SponsorshipPackage.list.find(byName(p)(_)))
     def validFrom = None
     def validTo = None
   }
@@ -205,6 +211,7 @@ object TestModel {
     def pillarId: Option[String] = None
     def pillarName: Option[String] = None
     def aliasPaths: Option[Seq[AliasPath]] = None
+    def channels: Option[collection.Seq[ContentChannel]] = None
   }
   implicit val stubItemFormat: Reads[StubItem] = Json.reads[StubItem]
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "19.2.3"
+  val capiVersion = "21.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.524"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

Upgrades to the newest CAPI scala client. So that projects that depend on CAPI scala client and facia-scala-client can upgrade to the newest CAPI client which is binary incompatible with the current version used by facia-scala-client
