### PR TITLE
Update CAPI dependency

### DIFF
--- a/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/TestModel.scala
@@ -5,6 +5,7 @@ import java.time.ZoneOffset.UTC
 import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
 import com.gu.contentapi.client.model.v1._
+import com.gu.contentapi.client.model.schemaorg.SchemaOrg
 import play.api.libs.json._
 
 import scala.io.Source
@@ -212,6 +213,7 @@ object TestModel {
     def pillarName: Option[String] = None
     def aliasPaths: Option[Seq[AliasPath]] = None
     def channels: Option[collection.Seq[ContentChannel]] = None
+    def schemaOrg: Option[SchemaOrg] = None
   }
   implicit val stubItemFormat: Reads[StubItem] = Json.reads[StubItem]
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "23.0.0"
+  val capiVersion = "24.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

This bumps the CAPI version to a version that includes schema org models (see https://github.com/guardian/content-api-scala-client/pull/408, https://github.com/guardian/content-api/pull/2858, https://github.com/guardian/content-api-models/pull/237, and https://github.com/guardian/frontend/pull/26931 for more context)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
