### PR TITLE
Add `containerStyle` and `imageAspectRatio` fields to collection config

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -227,7 +227,9 @@ object CollectionConfigJson {
     targetedTerritory: Option[TargetedTerritory] = None,
     platform: Option[CollectionPlatform] = None,
     frontsToolSettings: Option[FrontsToolSettings] = None,
-    suppressImages: Option[Boolean] = None
+    suppressImages: Option[Boolean] = None,
+    containerStyle: Option[String] = None,
+    imageAspectRatio: Option[String] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -251,8 +253,9 @@ object CollectionConfigJson {
     targetedTerritory,
     platform,
     frontsToolSettings,
-    suppressImages
-  )
+    suppressImages,
+    containerStyle,
+    imageAspectRatio)
 }
 
 case class CollectionConfigJson(
@@ -277,7 +280,9 @@ case class CollectionConfigJson(
   targetedTerritory: Option[TargetedTerritory],
   platform: Option[CollectionPlatform],
   frontsToolSettings: Option[FrontsToolSettings],
-  suppressImages: Option[Boolean]
+  suppressImages: Option[Boolean],
+  containerStyle: Option[String],
+  imageAspectRatio: Option[String]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -35,7 +35,9 @@ case class CollectionConfig(
     targetedTerritory: Option[TargetedTerritory],
     platform: CollectionPlatform = AnyPlatform,
     frontsToolSettings: Option[FrontsToolSettings],
-    suppressImages: Boolean)
+    suppressImages: Boolean,
+    containerStyle: Option[String],
+    imageAspectRatio: Option[String])
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-IV"
@@ -62,7 +64,9 @@ object CollectionConfig {
     targetedTerritory = None,
     platform = AnyPlatform,
     frontsToolSettings = None,
-    suppressImages = false)
+    suppressImages = false,
+    containerStyle = None,
+    imageAspectRatio = None)
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -87,5 +91,7 @@ object CollectionConfig {
       collectionJson.targetedTerritory,
       collectionJson.platform.getOrElse(AnyPlatform),
       collectionJson.frontsToolSettings,
-      collectionJson.suppressImages.exists(identity))
+      collectionJson.suppressImages.exists(identity),
+      collectionJson.containerStyle,
+      collectionJson.imageAspectRatio)
 }


### PR DESCRIPTION
## What does this change?

Adds two fields to collection config model:
- `containerStyle`
- `imageAspectRatio`

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
