### PR TITLE
Hide media if no cutout available

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -67,7 +67,7 @@ object ResolvedMetaData {
       isBreaking = trailMeta.isBreaking.exists(identity),
       isBoosted = trailMeta.isBoosted.exists(identity),
       boostLevel = trailMeta.boostLevel.getOrElse(BoostLevel.Default.label),
-      imageHide = trailMeta.imageHide.exists(identity),
+      imageHide = trailMeta.imageHide.exists(identity) || overrideImageHide(trailMeta),
       imageReplace = trailMeta.imageReplace.exists(identity),
       showKickerSection = trailMeta.showKickerSection.exists(identity),
       showKickerCustom = trailMeta.showKickerCustom.exists(identity),
@@ -92,18 +92,18 @@ object ResolvedMetaData {
         case _ => Default
       }
 
-
+  private def overrideImageHide(trailMeta: MetaDataCommonFields) = {
+    // If cutout requested but none available, automatically toggle hide media
+    trailMeta.imageCutoutReplace.getOrElse(false) && trailMeta.imageCutoutSrc.isEmpty
+  }
+  
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields, cardStyle: CardStyle): ResolvedMetaData = {
     val metaDataFromContent = fromContent(content, cardStyle)
-
-    // If cutout requested but none available, automatically toggle hide media
-    val shouldHideMedia = trailMeta.imageCutoutReplace.getOrElse(false) && trailMeta.imageCutoutSrc.isEmpty
-
     metaDataFromContent.copy(
       isBreaking = trailMeta.isBreaking.getOrElse(metaDataFromContent.isBreaking),
       isBoosted = trailMeta.isBoosted.getOrElse(metaDataFromContent.isBoosted),
       boostLevel = trailMeta.boostLevel.getOrElse(BoostLevel.Default.label),
-      imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide || shouldHideMedia),
+      imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide) || overrideImageHide(trailMeta),
       imageReplace = trailMeta.imageReplace.getOrElse(metaDataFromContent.imageReplace),
       showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
       showKickerCustom = trailMeta.showKickerCustom.getOrElse(metaDataFromContent.showKickerCustom),

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -92,13 +92,18 @@ object ResolvedMetaData {
         case _ => Default
       }
 
+
   def fromContentAndTrailMetaData(content: Content, trailMeta: MetaDataCommonFields, cardStyle: CardStyle): ResolvedMetaData = {
     val metaDataFromContent = fromContent(content, cardStyle)
+
+    // If cutout requested but none available, automatically toggle hide media
+    val shouldHideMedia = trailMeta.imageCutoutReplace.getOrElse(false) && trailMeta.imageCutoutSrc.isEmpty
+
     metaDataFromContent.copy(
       isBreaking = trailMeta.isBreaking.getOrElse(metaDataFromContent.isBreaking),
       isBoosted = trailMeta.isBoosted.getOrElse(metaDataFromContent.isBoosted),
       boostLevel = trailMeta.boostLevel.getOrElse(BoostLevel.Default.label),
-      imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide),
+      imageHide = trailMeta.imageHide.getOrElse(metaDataFromContent.imageHide || shouldHideMedia),
       imageReplace = trailMeta.imageReplace.getOrElse(metaDataFromContent.imageReplace),
       showKickerSection = trailMeta.showKickerSection.getOrElse(metaDataFromContent.showKickerSection),
       showKickerCustom = trailMeta.showKickerCustom.getOrElse(metaDataFromContent.showKickerCustom),


### PR DESCRIPTION
## What does this change?

If a cutout was requested (e.g. for `Comment` cards) but there is no cutout available, this should default to toggle the `hideImage` option on instead of showing the trail image by default.

[Trello ticket](https://trello.com/c/8E0k3BoJ/717-opinion-card-hide-media-by-default-if-no-cutout)

## How to test

[Create a pre-release version](https://github.com/guardian/facia-scala-client/blob/main/README.markdown#building-a-release) and install to a [`facia-tool`](https://github.com/guardian/facia-tool) branch then run locally or deploy to the CODE environment to check that:
- Comment cards with cutouts available still show the cutout
- Comment cards without cutouts available default to hide the image. You should be able to untoggle this and revert to the trail image in the fronts tool
- Other card behaviour should remain unchanged

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
