### PR TITLE
Remove suppress images prop from fronts tool settings

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -191,8 +191,8 @@ object FrontsToolSettings {
 }
 
 case class FrontsToolSettings (
-  displayEditWarning: Option[Boolean],
-  suppressImages: Option[Boolean])
+  displayEditWarning: Option[Boolean]
+)
 
 object DisplayHintsJson {
   implicit val jsonFormat: OFormat[DisplayHintsJson] = Json.format[DisplayHintsJson]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -226,7 +226,8 @@ object CollectionConfigJson {
     userVisibility: Option[String] = None,
     targetedTerritory: Option[TargetedTerritory] = None,
     platform: Option[CollectionPlatform] = None,
-    frontsToolSettings: Option[FrontsToolSettings] = None
+    frontsToolSettings: Option[FrontsToolSettings] = None,
+    suppressImages: Option[Boolean] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -249,7 +250,8 @@ object CollectionConfigJson {
     userVisibility,
     targetedTerritory,
     platform,
-    frontsToolSettings
+    frontsToolSettings,
+    suppressImages
   )
 }
 
@@ -275,7 +277,7 @@ case class CollectionConfigJson(
   targetedTerritory: Option[TargetedTerritory],
   platform: Option[CollectionPlatform],
   frontsToolSettings: Option[FrontsToolSettings],
-
+  suppressImages: Option[Boolean]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -34,7 +34,8 @@ case class CollectionConfig(
     userVisibility: Option[String],
     targetedTerritory: Option[TargetedTerritory],
     platform: CollectionPlatform = AnyPlatform,
-    frontsToolSettings: Option[FrontsToolSettings])
+    frontsToolSettings: Option[FrontsToolSettings],
+    suppressImages: Boolean)
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-IV"
@@ -60,7 +61,8 @@ object CollectionConfig {
     userVisibility = None,
     targetedTerritory = None,
     platform = AnyPlatform,
-    frontsToolSettings = None)
+    frontsToolSettings = None,
+    suppressImages = false)
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -84,5 +86,6 @@ object CollectionConfig {
       collectionJson.userVisibility,
       collectionJson.targetedTerritory,
       collectionJson.platform.getOrElse(AnyPlatform),
-      collectionJson.frontsToolSettings)
+      collectionJson.frontsToolSettings,
+      collectionJson.suppressImages.exists(identity))
 }


### PR DESCRIPTION
## What does this change?

Moves the suppressImages value from a collection's frontsToolSettings to the collection itself - this is now the preferred approach to ensure full functionality of suppressing images on a container. 

Will be used by the fronts tool via this [PR](https://github.com/guardian/facia-tool/pull/1672)
