### PR TITLE
Add method to apply default boost levels

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -205,35 +205,23 @@ object FAPI {
     case snap: LinkSnap => snap.copy(group = group)
   }
 
-  private def applyDefaultBoost[T](
-    content: T,
-    default: BoostLevel,
-    allowedBoosts: List[BoostLevel],
-    getBoostLevel: T => BoostLevel,
-    setBoostLevel: (T, BoostLevel) => T
-  ): T =
-    if (allowedBoosts.contains(getBoostLevel(content)))
-      content
-    else
-      setBoostLevel(content, default)
-
   case class GroupBoostConfig(default: BoostLevel, allowedBoosts: List[BoostLevel], maxItems: Int, group: String)
 
   private val flexibleGeneralBoosts = List(
     // Splash
     GroupBoostConfig(BoostLevel.Default, List(BoostLevel.Default, BoostLevel.Boost, BoostLevel.MegaBoost, BoostLevel.GigaBoost), maxItems = 1, group = "3"),
-    // Very large
+    // Very big
     GroupBoostConfig(BoostLevel.MegaBoost, List(BoostLevel.MegaBoost), maxItems = 0, group = "2"),
-    // Large
+    // Big
     GroupBoostConfig(BoostLevel.Boost, List(BoostLevel.Boost, BoostLevel.MegaBoost), maxItems = 0, group = "1"),
     // Standard
     GroupBoostConfig(BoostLevel.Default, List(BoostLevel.Default, BoostLevel.Boost, BoostLevel.MegaBoost), maxItems = 8, group = "0")
   )
 
   private def boostsConfigFor(collectionType: String, groupsConfig: List[GroupConfig]): Option[List[GroupBoostConfig]] = {
-    val groupsConfigBiggestFirst = groupsConfig.reverse
+    val groupsConfigTopGroupFirst = groupsConfig.reverse
     condOpt(collectionType) {
-      case "flexible/general" => flexibleGeneralBoosts.zip(groupsConfigBiggestFirst).map { case (boosts, groupConfig) =>
+      case "flexible/general" => flexibleGeneralBoosts.zip(groupsConfigTopGroupFirst).map { case (boosts, groupConfig) =>
         boosts.copy(maxItems = groupConfig.maxItems.getOrElse(boosts.maxItems))
       }
     }

--- a/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/FAPI.scala
@@ -223,12 +223,14 @@ object FAPI {
     GroupBoostConfig(BoostLevel.Default, List(BoostLevel.Default, BoostLevel.Boost, BoostLevel.MegaBoost), maxItems = 8)
   )
 
-  private def boostsConfigFor(collectionType: String, groupsConfig: List[GroupConfig]): Option[List[GroupBoostConfig]] =
+  private def boostsConfigFor(collectionType: String, groupsConfig: List[GroupConfig]): Option[List[GroupBoostConfig]] = {
+    val groupsConfigBiggestFirst = groupsConfig.reverse
     condOpt(collectionType) {
-      case "flexible/general" => flexibleGeneralBoosts.zip(groupsConfig).map { case (boosts, groupConfig) =>
+      case "flexible/general" => flexibleGeneralBoosts.zip(groupsConfigBiggestFirst).map { case (boosts, groupConfig) =>
         boosts.copy(maxItems = groupConfig.maxItems.getOrElse(boosts.maxItems))
       }
     }
+  }
 
   def applyDefaultBoostLevels(collectionConfig: CollectionConfig, contents: List[FaciaContent]): List[FaciaContent] = {
     applyDefaultBoostLevels[FaciaContent](collectionConfig.groupsConfig, collectionConfig.collectionType,


### PR DESCRIPTION
## What does this change?

Adds a new method applyDefaultBoostLevelsAndGroups which allows platforms to apply the correct boosts and groups to each card after backfilling and deduping has been completed.

It will also ensure that groups within containers are correctly limited to their max items and have appropriate card sizes for flexible/general.

There a two versions of the new method. One is very generic, which allows dotcom to use it with its own internal card data structure. One is tied to the `FaciaContent` type, which is convenient for MAPI.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
