### PR TITLE
Bump and test content-api-client preview release version

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "26.0.0"
+  val capiVersion = "27.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
We are testing `content-entity` latest release that is out after adopting gha-scala-release-process init, 
the version is updated in `content-api-model` and `content-api-client` so we need to test these libraries preview releases in fapi client too.

The intention is to test all these preview releases in any of client consuming these linbraries, we have `apple-news` and ` pubflow` for example.

## How to test

Make a preview release. test in `apple-news`

## How can we measure success?

Application should compile with no version conflicts between libraries
Application shoud run well without any erros.
