### PR TITLE
Make common properties available on FaciaContent

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -63,6 +63,14 @@ object FaciaImage {
 
 sealed trait FaciaContent {
   def brandingByEdition: BrandingByEdition = Map.empty
+  def maybeFrontPublicationDate: Option[Long]
+  def href: Option[String]
+  def trailText: Option[String]
+  def group: String
+  def image: Option[FaciaImage]
+  def properties: ContentProperties
+  def byline: Option[String]
+  def kicker: Option[ItemKicker]
 }
 
 // This needs to be kept aligned with Frontend until it's pushed all the way upstream to Thrift


### PR DESCRIPTION
## What does this change?

Adds a number of fields to the `FaciaContent` sealed trait. All existing implementations of FaciaContent provide these fields. Allowing access on the trait should avoid some situations where library users currently have to pattern match
