### PR TITLE
Update aws-java-sdk-s3 to remove ion-java

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val capiVersion = "23.0.0"
 
-  val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.524"
+  val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"
   val contentApi = "com.gu" %% "content-api-client" % capiVersion
   val contentApiDefault = "com.gu" %% "content-api-client-default" % capiVersion % Test


### PR DESCRIPTION
There’s a vulnerability in ion-java, which is depended on by the current version of aws-java-sdk-s3, but removed from 1.12.638 forward. This change updates that dependency to its newest version to remove the ion-java dependency and facilitate removal of the vulnerability from projects which depend on this one.

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
