### PR TITLE
Remove `Primary` container level

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -13,10 +13,6 @@ case class Backfill(
 
 sealed trait Metadata
 
-case object SecondaryLevel extends Metadata
-
-case object Primary extends Metadata
-
 case object Secondary extends Metadata
 
 case object Canonical extends Metadata
@@ -53,8 +49,6 @@ case object SpecialReportAltPalette extends Metadata
 object Metadata extends StrictLogging {
 
   val tags: Map[String, Metadata] = Map(
-    "SecondaryLevel" -> SecondaryLevel,
-    "Primary" -> Primary,
     "Secondary" -> Secondary,
     "Canonical" -> Canonical,
     "Special" -> Special,
@@ -87,8 +81,6 @@ object Metadata extends StrictLogging {
     }
 
     def writes(cardStyle: Metadata) = cardStyle match {
-      case SecondaryLevel => JsObject(Seq("type" -> JsString("SecondaryLevel")))
-      case Primary => JsObject(Seq("type" -> JsString("Primary")))
       case Secondary => JsObject(Seq("type" -> JsString("Secondary")))
       case Canonical => JsObject(Seq("type" -> JsString("Canonical")))
       case Special => JsObject(Seq("type" -> JsString("Special")))


### PR DESCRIPTION
## What does this change?

Removes the `Primary` metadata value.

The previous implementation had both `Primary` and `Secondary` as metadata options but since all containers are considered "primary" unless specified as "secondary", we can reduce this to just one option.

## How to test

Deploy a pre-release version of this branch (e.g. https://github.com/guardian/facia-scala-client/actions/runs/11892277827) and use this in the `facia-tool` repo (see commits on https://github.com/guardian/facia-tool/pull/1728). Run the `facia-tool` locally or deploy to CODE to test changes there.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
