### PR TITLE
Add deeply-read as a potential source of backfill content

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -88,7 +88,7 @@ object ContentApi extends StrictLogging {
                                  (implicit ec: ExecutionContext): Response[List[Content]] = {
     response.fold(
       _.map { itemResponse =>
-        (itemResponse.mostViewed.getOrElse(Nil) ++ itemResponse.results.getOrElse(Nil)).toList
+        (itemResponse.mostViewed.getOrElse(Nil) ++ itemResponse.deeplyRead.getOrElse(Nil) ++ itemResponse.results.getOrElse(Nil)).toList
       },
       _.map { searchResponse =>
         searchResponse.results.toList

--- a/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/contentapi/ContentApiTest.scala
@@ -129,6 +129,7 @@ class ContentApiTest extends AnyFreeSpec
       when(itemResponse.results) thenReturn someContents
       when(itemResponse.editorsPicks) thenReturn Some(Nil)
       when(itemResponse.mostViewed) thenReturn Some(Nil)
+      when(itemResponse.deeplyRead) thenReturn Some(Nil)
       val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
       ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
         err => fail(s"expected contents result, got error $err"),
@@ -141,6 +142,20 @@ class ContentApiTest extends AnyFreeSpec
       when(itemResponse.results) thenReturn Some(Nil)
       when(itemResponse.editorsPicks) thenReturn Some(Nil)
       when(itemResponse.mostViewed) thenReturn someContents
+      when(itemResponse.deeplyRead) thenReturn Some(Nil)
+      val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
+      ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
+        err => fail(s"expected contents result, got error $err"),
+        result => result should be(contents)
+      )
+    }
+
+    "includes deeply read in item query backfill" in {
+      val itemResponse = mock[ItemResponse]
+      when(itemResponse.results) thenReturn Some(Nil)
+      when(itemResponse.editorsPicks) thenReturn Some(Nil)
+      when(itemResponse.mostViewed) thenReturn Some(Nil)
+      when(itemResponse.deeplyRead) thenReturn someContents
       val response: Either[Response[ItemResponse], Response[SearchResponse]] = Left(Response.Right(itemResponse))
       ContentApi.backfillContentFromResponse(response).asFuture.futureValue.fold(
         err => fail(s"expected contents result, got error $err"),

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "33.0.0"
+  val capiVersion = "34.0.0"
   val eTagCachingVersion = "7.0.0"
 
   val awsS3SdkV1 = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.765"


### PR DESCRIPTION
## What does this change?

Updates content-api-client to a version that knows about deeplyRead.

Adds Deeply Read articles (if present in CAPI response) to the backfilled content, in the same way as mostViewed is.

Hopefully the order of mostViewed/deeplyRead doesn't matter - I don't anticipate backfill queries searching for both mostViewed and deeplyRead