### PR TITLE
Add Play v2.9 support to aid Facia Tool upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ description := "Scala client for The Guardian's Facia JSON API"
 
 val sonatypeReleaseSettings = Seq(
   licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-  releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+  // releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -27,9 +27,11 @@ val sonatypeReleaseSettings = Seq(
 lazy val root = (project in file(".")).aggregate(
     faciaJson_play27,
     faciaJson_play28,
+    faciaJson_play29,
     faciaJson_play30,
     fapiClient_play27,
     fapiClient_play28,
+    fapiClient_play29,
     fapiClient_play30
   ).settings(
     publish / skip := true,
@@ -77,10 +79,12 @@ def fapiClient_playJsonVersion(playJsonVersion: PlayJsonVersion) =  baseProject(
 
 lazy val faciaJson_play27 = faciaJson_playJsonVersion(PlayJsonVersion.V27)
 lazy val faciaJson_play28 = faciaJson_playJsonVersion(PlayJsonVersion.V28)
+lazy val faciaJson_play29 = faciaJson_playJsonVersion(PlayJsonVersion.V29)
 lazy val faciaJson_play30 = faciaJson_playJsonVersion(PlayJsonVersion.V30)
 
 lazy val fapiClient_play27 = fapiClient_playJsonVersion(PlayJsonVersion.V27).dependsOn(faciaJson_play27)
 lazy val fapiClient_play28 = fapiClient_playJsonVersion(PlayJsonVersion.V28).dependsOn(faciaJson_play28)
+lazy val fapiClient_play29 = fapiClient_playJsonVersion(PlayJsonVersion.V29).dependsOn(faciaJson_play29)
 lazy val fapiClient_play30 = fapiClient_playJsonVersion(PlayJsonVersion.V30).dependsOn(faciaJson_play30)
 
 Test/testOptions += Tests.Argument(

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "21.0.0"
+  val capiVersion = "22.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.524"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
@@ -27,6 +27,7 @@ object Dependencies {
   object PlayJsonVersion {
     val V27 = PlayJsonVersion("27", "com.typesafe.play", "2.7.4")
     val V28 = PlayJsonVersion("28", "com.typesafe.play", "2.8.2")
+    val V29 = PlayJsonVersion("29", "com.typesafe.play", "2.10.4", supportsScala3 = true)
     val V30 = PlayJsonVersion("30", "org.playframework", "3.0.1", supportsScala3 = true)
   }
 }


### PR DESCRIPTION
Whether you get benefit from going 2.8→2.9→3.0 (over just going 2.8→3.0) is probably a factor of how big and complicated the project being upgraded is (see also https://github.com/guardian/maintaining-scala-projects/issues/4) - I'd guess Facia Tool is quite big, so breaking the changes down into smaller chunks might be worth it in terms of avoiding risk.

Obviously we're encouraging people to get onto Play 3.0 to avoid the Akka BSL licensing issue!

Note also that Play 2.9 actually uses Play-Json *2.10*, which is a bit surprising!


