### PR TITLE
define reference snap and include in FaciaContentUtils.fold

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -166,6 +166,21 @@ case class LinkSnap(
   override val brandingByEdition: BrandingByEdition
 ) extends Snap
 
+case class ReferenceSnap (
+  id: String,
+  maybeFrontPublicationDate: Option[Long],
+  snapType: String,
+  headline: Option[String],
+  href: Option[String],
+  trailText: Option[String],
+  group: String,
+  image: Option[FaciaImage],
+  properties: ContentProperties,
+  kicker: Option[ItemKicker],
+  snapReferenceType: String,
+  snapReferenceId: String,
+) extends Snap
+
 case class LatestSnap(
   id: String,
   maybeFrontPublicationDate: Option[Long],


### PR DESCRIPTION
## What does this change?

Adds a 3rd variety of Snap, the "ReferenceSnap" (the existing one being "LinkSnap" and "LatestSnap").

The intent is that the "ReferenceSnap" would be used on Fronts to point to an arbitrary entity that can be identified by the   `snapReferenceType` and `snapReferenceId` which the platforms can look-up and render some element representing that entity (or safely render nothing if the platform does not support an element for the entity type or does not have access to the data/content needed).

The current use-case envisaged is promotion blocks for newsletters (currently done using thrashers) - for example the, [first dog on the moon newsletter](https://newsletters-tool.gutools.co.uk/launched/first-dog) could be represented by a "ReferenceSnap" with {snapReferenceType: "newsletter", snapReferenceId: "first-dog"}.

It could also be used to reflex other non-article entities, such as  guardian podcast series or custom content of the sort added in https://github.com/guardian/dotcom-rendering/pull/12593


 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
