### PR TITLE
Add setup-sbt to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,7 @@ jobs:
           # 'Facia-Scala-Client-CI-Role-Provider' cloudformation stack.
           role-to-assume: ${{ secrets.AWS_ROLE_FOR_TESTS }}
           aws-region: eu-west-1
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 11
-          cache: sbt
+      - uses: guardian/setup-scala@v1
       - name: Build and Test
         run: sbt -v +test
       - name: Test Summary


### PR DESCRIPTION
## What does this change?
As we're so dependent on `sbt` and the `sbt launcher` hence we should provide this in our workflow so that external dependency wouldn't matter such as we had failed workflows on upgraded version of ubuntu recently because it has no sbt information in it.
So, to save us from these kind of issues we will provide our own setup-sbt as an action to resolve sbt easily.

## How to test
Raise this PR and observe running CI.

## How can we measure success?
Build should run as normal and no failing CI should be observed.