### PR TITLE
Correctly assign flexible special splash card

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -42,7 +42,7 @@ object Collection {
   private def isSplashCard(trail: Trail, index: Int, collectionType: String): Boolean = {
     (collectionType, trail.safeMeta.group, index) match {
       case ("flexible/general", Some("3"), _) => true
-      case ("flexible/special", Some("0"), 0) => true
+      case ("flexible/special", Some("1"), 0) => true
       case _ => false
     }
   }


### PR DESCRIPTION
## What does this change?

Change the group number from 0 -> 1 in the pattern match for splash cards in flexible special.

In flexible/special the first group (0) is reserved for snap links. The splash card is actually the first card in the standard group (1)

This means there is a bug where flex special splash cards can only have max 2 sublinks when they should be able to display up to 4. 

## How to test
1. Observe that the splash card in a flexible special container can only have 2 sublinks when it should have up to 4.

2. Use a preview version of this release on frontend and deploy to code.

3. Observe that a splash card in a flexible special container can now have up to 4 sublinks
