### PR TITLE
Fix release so that it does not attempt to use Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ name := "facia-api-client"
 
 description := "Scala client for The Guardian's Facia JSON API"
 
+ThisBuild / scalaVersion := "2.13.14"
+
 val sonatypeReleaseSettings = Seq(
   releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
@@ -25,7 +27,6 @@ def artifactProducingSettings(supportScala3: Boolean) = Seq(
   organization := "com.gu",
   licenses := Seq(License.Apache2),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
-  scalaVersion := "2.13.14",
   crossScalaVersions := Seq(scalaVersion.value) ++ (if (supportScala3) Seq("3.3.3") else Seq.empty),
   scalacOptions := Seq(
     "-release:8",


### PR DESCRIPTION
After https://github.com/guardian/facia-scala-client/pull/318 dropped support for Scala 2.12, release 8.0.1 correctly no longer published Scala 2.12 artifacts, but unfortunately the 'root' project (which does not have any code!) was still defaulting to using Scala 2.12, because that is the default sbt uses if no `scalaVersion` is set.

The next time we tried to do a release (https://github.com/guardian/facia-scala-client/pull/319#issuecomment-2263535032) the automated-compatibility checking failed, because it saw that one project was using Scala 2.12, and so it attempted to download all the non-existent Scala 2.12 artifacts for release 8.0.1[^1] - and failed.

To fix this, we can simply ensure that all modules in this sbt build default to Scala 2.13, not 2.12 - ie particularly, the 'root' module!

## Testing

We [ran a preview release on this PR](https://github.com/guardian/facia-scala-client/actions/runs/10213913578), and the automated-compatibility checking succeeded 👍 :

![image](https://github.com/user-attachments/assets/3e547dee-a27f-4db8-9974-36784c14a311)



[^1]: This behaviour seems like a bug in `sbt-version-policy`?! `sbt-version-policy` is already aware of the `publish / skip := true` flag, so should know that `root` does not have any artifacts...