### PR TITLE
Bump CAPI scala client to v33

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "32.0.0"
+  val capiVersion = "33.0.0"
 
   val awsSdk = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.673"
   val commonsIo = "org.apache.commons" % "commons-io" % "1.3.2"


### PR DESCRIPTION
## What does this change?

Bump to support changes to to the CAPI Scala Client:

- Multi byline contributor: https://github.com/guardian/content-api-models/pull/254 (via https://github.com/guardian/content-api-scala-client/pull/438)
- Crossword Design: https://github.com/guardian/content-api-scala-client/pull/437

We are bumping the CAPI Scala client in frontend, we'll also beed to bump facia-scala-client to get the build to pass: https://github.com/guardian/frontend/pull/27698