### PR TITLE
[fairground] Add BoostLevel attribute in card meta data

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -30,6 +30,7 @@ sealed trait MetaDataCommonFields {
   lazy val imageSrcHeight: Option[String] = json.get("imageSrcHeight").flatMap(_.asOpt[String])
   lazy val isBreaking: Option[Boolean] = json.get("isBreaking").flatMap(_.asOpt[Boolean])
   lazy val isBoosted: Option[Boolean] = json.get("isBoosted").flatMap(_.asOpt[Boolean])
+  lazy val boostLevel: Option[String] = json.get("boostLevel").flatMap(_.asOpt[String])
   lazy val imageHide: Option[Boolean] = json.get("imageHide").flatMap(_.asOpt[Boolean])
   lazy val imageReplace: Option[Boolean] = json.get("imageReplace").flatMap(_.asOpt[Boolean])
   lazy val showMainVideo: Option[Boolean] = json.get("showMainVideo").flatMap(_.asOpt[Boolean])

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -155,6 +155,12 @@ object FaciaContentUtils {
     linkSnap => linkSnap.properties.isBoosted,
     latestSnap => latestSnap.properties.isBoosted
   )
+  def boostLevel(fc: FaciaContent): BoostLevel = fold(fc)(
+    curatedContent => curatedContent.properties.boostLevel,
+    supportingCuratedContent => supportingCuratedContent.properties.boostLevel,
+    linkSnap => linkSnap.properties.boostLevel,
+    latestSnap => latestSnap.properties.boostLevel
+  )
   def showBoostedHeadline(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showBoostedHeadline,
     supportingCuratedContent => supportingCuratedContent.properties.showBoostedHeadline,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -4,6 +4,30 @@ import com.gu.facia.client.models.MetaDataCommonFields
 import play.api.libs.json.{Format, Json}
 import com.gu.contentapi.client.model.v1.{Content, Element, ElementType}
 
+sealed trait BoostLevel {
+  def label: String
+}
+
+object BoostLevel {
+  case object Default extends BoostLevel {
+    val label = "default"
+  }
+  case object Boost extends BoostLevel {
+    val label = "boost"
+  }
+  case object MegaBoost extends BoostLevel {
+    val label = "megaboost"
+  }
+  case object GigaBoost extends BoostLevel {
+    val label = "gigaboost"
+  }
+  def fromMetaData(value: String): BoostLevel = value match {
+    case GigaBoost.label => GigaBoost
+    case MegaBoost.label => MegaBoost
+    case Boost.label => Boost
+    case _ => Default
+  }
+}
 
 object ResolvedMetaData {
   implicit val resolvedMetaDataFormat: Format[ResolvedMetaData] = Json.format[ResolvedMetaData]
@@ -24,6 +48,7 @@ object ResolvedMetaData {
   val Default = ResolvedMetaData(
     isBreaking = false,
     isBoosted = false,
+    boostLevel = BoostLevel.Default.label,
     imageHide = false,
     imageReplace = false,
     showKickerSection = false,
@@ -41,6 +66,7 @@ object ResolvedMetaData {
     ResolvedMetaData(
       isBreaking = trailMeta.isBreaking.exists(identity),
       isBoosted = trailMeta.isBoosted.exists(identity),
+      boostLevel = trailMeta.boostLevel.getOrElse(BoostLevel.Default.label),
       imageHide = trailMeta.imageHide.exists(identity),
       imageReplace = trailMeta.imageReplace.exists(identity),
       showKickerSection = trailMeta.showKickerSection.exists(identity),
@@ -71,6 +97,7 @@ object ResolvedMetaData {
     metaDataFromContent.copy(
       isBreaking = trailMeta.isBreaking.getOrElse(metaDataFromContent.isBreaking),
       isBoosted = trailMeta.isBoosted.getOrElse(metaDataFromContent.isBoosted),
+      boostLevel = trailMeta.boostLevel.getOrElse(BoostLevel.Default.label),
       imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide),
       imageReplace = trailMeta.imageReplace.getOrElse(metaDataFromContent.imageReplace),
       showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
@@ -88,6 +115,7 @@ object ResolvedMetaData {
     case ResolvedMetaData(
       isBreaking,
       isBoosted,
+      boostLevel,
       imageHide,
       imageReplace,
       showKickerSection,
@@ -103,6 +131,10 @@ object ResolvedMetaData {
       Map(
         "isBreaking" -> isBreaking,
         "isBoosted" -> isBoosted,
+        "boostLevel.default" -> (BoostLevel.fromMetaData(boostLevel) == BoostLevel.Default),
+        "boostLevel.boost" -> (BoostLevel.fromMetaData(boostLevel) == BoostLevel.Boost),
+        "boostLevel.megaboost" -> (BoostLevel.fromMetaData(boostLevel) == BoostLevel.MegaBoost),
+        "boostLevel.gigaBoost" -> (BoostLevel.fromMetaData(boostLevel) == BoostLevel.GigaBoost),
         "imageHide" -> imageHide,
         "imageReplace" -> imageReplace,
         "showKickerSection" -> showKickerSection,
@@ -121,6 +153,7 @@ object ResolvedMetaData {
 case class ResolvedMetaData(
     isBreaking: Boolean,
     isBoosted: Boolean,
+    boostLevel: String,
     imageHide: Boolean,
     imageReplace: Boolean,
     showKickerSection: Boolean,
@@ -139,6 +172,7 @@ object ContentProperties {
     ContentProperties(
       isBreaking = resolvedMetaData.isBreaking,
       isBoosted = resolvedMetaData.isBoosted,
+      boostLevel = BoostLevel.fromMetaData(resolvedMetaData.boostLevel),
       imageHide = resolvedMetaData.imageHide,
       showBoostedHeadline = resolvedMetaData.showBoostedHeadline,
       showMainVideo = resolvedMetaData.showMainVideo,
@@ -152,6 +186,7 @@ object ContentProperties {
 case class ContentProperties(
     isBreaking: Boolean,
     isBoosted: Boolean,
+    boostLevel: BoostLevel,
     imageHide: Boolean,
     showBoostedHeadline: Boolean,
     showMainVideo: Boolean,

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -1,11 +1,13 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.v1.ContentFields
-import com.gu.facia.api.utils.{ContentProperties, DefaultCardstyle, FaciaContentUtils}
+import com.gu.facia.api.utils.{BoostLevel, ContentProperties, DefaultCardstyle, FaciaContentUtils}
 import com.gu.facia.client.models.{Trail, TrailMetaData}
 import lib.TestContent
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import com.gu.facia.client.models.CollectionConfigJson
+import play.api.libs.json.JsString
 
 class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent {
 
@@ -14,6 +16,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
   val emptyContentProperties =
     ContentProperties(
       isBreaking = false,
+      boostLevel = BoostLevel.Default,
       isBoosted = false,
       imageHide = false,
       showBoostedHeadline = false,
@@ -56,6 +59,18 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
     val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty)
     FaciaContentUtils.href(cc) should equal(None)
   }
+
+  "should return default boost level for a CuratedContent if the boostLevel is not present in meta data" in {
+    val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("myByline"))))
+    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData.empty, None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+    FaciaContentUtils.boostLevel(cc) should equal(BoostLevel.Default)
+  }
+
+  "should return boost level for a CuratedContent" in {
+    val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("myByline"))))
+    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData(Map("boostLevel" -> JsString("gigaboost"))), None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+    FaciaContentUtils.boostLevel(cc) should equal(BoostLevel.GigaBoost)
+  }  
 
   "should return a href for a LatestSnap" in {
     val snap = LatestSnap("myId",


### PR DESCRIPTION
## What does this change?

We (the fairground team) is building the new dynamic containers as part of the homepage redesign project.

A pull request guardian/facia-tool#1611 has been raised to support new dynamic containers in the fronts tool.  A new property `boostLevel` is added to the meta data of cards.

This pull request extends the facia Scala client library to expose the `boostLevel` as a new property of `ContentProperties` to the platform.

## How to test

Test cases have been added to validate the new property.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
