### PR TITLE
Update sublink logic and add tests

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -46,8 +46,11 @@ object Collection {
       case _ => false
     }
   }
-  private def maxSupportingItems(isSplashCard: Boolean, collectionType: String): Int = {
-    if (BetaCollections.contains(collectionType) && !isSplashCard && BoostLevel.Default.label == "default") {
+  private[models] def maxSupportingItems(isSplashCard: Boolean, collectionType: String, boostLevel: String): Int = {
+    if (
+          (collectionType == "flexible/general" || collectionType == "flexible/special") &&
+          !isSplashCard && boostLevel == BoostLevel.Default.label)
+    {
        2
     } else {
       4
@@ -64,7 +67,7 @@ object Collection {
     def resolveTrail(trail: Trail, index: Int): Option[FaciaContent] = {
       val boostLevel = trail.safeMeta.boostLevel
       val isSplash = isSplashCard(trail, index, collection.collectionConfig.collectionType)
-      val maxItems =  maxSupportingItems(isSplash, boostLevel.getOrElse(""))
+      val maxItems =  maxSupportingItems(isSplash, collection.collectionConfig.collectionType, boostLevel.getOrElse("default") )
 
       content.find { c =>
         trail.id.endsWith("/" + c.fields.flatMap(_.internalPageCode).getOrElse(throw new RuntimeException("No internal page code")))

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -486,5 +486,58 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       CollectionConfig.getAspectRatio(scrollableSmallConfig) should be (CollectionConfig.AspectRatio.Landscape54)
       CollectionConfig.getAspectRatio(scrollableHighlightsConfig) should be (CollectionConfig.AspectRatio.Square)
     }
+
   }
+
+  "maxSupportingItems" - {
+    "should return 2 for non-splash cards in flexible/general collections with default boost level" in {
+      val isSplashCard = false
+      val collectionType = "flexible/general"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 2
+    }
+
+    "should return 2 for non-splash cards in flexible/special collections with default boost level" in {
+      val isSplashCard = false
+      val collectionType = "flexible/special"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 2
+    }
+
+    "should return 4 for non-splash cards in flexible/special collections with mega boost boost level" in {
+      val isSplashCard = false
+      val collectionType = "flexible/special"
+      val boostLevel = BoostLevel.MegaBoost.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
+    }
+
+    "should return 4 for splash cards in flexible/general collections" in {
+      val isSplashCard = true
+      val collectionType = "flexible/general"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
+    }
+
+    "should return 4 for splash cards in flexible/special collections" in {
+      val isSplashCard = true
+      val collectionType = "flexible/special"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
+    }
+
+    "should return 4 for any other beta collection type" in {
+      val isSplashCard = false
+      val collectionType = "scrollable/small"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
+    }
+
+    "should return 4 for any other collection type" in {
+      val isSplashCard = false
+      val collectionType = "dynamic/fast"
+      val boostLevel = BoostLevel.Default.label
+      Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
+    }
+  }
+
 }


### PR DESCRIPTION
## What does this change?
Refines the sublink limit logic so that we only limit cards with boost levels if they are in a flexible container. This is necessary as all cards get a "default" boost level set in the tool.

It also adds a suite of tests to ensure we have captured all our use cases. 


## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
