### PR TITLE
Drop Scala 2.12 and Play 2.7, begin partial support for Scala 3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-21.0.3.9.1
+java corretto-11.0.23.9.1

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,11 @@ import Dependencies.*
 import sbtrelease.ReleaseStateTransformations.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease
 
-organization := "com.gu"
-
 name := "facia-api-client"
 
 description := "Scala client for The Guardian's Facia JSON API"
 
 val sonatypeReleaseSettings = Seq(
-  licenses := Seq("Apache V2" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
@@ -24,12 +21,25 @@ val sonatypeReleaseSettings = Seq(
   )
 )
 
+def artifactProducingSettings(supportScala3: Boolean) = Seq(
+  organization := "com.gu",
+  licenses := Seq(License.Apache2),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
+  scalaVersion := "2.13.14",
+  crossScalaVersions := Seq(scalaVersion.value) ++ (if (supportScala3) Seq("3.3.3") else Seq.empty),
+  scalacOptions := Seq(
+    "-release:8",
+    "-feature",
+    "-deprecation",
+    "-Xfatal-warnings"
+  ),
+  libraryDependencies += scalaTest
+)
+
 lazy val root = (project in file(".")).aggregate(
-    faciaJson_play27,
     faciaJson_play28,
     faciaJson_play29,
     faciaJson_play30,
-    fapiClient_play27,
     fapiClient_play28,
     fapiClient_play29,
     fapiClient_play30
@@ -38,24 +48,12 @@ lazy val root = (project in file(".")).aggregate(
     sonatypeReleaseSettings
   )
 
-def baseProject(module: String, playJsonVersion: PlayJsonVersion) = Project(s"$module-${playJsonVersion.projectId}", file(s"$module-${playJsonVersion.projectId}"))
+def playJsonSpecificProject(module: String, playJsonVersion: PlayJsonVersion) = Project(s"$module-${playJsonVersion.projectId}", file(s"$module-${playJsonVersion.projectId}"))
   .settings(
-    sourceDirectory := baseDirectory.value / s"../$module/src",
-    organization := "com.gu",
-    resolvers ++= Resolver.sonatypeOssRepos("releases"),
-    scalaVersion := "2.13.13",
-    crossScalaVersions := Seq(scalaVersion.value, "2.12.19"), // ++ (if (playJsonVersion.supportsScala3) Seq("3.3.1") else Seq.empty),
-    scalacOptions := Seq(
-        "-release:11",
-        "-feature",
-        "-deprecation",
-        "-Xfatal-warnings"
-    ),
-    libraryDependencies += scalaTest,
-    sonatypeReleaseSettings
+    sourceDirectory := baseDirectory.value / s"../$module/src"
   )
 
-def faciaJson_playJsonVersion(playJsonVersion: PlayJsonVersion) = baseProject("facia-json", playJsonVersion)
+def faciaJson(playJsonVersion: PlayJsonVersion) = playJsonSpecificProject("facia-json", playJsonVersion)
   .settings(
     libraryDependencies ++= Seq(
       awsSdk,
@@ -63,10 +61,11 @@ def faciaJson_playJsonVersion(playJsonVersion: PlayJsonVersion) = baseProject("f
       playJsonVersion.lib,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0",
       scalaLogging
-    )
+    ),
+    artifactProducingSettings(supportScala3 = playJsonVersion.supportsScala3)
   )
 
-def fapiClient_playJsonVersion(playJsonVersion: PlayJsonVersion) =  baseProject("fapi-client", playJsonVersion)
+def fapiClient(playJsonVersion: PlayJsonVersion) =  playJsonSpecificProject("fapi-client", playJsonVersion)
   .settings(
     libraryDependencies ++= Seq(
       contentApi,
@@ -74,18 +73,17 @@ def fapiClient_playJsonVersion(playJsonVersion: PlayJsonVersion) =  baseProject(
       commercialShared,
       scalaTestMockito,
       mockito
-    )
+    ),
+    artifactProducingSettings(supportScala3 = false) // currently blocked by contentApi & commercialShared clients
   )
 
-lazy val faciaJson_play27 = faciaJson_playJsonVersion(PlayJsonVersion.V27)
-lazy val faciaJson_play28 = faciaJson_playJsonVersion(PlayJsonVersion.V28)
-lazy val faciaJson_play29 = faciaJson_playJsonVersion(PlayJsonVersion.V29)
-lazy val faciaJson_play30 = faciaJson_playJsonVersion(PlayJsonVersion.V30)
+lazy val faciaJson_play28 = faciaJson(PlayJsonVersion.V28)
+lazy val faciaJson_play29 = faciaJson(PlayJsonVersion.V29)
+lazy val faciaJson_play30 = faciaJson(PlayJsonVersion.V30)
 
-lazy val fapiClient_play27 = fapiClient_playJsonVersion(PlayJsonVersion.V27).dependsOn(faciaJson_play27)
-lazy val fapiClient_play28 = fapiClient_playJsonVersion(PlayJsonVersion.V28).dependsOn(faciaJson_play28)
-lazy val fapiClient_play29 = fapiClient_playJsonVersion(PlayJsonVersion.V29).dependsOn(faciaJson_play29)
-lazy val fapiClient_play30 = fapiClient_playJsonVersion(PlayJsonVersion.V30).dependsOn(faciaJson_play30)
+lazy val fapiClient_play28 = fapiClient(PlayJsonVersion.V28).dependsOn(faciaJson_play28)
+lazy val fapiClient_play29 = fapiClient(PlayJsonVersion.V29).dependsOn(faciaJson_play29)
+lazy val fapiClient_play30 = fapiClient(PlayJsonVersion.V30).dependsOn(faciaJson_play30)
 
 Test/testOptions += Tests.Argument(
   TestFrameworks.ScalaTest,

--- a/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/ConfigSpec.scala
@@ -54,7 +54,7 @@ class ConfigSpec extends AnyFlatSpec with Matchers with OptionValues with Resour
 
     val collection = config.collections.get("uk/commentisfree/most-viewed/regular-stories").value
     val collectionWithTerritory = collection.copy(targetedTerritory = Some(NZTerritory))
-    val json = Json.toJson(collectionWithTerritory).toString()
-    json shouldBe """{"displayName":"Most popular","backfill":{"type":"capi","query":"uk/commentisfree?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true"},"type":"news/most-popular","uneditable":true,"targetedTerritory":"NZ"}"""
+    val json = Json.toJson(collectionWithTerritory)
+    json shouldBe Json.parse("""{"displayName":"Most popular","backfill":{"type":"capi","query":"uk/commentisfree?show-most-viewed=true&show-editors-picks=false&hide-recent-content=true"},"type":"news/most-popular","uneditable":true,"targetedTerritory":"NZ"}""")
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -25,7 +25,6 @@ object Dependencies {
   }
 
   object PlayJsonVersion {
-    val V27 = PlayJsonVersion("27", "com.typesafe.play", "2.7.4")
     val V28 = PlayJsonVersion("28", "com.typesafe.play", "2.8.2")
     val V29 = PlayJsonVersion("29", "com.typesafe.play", "2.10.4", supportsScala3 = true)
     val V30 = PlayJsonVersion("30", "org.playframework", "3.0.2", supportsScala3 = true)


### PR DESCRIPTION
Fixes #317, meaning that PRs like #287 can use Scala 2.13 features. Also dropping Play 2.7- [Play 2.8 was end-of-life (EOL) on 31st May 2024](https://github.com/playframework/playframework/releases/tag/2.8.21), so dropping support for Play 2.7 seems very reasonable!

Running the tests under Scala 3 required 3690941515d0f0c3e97781f202d0bd1aa915e0a8, fixing a test so that it doesn't rely on JSON object's field order.

## Consumers of `facia-scala-client`

All 7 consumers of the `facia-scala-client` library are now on Scala 2.13 (last one to upgrade was https://github.com/guardian/story-packages/pull/195!), and Play 2.8 or above, so they do not pose blockers to dropping Scala 2.12 and Play 2.7:

- [guardian/ophan](https://github.com/guardian/ophan/blob/4d51e80d85b0dacae2bc6966ed6f2e380119f26e/build.sbt#L92) - [Play 3.0.4](https://github.com/guardian/ophan/blob/4d51e80d85b0dacae2bc6966ed6f2e380119f26e/project/plugins.sbt#L3)
- [guardian/frontend](https://github.com/guardian/frontend/blob/1a25c1d9e5d1787660cb0502a65252b424c22ed2/project/ProjectSettings.scala#L35) - [Play 3.0.4](https://github.com/guardian/frontend/blob/1a25c1d9e5d1787660cb0502a65252b424c22ed2/project/plugins.sbt#L12)
- [guardian/apple-news](https://github.com/guardian/apple-news/blob/30fa9ea149c9b8296bd58a196030b9012958bc07/build.sbt#L8) - [Play 3.0.2](https://github.com/guardian/apple-news/blob/30fa9ea149c9b8296bd58a196030b9012958bc07/project/plugins.sbt#L7)
- [guardian/editors-picks-uploader](https://github.com/guardian/editors-picks-uploader/blob/bfc5c3524751c6c51be3cdf8c6cab159b295dc45/build.sbt#L4) - AWS Lambda, doesn't use Play
- [guardian/facia-tool](https://github.com/guardian/facia-tool/blob/00b5de0c43ef0a9f474844def545e6295f7d632a/build.sbt#L11) - [Play 3.0.2](https://github.com/guardian/facia-tool/blob/00b5de0c43ef0a9f474844def545e6295f7d632a/project/plugins.sbt#L15)
- [guardian/story-packages](https://github.com/guardian/story-packages/blob/041d6946a1da3d24f687dd4ff643798d8d160887/build.sbt#L13) - [Play 2.8.19](https://github.com/guardian/story-packages/blob/041d6946a1da3d24f687dd4ff643798d8d160887/project/plugins.sbt#L9)
- [guardian/mobile-apps-api](https://github.com/guardian/mobile-apps-api/blob/3a0fd3b7e17e138747fec5bd816bb5579069952a/build.sbt#L5) - [Play 3.0.3](https://github.com/guardian/mobile-apps-api/blob/3a0fd3b7e17e138747fec5bd816bb5579069952a/project/plugins.sbt#L3)

