### PR TITLE
Check for beta collection before limiting sublinks

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -2,9 +2,10 @@ package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.{LatestSnapsRequest, LinkSnapsRequest}
+import com.gu.facia.api.models.CollectionConfig.BetaCollections
 import com.gu.facia.client.models.{CollectionJson, SupportingItem, TargetedTerritory, Trail}
 import org.joda.time.DateTime
-import com.gu.facia.api.utils.{BoostLevel}
+import com.gu.facia.api.utils.BoostLevel
 import com.gu.facia.api.utils.ResolvedMetaData
 
 
@@ -56,7 +57,7 @@ object Collection {
     // note that this does not currently deal with e.g. snaps
     def resolveTrail(trail: Trail): Option[FaciaContent] = {
       val boostLevel = trail.safeMeta.boostLevel
-      val maxItems = maxSupportingItems(boostLevel.getOrElse(""))
+      val maxItems = if (BetaCollections.contains(collection.collectionConfig.collectionType)) maxSupportingItems(boostLevel.getOrElse("")) else 4
 
       content.find { c =>
         trail.id.endsWith("/" + c.fields.flatMap(_.internalPageCode).getOrElse(throw new RuntimeException("No internal page code")))

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -150,6 +150,15 @@ object CollectionConfig {
     )
   }
 
+    val BetaCollections = List(
+      "flexible/special",
+      "flexible/general",
+      "scrollable/small",
+      "scrollable/medium",
+      "static/medium/4",
+    )
+
+
   def getAspectRatio(collectionConfig: CollectionConfig): AspectRatio = {
     collectionConfig.collectionType match {
       case _ if PortraitCollections.contains(collectionConfig.collectionType) => Portrait45


### PR DESCRIPTION
## What does this change?
Adds a check to make sure we are in a beta container before we map boost levels to sublink limits. If we are not in a beta container we limit the sublinks to 4. 


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
