### PR TITLE
Free up room in CollectionConfig case classes

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -202,7 +202,7 @@ object DisplayHintsJson {
   implicit val jsonFormat: OFormat[DisplayHintsJson] = Json.format[DisplayHintsJson]
 }
 
-case class DisplayHintsJson(maxItemsToDisplay: Option[Int])
+case class DisplayHintsJson(maxItemsToDisplay: Option[Int], suppressImages: Option[Boolean] = None)
 
 object CollectionConfigJson {
   implicit val jsonFormat: OFormat[CollectionConfigJson] = Json.format[CollectionConfigJson]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Config.scala
@@ -230,8 +230,7 @@ object CollectionConfigJson {
     userVisibility: Option[String] = None,
     targetedTerritory: Option[TargetedTerritory] = None,
     platform: Option[CollectionPlatform] = None,
-    frontsToolSettings: Option[FrontsToolSettings] = None,
-    suppressImages: Option[Boolean] = None
+    frontsToolSettings: Option[FrontsToolSettings] = None
   ): CollectionConfigJson
     = CollectionConfigJson(
     displayName,
@@ -254,8 +253,7 @@ object CollectionConfigJson {
     userVisibility,
     targetedTerritory,
     platform,
-    frontsToolSettings,
-    suppressImages
+    frontsToolSettings
   )
 }
 
@@ -280,8 +278,7 @@ case class CollectionConfigJson(
   userVisibility: Option[String],
   targetedTerritory: Option[TargetedTerritory],
   platform: Option[CollectionPlatform],
-  frontsToolSettings: Option[FrontsToolSettings],
-  suppressImages: Option[Boolean]
+  frontsToolSettings: Option[FrontsToolSettings]
   ) {
   val collectionType = `type`
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -35,8 +35,8 @@ case class CollectionConfig(
     userVisibility: Option[String],
     targetedTerritory: Option[TargetedTerritory],
     platform: CollectionPlatform = AnyPlatform,
-    frontsToolSettings: Option[FrontsToolSettings],
-    suppressImages: Boolean)
+    frontsToolSettings: Option[FrontsToolSettings]
+   )
 
 object CollectionConfig {
   val DefaultCollectionType = "fixed/small/slow-IV"
@@ -62,8 +62,8 @@ object CollectionConfig {
     userVisibility = None,
     targetedTerritory = None,
     platform = AnyPlatform,
-    frontsToolSettings = None,
-    suppressImages = false)
+    frontsToolSettings = None
+  )
 
   def fromCollectionJson(collectionJson: CollectionConfigJson): CollectionConfig =
     CollectionConfig(
@@ -87,8 +87,8 @@ object CollectionConfig {
       collectionJson.userVisibility,
       collectionJson.targetedTerritory,
       collectionJson.platform.getOrElse(AnyPlatform),
-      collectionJson.frontsToolSettings,
-      collectionJson.suppressImages.exists(identity))
+      collectionJson.frontsToolSettings
+    )
 
   sealed trait AspectRatio {
     def label: String

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -5,11 +5,12 @@ import com.gu.facia.client.models.{AnyPlatform, Backfill, CollectionConfigJson, 
 
 case class Groups(groups: List[String])
 
-case class DisplayHints(maxItemsToDisplay: Option[Int])
+case class DisplayHints(maxItemsToDisplay: Option[Int], suppressImages: Option[Boolean])
 
 object DisplayHints {
   def fromDisplayHintsJson(displayHintsJson: DisplayHintsJson): DisplayHints = DisplayHints(
-    maxItemsToDisplay = displayHintsJson.maxItemsToDisplay
+    maxItemsToDisplay = displayHintsJson.maxItemsToDisplay,
+    suppressImages = displayHintsJson.suppressImages
   )
 }
 


### PR DESCRIPTION
## What does this change?

Case classes in Scala have a limit of 22 fields (the limit was removed in 2.12 but there are still other issues with this limit, such as the .unapply method not working). 

We would like to free up some room in the CollectionConfig case classes to make room for a new field which will handle the number of stories a container can have in respect to Splash, Large and Small cards.

## How to test

Compiles as expected. Newer versions of the API client will need to retrieve the `suppressImages` field from DisplayHints field rather than directly from the CollectionConfig.
