### PR TITLE
Gitignore VSCode And Metals Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ project/plugins/project/
 # Maven
 log/
 target/
+
+# VSCode
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt


### PR DESCRIPTION
They're IDE config and build files, not intended for version control.
