### PR TITLE
Bump CAPI version to allow rolling out change to CAPI model

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "27.0.0"
+  val capiVersion = "31.0.2"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

Only bumps CAPI, to allow us to roll out a binary compatible version of CAPI client, CAPI model and Facia client to various projects