### PR TITLE
Update default collection type

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -37,7 +37,7 @@ case class CollectionConfig(
     frontsToolSettings: Option[FrontsToolSettings])
 
 object CollectionConfig {
-  val DefaultCollectionType = "fixed/small/slow-VI"
+  val DefaultCollectionType = "fixed/small/slow-IV"
 
   val empty = CollectionConfig(
     displayName = None,


### PR DESCRIPTION
## What does this change?

Swaps "fixed/small/slow-**VI**" for "fixed/small/slow-**IV**"

## Why

The container type "fixed/small/slow-VI" does not exist, so it looks like this might be a mistake. MAPI updated the equivalent logic in 2017: https://github.com/guardian/mobile-apps-api/pull/1038

Though, I'm not even sure this is ever used! The git blame says this was last updated about 10 years ago 😵 (https://github.com/guardian/facia-scala-client/pull/31)