### PR TITLE
Filter empty groupsConfig field from collection json to fallback to groups field

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collectionconfig.scala
@@ -98,7 +98,7 @@ object CollectionConfig {
       collectionJson.collectionType getOrElse DefaultCollectionType,
       collectionJson.href,
       collectionJson.description,
-      collectionJson.groupsConfig.map(GroupsConfig.fromGroupsConfigJson).orElse(collectionJson.groups.map(GroupsConfig.fromGroups)),
+      collectionJson.groupsConfig.filter(_.nonEmpty).map(GroupsConfig.fromGroupsConfigJson).orElse(collectionJson.groups.map(GroupsConfig.fromGroups)),
       collectionJson.uneditable.exists(identity),
       collectionJson.showTags.exists(identity),
       collectionJson.showSections.exists(identity),


### PR DESCRIPTION
This situation can arise when containers created prior to the groupsConfig field being added to the model have a modification. This causes them to be rewritten to s3 with an empty groupsConfig rather than a missing groupsConfig.

As a consequence, the fronts tool thought that the collection didn't have groups and so removed the group information from cards. 


## What does this change?

Filter empty groupsConfig field from collection json to fallback to groups field

## How to test
This has been tested using the following steps
In fronts tool:
- ensure that a container has valid groups but an empty array groupsConfig field
- move a card in a standard group into a big group
- launch the container and observe that the card is moved back into the standard group
- bump the facia-scala-client version to this branch 
- repeat the above steps and observe that the card stays in the big group.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
Its possible that this will resolve other unnoticed bugs in Frontend and MAPI

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
