### PR TITLE
Add max limit of sublinks shown a card

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -40,7 +40,7 @@ object Collection {
   }
 
   /** Cards can have varying amounts of supporting content (sublinks) depending on their boostlevel**/
-  def maxSupportingItems(value: String): Int = value match {
+  private def maxSupportingItems(value: String): Int = value match {
     case BoostLevel.Default.label => 2
     case BoostLevel.Boost.label => 2
     case BoostLevel.MegaBoost.label => 4

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -56,9 +56,8 @@ object Collection {
     // if content is not in the set it was most likely filtered out by the CAPI query, so exclude it
     // note that this does not currently deal with e.g. snaps
     def resolveTrail(trail: Trail): Option[FaciaContent] = {
-         val boostLevel = trail.safeMeta.boostLevel
-         val maxItems = maxSupportingItems(boostLevel.getOrElse(""))
-
+      val boostLevel = trail.safeMeta.boostLevel
+      val maxItems = maxSupportingItems(boostLevel.getOrElse(""))
 
       content.find { c =>
         trail.id.endsWith("/" + c.fields.flatMap(_.internalPageCode).getOrElse(throw new RuntimeException("No internal page code")))

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -5,6 +5,9 @@ import com.gu.facia.api.contentapi.{LatestSnapsRequest, LinkSnapsRequest}
 import com.gu.facia.api.utils.IntegerString
 import com.gu.facia.client.models.{CollectionJson, SupportingItem, TargetedTerritory, Trail}
 import org.joda.time.DateTime
+import com.gu.facia.api.utils.{BoostLevel}
+import com.gu.facia.api.utils.ResolvedMetaData
+
 
 case class Collection(
   id: String,
@@ -36,6 +39,15 @@ object Collection {
       collectionConfig.targetedTerritory)
   }
 
+  /** Cards can have varying amounts of supporting content (sublinks) depending on their boostlevel**/
+  def maxSupportingItems(value: String): Int = value match {
+    case BoostLevel.Default.label => 2
+    case BoostLevel.Boost.label => 2
+    case BoostLevel.MegaBoost.label => 4
+    case BoostLevel.GigaBoost.label => 4
+    case _ => 4
+  }
+
   def contentFrom(collection: Collection,
                   content: Set[Content],
                   snapContent: Map[String, Option[Content]] = Map.empty,
@@ -44,13 +56,17 @@ object Collection {
     // if content is not in the set it was most likely filtered out by the CAPI query, so exclude it
     // note that this does not currently deal with e.g. snaps
     def resolveTrail(trail: Trail): Option[FaciaContent] = {
+         val boostLevel = trail.safeMeta.boostLevel
+         val maxItems = maxSupportingItems(boostLevel.getOrElse(""))
+
+
       content.find { c =>
         trail.id.endsWith("/" + c.fields.flatMap(_.internalPageCode).getOrElse(throw new RuntimeException("No internal page code")))
       }
         .map { content =>
         trail.safeMeta.supporting
           .map(_.flatMap(resolveSupportingContent))
-          .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, Option(trail.frontPublicationDate), supportingItems, collection.collectionConfig))
+          .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, Option(trail.frontPublicationDate), supportingItems.take(maxItems), collection.collectionConfig))
           .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, Option(trail.frontPublicationDate), collection.collectionConfig))}
         .orElse {
           snapContent


### PR DESCRIPTION
## What does this change?
Adds a maximum number of sublinks that a card can have, dependent on its boost level. 

The limits for boost levels are as follows:

Default level => max 2 sublinks
Boost level => max 2 sublinks
Megaboost level => max 4 sublinks
Gigaboost level => max 4 sublinks

Not all cards have boost levels - only cards in beta containers do. For those that don't, we default to maximum 4

## Screenshots

### Fronts tool showing excessive sublinks

|   Fronts tool    |
|-------------|
| ![tool][] |

### DCR limiting sublinks

| default & boost      | megaboost      | splash  / gigaboost    
|------------|-------------|------------|
| ![boost][] | ![megaboost][] | ![splash][] |

[tool]: https://github.com/user-attachments/assets/d690351c-cfe6-427b-8148-09ef8dc2cd8f
[splash]: https://github.com/user-attachments/assets/3d37b0e5-3c42-4cf5-9c74-2670f3173bde
[boost]: https://github.com/user-attachments/assets/3a1d2845-f7b2-4cbe-83ad-b1aa066b884d
[megaboost]: https://github.com/user-attachments/assets/63f1b799-5c5a-48e2-bd3c-38901cc27757



## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
