### PR TITLE
Add Europe edition to findBranding function

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ContentApiUtils.scala
@@ -53,7 +53,7 @@ object ContentApiUtils {
   }
 
   private def findBranding[T: Brandable](brandable: T): BrandingByEdition = {
-    val editions = Seq("uk", "us", "au", "int")
+    val editions = Seq("uk", "us", "au", "int", "eur")
     editions.map { edition =>
       edition -> BrandingFinder.findBranding(edition)(brandable)
     }.toMap


### PR DESCRIPTION
## What does this change?
Adds the Europe edition ID "eur" to the editions mapped over in the findBranding function. This should mean that edition branding will now be added for the Europe edition. This will enable the correct styling of labs containers and cards when the Europe edition is selected.

Tested on CODE and the EditionBranding now pulls through for "EUR" correctly:

![Screenshot 2024-09-24 at 15 55 28](https://github.com/user-attachments/assets/685b04ad-3e92-4b2c-b985-76b64318946f)

