### PR TITLE
Add primary and secondary options to the list of tags

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -13,6 +13,10 @@ case class Backfill(
 
 sealed trait Metadata
 
+case object Primary extends Metadata
+
+case object Secondary extends Metadata
+
 case object Canonical extends Metadata
 
 case object Special extends Metadata
@@ -47,6 +51,8 @@ case object SpecialReportAltPalette extends Metadata
 object Metadata extends StrictLogging {
 
   val tags: Map[String, Metadata] = Map(
+    "Primary" -> Primary,
+    "Secondary" -> Secondary,
     "Canonical" -> Canonical,
     "Special" -> Special,
     "Breaking" -> Breaking,
@@ -78,6 +84,8 @@ object Metadata extends StrictLogging {
     }
 
     def writes(cardStyle: Metadata) = cardStyle match {
+      case Primary => JsObject(Seq("type" -> JsString("Primary")))
+      case Secondary => JsObject(Seq("type" -> JsString("Secondary")))
       case Canonical => JsObject(Seq("type" -> JsString("Canonical")))
       case Special => JsObject(Seq("type" -> JsString("Special")))
       case Breaking => JsObject(Seq("type" -> JsString("Breaking")))


### PR DESCRIPTION
## What does this change?

Part of the fairgound project, specifically [this ticket](https://trello.com/c/WHWQmmsL/525-allow-changing-the-container-level-between-primary-and-secondary-in-the-config-tool). Adds primary and secondary options to the list of available tags - which will be used to adjust the styling on platforms. 

## How can we measure success?

Can be seen in the list of tags in facia tool using the preview release : 

<img width="341" alt="image" src="https://github.com/user-attachments/assets/dfa14f87-cab0-42c7-bd80-23c7cec9eb18">

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
