### PR TITLE
Update CAPI Scala Client -> 26.0.0

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "25.0.0"
+  val capiVersion = "26.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

This brings in the timeline element changes (https://github.com/guardian/content-api-scala-client/pull/414) - see also https://github.com/guardian/content-api-models/pull/245.