### PR TITLE
Add fields for replacement video atom

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -49,6 +49,7 @@ sealed trait MetaDataCommonFields {
   lazy val showQuotedHeadline: Option[Boolean] = json.get("showQuotedHeadline").flatMap(_.asOpt[Boolean])
   lazy val excludeFromRss: Option[Boolean] = json.get("excludeFromRss").flatMap(_.asOpt[Boolean])
   lazy val imageSlideshowReplace: Option[Boolean] = json.get("imageSlideshowReplace").flatMap(_.asOpt[Boolean])
+  lazy val videoReplace: Option[Boolean] = json.get("videoReplace").flatMap(_.asOpt[Boolean])
   lazy val slideshow: Option[List[SlideshowAsset]] =
     json.get("slideshow").flatMap(_.asOpt[List[SlideshowAsset]]).filter(_.nonEmpty)
   lazy val showLivePlayable: Option[Boolean] = json.get("showLivePlayable").flatMap(_.asOpt[Boolean])

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -155,8 +155,6 @@ trait ItemQueries {
   def latestContentQueryFromSnapUri(uri: String): ItemQuery
 
   def brandingQueryFromSnapUri(uri: URI): ItemQuery
-
-  def queryFromAtomId(atomId: String): ItemQuery
 }
 
 object ItemQueries extends ItemQueries {
@@ -171,9 +169,5 @@ object ItemQueries extends ItemQueries {
   def brandingQueryFromSnapUri(uri: URI): ItemQuery = {
     def cleaned(path: String) = path.stripPrefix("/").stripSuffix("/all").stripSuffix("/latest")
     ContentApiClient.item(cleaned(uri.getPath)).pageSize(1)
-  }
-
-  def queryFromAtomId(atomId: String): ItemQuery ={
-    ContentApiClient.item(s"atom/video/$atomId")
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/contentapi/ContentApi.scala
@@ -155,6 +155,8 @@ trait ItemQueries {
   def latestContentQueryFromSnapUri(uri: String): ItemQuery
 
   def brandingQueryFromSnapUri(uri: URI): ItemQuery
+
+  def queryFromAtomId(atomId: String): ItemQuery
 }
 
 object ItemQueries extends ItemQueries {
@@ -169,5 +171,9 @@ object ItemQueries extends ItemQueries {
   def brandingQueryFromSnapUri(uri: URI): ItemQuery = {
     def cleaned(path: String) = path.stripPrefix("/").stripSuffix("/all").stripSuffix("/latest")
     ContentApiClient.item(cleaned(uri.getPath)).pageSize(1)
+  }
+
+  def queryFromAtomId(atomId: String): ItemQuery ={
+    ContentApiClient.item(s"atom/video/$atomId")
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -182,7 +182,8 @@ object Collection extends StrictLogging {
         getMediaAtomData(curatedContent).map {
           case mediaAtomData@Some(_) => curatedContent.copy(mediaAtomData = mediaAtomData)
           case None => curatedContent
-        }      case content => Response.Right(content)
+        }      
+      case content => Response.Right(content)
     }
 
     Response.traverse(responses.toList)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -135,9 +135,7 @@ object Collection {
                 case _ => false
               }
             )
-
-            mainMediaAtomData = mainMediaAtom.data
-          } yield mainMediaAtomData
+          } yield mainMediaAtom.data
 
           Future.successful(maybeMainMediaAtomData)
         case _ => Future.successful(None)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -2,13 +2,14 @@ package com.gu.facia.api.models
 
 import com.gu.contentapi.client.ContentApiClient
 import com.gu.contentapi.client.model.v1.{Content, ItemResponse}
-import com.gu.contentatom.thrift.AtomData
+import com.gu.contentatom.thrift.{Atom, AtomData}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import com.gu.facia.api.contentapi.{ItemQueries, LatestSnapsRequest, LinkSnapsRequest}
 import com.gu.facia.client.models.{CollectionJson, SupportingItem, TargetedTerritory, Trail}
 import org.joda.time.{DateTime, DateTimeZone}
-import com.gu.facia.api.utils.{BoostLevel}
+import com.gu.facia.api.utils.BoostLevel
 import com.gu.facia.api.{CapiError, Response}
+
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -129,8 +130,8 @@ object Collection {
             atoms <- faciaContent.content.atoms
             mediaAtoms <- atoms.media
             mainMediaAtom <- mediaAtoms.find(atom =>
-              atom match {
-                case media: MediaAtom => isExpired(media)
+              atom.data match {
+                case AtomData.Media(media) => isExpired(media)
                 case _ => false
               }
             )

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -143,7 +143,7 @@ object Collection extends StrictLogging {
 
 
         case faciaContent: CuratedContent if faciaContent.properties.showMainVideo =>
-           val mainAtom = for {
+          val mainAtom = for {
             atoms <- faciaContent.content.atoms
             mediaAtoms <- atoms.media
             validMediaAtom <- extractValidMediaAtom(mediaAtoms, faciaContent.content.id)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -2,10 +2,9 @@ package com.gu.facia.api.models
 
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.facia.api.contentapi.{LatestSnapsRequest, LinkSnapsRequest}
-import com.gu.facia.api.models.CollectionConfig.BetaCollections
 import com.gu.facia.client.models.{CollectionJson, SupportingItem, TargetedTerritory, Trail}
 import org.joda.time.DateTime
-import com.gu.facia.api.utils.{BoostLevel, ResolvedMetaData}
+import com.gu.facia.api.utils.{BoostLevel}
 
 
 case class Collection(

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -120,7 +120,7 @@ object Collection {
     def getMediaAtomData(fcContent: FaciaContent)(implicit ec: ExecutionContext, capiClient: ContentApiClient): Response[Option[AtomData.Media]] = {
       val futureMaybeAtomData = fcContent match {
         case faciaContent if faciaContent.properties.videoReplace && faciaContent.atomId.isDefined =>
-          val futureResponse = capiClient.getResponse(ItemQueries.queryFromAtomId(faciaContent.atomId.get))
+          val futureResponse = capiClient.getResponse(ContentApiClient.item(faciaContent.atomId.get))
           futureResponse.map { response =>
             resolveVideo(response) match {
               case Some(atom: AtomData.Media) if !isExpired(atom.media) => Some(atom)

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -131,7 +131,7 @@ object Collection {
             mediaAtoms <- atoms.media
             mainMediaAtom <- mediaAtoms.find(atom =>
               atom.data match {
-                case AtomData.Media(media) => isExpired(media)
+                case AtomData.Media(media) => !isExpired(media)
                 case _ => false
               }
             )

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -123,7 +123,7 @@ object Collection {
           val futureResponse = capiClient.getResponse(ItemQueries.queryFromAtomId(faciaContent.atomId.get))
           futureResponse.map { response =>
             resolveVideo(response) match {
-              case Some(media: AtomData.Media) => Some(media)
+              case Some(atom: AtomData.Media) if !isExpired(atom.media) => Some(atom)
               case _ => None
             }
           }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -9,8 +9,11 @@ import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Trail, TrailMetaData}
 
 sealed trait FaciaImage
+
 case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
+
 case class Replace(imageSrc: String, imageSrcWidth: String, imageSrcHeight: String, imageCaption: Option[String]) extends FaciaImage
+
 case class ImageSlideshow(assets: List[Replace]) extends FaciaImage
 
 object FaciaImage {
@@ -24,7 +27,8 @@ object FaciaImage {
       imageReplace(trailMeta, resolvedMetadata)
     else if (resolvedMetadata.imageCutoutReplace)
       imageCutout(trailMeta) orElse maybeContent.flatMap(fromContentTags(_, trailMeta))
-    else None}
+    else None
+  }
 
   def fromContentTags(content: Content, trailMeta: MetaDataCommonFields): Option[FaciaImage] = {
     val contributorTags = content.tags.filter(_.`type` == TagType.Contributor)
@@ -58,20 +62,30 @@ object FaciaImage {
   def imageSlideshow(trailMeta: MetaDataCommonFields, resolvedMetaData: ResolvedMetaData): Option[FaciaImage] =
     trailMeta.slideshow.map { assets =>
       val slideshowAssets = assets.map(asset => Replace(asset.src, asset.width, asset.height, asset.caption))
-      ImageSlideshow(slideshowAssets)}
+      ImageSlideshow(slideshowAssets)
+    }
 
 }
 
 sealed trait FaciaContent {
   def brandingByEdition: BrandingByEdition = Map.empty
+
   def maybeFrontPublicationDate: Option[Long]
+
   def href: Option[String]
+
   def trailText: Option[String]
+
   def group: String
+
   def image: Option[FaciaImage]
+
   def properties: ContentProperties
+
   def byline: Option[String]
+
   def kicker: Option[ItemKicker]
+
   def atomId: Option[String]
 }
 
@@ -79,15 +93,16 @@ sealed trait FaciaContent {
 // https://github.com/guardian/frontend/blob/46ac997bbb6482bacbd59c3528ce3141623c8033/common/app/model/meta.scala#L220-L224
 
 final case class ContentFormat(
-  design: Design,
-  theme: Theme,
-  display: Display,
-)
+                                design: Design,
+                                theme: Theme,
+                                display: Display,
+                              )
 
 object ContentFormat {
   lazy val defaultContentFormat: ContentFormat = {
     ContentFormat(ArticleDesign, NewsPillar, StandardDisplay)
   }
+
   def apply(content: Content): ContentFormat = {
     ContentFormat(content.design, content.theme, content.display)
   }
@@ -101,9 +116,9 @@ object Snap {
   def maybeFromTrail(trail: Trail): Option[Snap] = maybeFromTrailAndBrandings(trail, Map.empty)
 
   def maybeFromTrailAndBrandings(
-    trail: Trail,
-    brandingByEdition: BrandingByEdition
-  ): Option[Snap] =
+                                  trail: Trail,
+                                  brandingByEdition: BrandingByEdition
+                                ): Option[Snap] =
     trail.safeMeta.snapType match {
       case Some("latest") =>
         Option(LatestSnap.fromTrailAndContent(trail, None))
@@ -160,44 +175,45 @@ object Snap {
 }
 
 sealed trait Snap extends FaciaContent
+
 case class LinkSnap(
-  id: String,
-  maybeFrontPublicationDate: Option[Long],
-  snapType: String,
-  snapUri: Option[String],
-  snapCss: Option[String],
-  atomId: Option[String],
-  headline: Option[String],
-  href: Option[String],
-  trailText: Option[String],
-  group: String,
-  image: Option[FaciaImage],
-  properties: ContentProperties,
-  byline: Option[String],
-  kicker: Option[ItemKicker],
-  override val brandingByEdition: BrandingByEdition,
-  atomData: Option[AtomData]
-) extends Snap
+                     id: String,
+                     maybeFrontPublicationDate: Option[Long],
+                     snapType: String,
+                     snapUri: Option[String],
+                     snapCss: Option[String],
+                     atomId: Option[String],
+                     headline: Option[String],
+                     href: Option[String],
+                     trailText: Option[String],
+                     group: String,
+                     image: Option[FaciaImage],
+                     properties: ContentProperties,
+                     byline: Option[String],
+                     kicker: Option[ItemKicker],
+                     override val brandingByEdition: BrandingByEdition,
+                     atomData: Option[AtomData]
+                   ) extends Snap
 
 case class LatestSnap(
-  id: String,
-  maybeFrontPublicationDate: Option[Long],
-  cardStyle: CardStyle,
-  format: ContentFormat,
-  snapUri: Option[String],
-  snapCss: Option[String],
-  latestContent: Option[Content],
-  headline: Option[String],
-  href: Option[String],
-  trailText: Option[String],
-  group: String,
-  image: Option[FaciaImage],
-  properties: ContentProperties,
-  byline: Option[String],
-  kicker: Option[ItemKicker],
-  override val brandingByEdition: BrandingByEdition,
-  atomId: Option[String],
-  atomData: Option[AtomData]
+                       id: String,
+                       maybeFrontPublicationDate: Option[Long],
+                       cardStyle: CardStyle,
+                       format: ContentFormat,
+                       snapUri: Option[String],
+                       snapCss: Option[String],
+                       latestContent: Option[Content],
+                       headline: Option[String],
+                       href: Option[String],
+                       trailText: Option[String],
+                       group: String,
+                       image: Option[FaciaImage],
+                       properties: ContentProperties,
+                       byline: Option[String],
+                       kicker: Option[ItemKicker],
+                       override val brandingByEdition: BrandingByEdition,
+                       atomId: Option[String],
+                       atomData: Option[AtomData]
 
                      ) extends Snap
 
@@ -260,42 +276,42 @@ object LatestSnap {
 }
 
 case class CuratedContent(
-  content: Content,
-  maybeFrontPublicationDate: Option[Long],
-  supportingContent: List[FaciaContent],
-  cardStyle: CardStyle,
-  format: ContentFormat,
-  headline: String,
-  href: Option[String],
-  trailText: Option[String],
-  group: String,
-  image: Option[FaciaImage],
-  properties: ContentProperties,
-  byline: Option[String],
-  kicker: Option[ItemKicker],
-  embedType: Option[String],
-  embedUri: Option[String],
-  embedCss: Option[String],
-  override val brandingByEdition: BrandingByEdition,
-  atomId: Option[String],
-  atomData: Option[AtomData]
+                           content: Content,
+                           maybeFrontPublicationDate: Option[Long],
+                           supportingContent: List[FaciaContent],
+                           cardStyle: CardStyle,
+                           format: ContentFormat,
+                           headline: String,
+                           href: Option[String],
+                           trailText: Option[String],
+                           group: String,
+                           image: Option[FaciaImage],
+                           properties: ContentProperties,
+                           byline: Option[String],
+                           kicker: Option[ItemKicker],
+                           embedType: Option[String],
+                           embedUri: Option[String],
+                           embedCss: Option[String],
+                           override val brandingByEdition: BrandingByEdition,
+                           atomId: Option[String],
+                           atomData: Option[AtomData]
                          ) extends FaciaContent
 
 case class SupportingCuratedContent(
-  content: Content,
-  maybeFrontPublicationDate: Option[Long],
-  cardStyle: CardStyle,
-  format: ContentFormat,
-  headline: String,
-  href: Option[String],
-  trailText: Option[String],
-  group: String,
-  image: Option[FaciaImage],
-  properties: ContentProperties,
-  byline: Option[String],
-  kicker: Option[ItemKicker],
-  atomId: Option[String],
-  atomData: Option[AtomData]
+                                     content: Content,
+                                     maybeFrontPublicationDate: Option[Long],
+                                     cardStyle: CardStyle,
+                                     format: ContentFormat,
+                                     headline: String,
+                                     href: Option[String],
+                                     trailText: Option[String],
+                                     group: String,
+                                     image: Option[FaciaImage],
+                                     properties: ContentProperties,
+                                     byline: Option[String],
+                                     kicker: Option[ItemKicker],
+                                     atomId: Option[String],
+                                     atomData: Option[AtomData]
                                    ) extends FaciaContent
 
 object CuratedContent {
@@ -360,7 +376,8 @@ object CuratedContent {
       brandingByEdition = content.brandingByEdition,
       trailMetaData.atomId,
       None
-    )}
+    )
+  }
 }
 
 object SupportingCuratedContent {

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -66,6 +66,12 @@ object FaciaImage {
     }
 
 }
+object AtomId {
+  def unapply(content: FaciaContent): Option[String] = {
+    content.atomId
+  }
+}
+
 
 sealed trait FaciaContent {
   def brandingByEdition: BrandingByEdition = Map.empty

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -190,7 +190,8 @@ case class LatestSnap(
   properties: ContentProperties,
   byline: Option[String],
   kicker: Option[ItemKicker],
-  override val brandingByEdition: BrandingByEdition
+  override val brandingByEdition: BrandingByEdition,
+  atomId: Option[String]
 ) extends Snap
 
 object LatestSnap {
@@ -216,7 +217,8 @@ object LatestSnap {
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
       trail.safeMeta.byline.orElse(maybeContent.flatMap(_.fields.flatMap(_.byline))),
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData),
-      brandingByEdition
+      brandingByEdition,
+      trail.safeMeta.atomId
     )
   }
 
@@ -242,7 +244,8 @@ object LatestSnap {
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
       supportingItem.safeMeta.byline.orElse(maybeContent.flatMap(_.fields.flatMap(_.byline))),
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData),
-      brandingByEdition
+      brandingByEdition,
+      supportingItem.safeMeta.atomId
     )
   }
 }
@@ -264,8 +267,8 @@ case class CuratedContent(
   embedType: Option[String],
   embedUri: Option[String],
   embedCss: Option[String],
-  override val brandingByEdition: BrandingByEdition
-) extends FaciaContent
+  override val brandingByEdition: BrandingByEdition,
+  atomId: Option[String]) extends FaciaContent
 
 case class SupportingCuratedContent(
   content: Content,
@@ -279,7 +282,8 @@ case class SupportingCuratedContent(
   image: Option[FaciaImage],
   properties: ContentProperties,
   byline: Option[String],
-  kicker: Option[ItemKicker]) extends FaciaContent
+  kicker: Option[ItemKicker],
+  atomId: Option[String]) extends FaciaContent
 
 object CuratedContent {
 
@@ -308,7 +312,8 @@ object CuratedContent {
       embedType = trailMetaData.snapType,
       embedUri = trailMetaData.snapUri,
       embedCss = trailMetaData.snapCss,
-      brandingByEdition = content.brandingByEdition
+      brandingByEdition = content.brandingByEdition,
+      trailMetaData.atomId
     )
   }
 
@@ -338,7 +343,8 @@ object CuratedContent {
       embedType = trailMetaData.snapType,
       embedUri = trailMetaData.snapUri,
       embedCss = trailMetaData.snapCss,
-      brandingByEdition = content.brandingByEdition
+      brandingByEdition = content.brandingByEdition,
+      trailMetaData.atomId
     )}
 }
 
@@ -362,7 +368,8 @@ object SupportingCuratedContent {
       FaciaImage.getFaciaImage(Some(content), trailMetaData, resolvedMetaData),
       ContentProperties.fromResolvedMetaData(resolvedMetaData),
       trailMetaData.byline.orElse(content.fields.flatMap(_.byline)),
-      ItemKicker.fromContentAndTrail(Option(content), trailMetaData, resolvedMetaData, None)
+      ItemKicker.fromContentAndTrail(Option(content), trailMetaData, resolvedMetaData, None),
+      trailMetaData.atomId
     )
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -3,7 +3,7 @@ package com.gu.facia.api.models
 import com.gu.contentapi.client.model.v1.{Content, TagType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
 import com.gu.contentapi.client.utils.format._
-import com.gu.contentatom.thrift.AtomData
+import com.gu.contentatom.thrift.AtomData.{ Media => MediaAtomData}
 import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Trail, TrailMetaData}
@@ -192,7 +192,7 @@ case class LinkSnap(
                      byline: Option[String],
                      kicker: Option[ItemKicker],
                      override val brandingByEdition: BrandingByEdition,
-                     atomData: Option[AtomData]
+                     mediaAtomData: Option[MediaAtomData]
                    ) extends Snap
 
 case class LatestSnap(
@@ -213,7 +213,7 @@ case class LatestSnap(
                        kicker: Option[ItemKicker],
                        override val brandingByEdition: BrandingByEdition,
                        atomId: Option[String],
-                       atomData: Option[AtomData]
+                       mediaAtomData: Option[MediaAtomData]
 
                      ) extends Snap
 
@@ -294,7 +294,7 @@ case class CuratedContent(
                            embedCss: Option[String],
                            override val brandingByEdition: BrandingByEdition,
                            atomId: Option[String],
-                           atomData: Option[AtomData]
+                           mediaAtomData: Option[MediaAtomData]
                          ) extends FaciaContent
 
 case class SupportingCuratedContent(
@@ -311,7 +311,7 @@ case class SupportingCuratedContent(
                                      byline: Option[String],
                                      kicker: Option[ItemKicker],
                                      atomId: Option[String],
-                                     atomData: Option[AtomData]
+                                     mediaAtomData: Option[MediaAtomData]
                                    ) extends FaciaContent
 
 object CuratedContent {

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -103,12 +103,12 @@ object FaciaContentUtils {
     latestSnap => latestSnap.href.orElse(latestSnap.snapUri))
 
   def atomId(fc: FaciaContent): Option[String] = fold(fc)(
-    curatedContent => None,
-    supportingCuratedContent => None,
+    curatedContent => curatedContent.atomId,
+    supportingCuratedContent => supportingCuratedContent.atomId,
     linkSnap => linkSnap.atomId,
-    latestSnap => None
+    latestSnap => latestSnap.atomId
   )
-
+  
 
   def mediaType(fc: FaciaContent): Option[MediaType] = {
     def mediaTypeFromContent(content: Content): Option[MediaType] =

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/FaciaContentUtils.scala
@@ -185,6 +185,14 @@ object FaciaContentUtils {
     linkSnap => linkSnap.properties.showMainVideo,
     latestSnap => latestSnap.properties.showMainVideo
   )
+
+  def videoReplace(fc: FaciaContent): Boolean = fold(fc)(
+    curatedContent => curatedContent.properties.videoReplace,
+    supportingCuratedContent => supportingCuratedContent.properties.videoReplace,
+    linkSnap => linkSnap.properties.videoReplace,
+    latestSnap => latestSnap.properties.videoReplace
+  )
+
   def showLivePlayable(fc: FaciaContent): Boolean = fold(fc)(
     curatedContent => curatedContent.properties.showLivePlayable,
     supportingCuratedContent => supportingCuratedContent.properties.showLivePlayable,

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -61,7 +61,9 @@ object ResolvedMetaData {
     showByline = false,
     imageCutoutReplace = false,
     showQuotedHeadline = false,
-    imageSlideshowReplace = false)
+    imageSlideshowReplace = false,
+    videoReplace = false
+  )
 
   def fromTrailMetaData(trailMeta: MetaDataCommonFields): ResolvedMetaData =
     ResolvedMetaData(
@@ -80,7 +82,8 @@ object ResolvedMetaData {
       showByline = trailMeta.showByline.exists(identity),
       imageCutoutReplace = trailMeta.imageCutoutReplace.exists(identity),
       showQuotedHeadline = trailMeta.showQuotedHeadline.exists(identity),
-      imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity)
+      imageSlideshowReplace = trailMeta.imageSlideshowReplace.exists(identity),
+      videoReplace = trailMeta.videoReplace.exists(identity)
   )
 
   def fromContent(content: Content, cardStyle: CardStyle): ResolvedMetaData =
@@ -131,7 +134,9 @@ object ResolvedMetaData {
       showByline,
       imageCutoutReplace,
       showQuotedHeadline,
-      imageSlideshowReplace) =>
+      imageSlideshowReplace,
+      videoReplace
+    ) =>
       Map(
         "isBreaking" -> isBreaking,
         "isBoosted" -> isBoosted,
@@ -151,7 +156,9 @@ object ResolvedMetaData {
         "showByline" -> showByline,
         "imageCutoutReplace" -> imageCutoutReplace,
         "showQuotedHeadline" -> showQuotedHeadline,
-        "imageSlideshowReplace" -> imageSlideshowReplace)
+        "imageSlideshowReplace" -> imageSlideshowReplace,
+        "videoReplace" -> videoReplace
+      )
   }
 }
 
@@ -171,7 +178,8 @@ case class ResolvedMetaData(
     showByline: Boolean,
     imageCutoutReplace: Boolean,
     showQuotedHeadline: Boolean,
-    imageSlideshowReplace: Boolean)
+    imageSlideshowReplace: Boolean,
+    videoReplace: Boolean)
 
 object ContentProperties {
   def fromResolvedMetaData(resolvedMetaData: ResolvedMetaData): ContentProperties =
@@ -187,7 +195,9 @@ object ContentProperties {
       showKickerTag = resolvedMetaData.showKickerTag,
       showByline = resolvedMetaData.showByline,
       showQuotedHeadline = resolvedMetaData.showQuotedHeadline,
-      imageSlideshowReplace = resolvedMetaData.imageSlideshowReplace)
+      imageSlideshowReplace = resolvedMetaData.imageSlideshowReplace,
+      videoReplace = resolvedMetaData.videoReplace
+    )
 }
 
 case class ContentProperties(
@@ -202,4 +212,5 @@ case class ContentProperties(
     showKickerTag: Boolean,
     showByline: Boolean,
     showQuotedHeadline: Boolean,
-    imageSlideshowReplace: Boolean)
+    imageSlideshowReplace: Boolean,
+    videoReplace: Boolean)

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -116,7 +116,7 @@ object ResolvedMetaData {
       imageCutoutReplace = trailMeta.imageCutoutReplace.getOrElse(metaDataFromContent.imageCutoutReplace),
       showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline),
       imageSlideshowReplace = trailMeta.imageSlideshowReplace.getOrElse(metaDataFromContent.imageSlideshowReplace),
-      videoReplace = trailMeta.videoReplace.exists(identity)
+      videoReplace = trailMeta.videoReplace.getOrElse(metaDataFromContent.videoReplace)
     )}
 
 

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/ResolvedMetaData.scala
@@ -115,7 +115,10 @@ object ResolvedMetaData {
       showByline = trailMeta.showByline.getOrElse(metaDataFromContent.showByline),
       imageCutoutReplace = trailMeta.imageCutoutReplace.getOrElse(metaDataFromContent.imageCutoutReplace),
       showQuotedHeadline = trailMeta.showQuotedHeadline.getOrElse(metaDataFromContent.showQuotedHeadline),
-      imageSlideshowReplace = trailMeta.imageSlideshowReplace.getOrElse(metaDataFromContent.imageSlideshowReplace))}
+      imageSlideshowReplace = trailMeta.imageSlideshowReplace.getOrElse(metaDataFromContent.imageSlideshowReplace),
+      videoReplace = trailMeta.videoReplace.exists(identity)
+    )}
+
 
   def toMap(resolvedMetaData: ResolvedMetaData): Map[String, Boolean] = resolvedMetaData match {
     case ResolvedMetaData(

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -88,7 +88,8 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       contentProperties,
       byline,
       kicker,
-      latestContent map (_.brandingByEdition) getOrElse Map.empty
+      latestContent map (_.brandingByEdition) getOrElse Map.empty,
+      atomId = None
     )
 
   def makeLinkSnap(

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -46,20 +46,21 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       emptyContentProperties,
       None,
       None,
-      Map.empty
+      Map.empty,
+      None
     )
     FaciaContentUtils.headlineOption(snap) should equal(None)
   }
 
   "should return the headline for a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None)
     FaciaContentUtils.headlineOption(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None)
     FaciaContentUtils.href(cc) should equal(None)
   }
 
@@ -91,7 +92,8 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       emptyContentProperties,
       None,
       None,
-      Map.empty
+      Map.empty,
+      None
     )
     FaciaContentUtils.href(snap) should equal(Some("The href"))
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -47,6 +47,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       None,
       Map.empty,
+      None,
       None
     )
     FaciaContentUtils.headlineOption(snap) should equal(None)
@@ -54,13 +55,13 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
 
   "should return the headline for a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None)
     FaciaContentUtils.headlineOption(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None)
     FaciaContentUtils.href(cc) should equal(None)
   }
 
@@ -93,6 +94,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       None,
       Map.empty,
+      None,
       None
     )
     FaciaContentUtils.href(snap) should equal(Some("The href"))
@@ -120,7 +122,8 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       emptyContentProperties,
       None,
       None,
-      Map.empty
+      Map.empty,
+      None
     )
 
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("myByline"))))

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -26,7 +26,9 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       showByline = false,
       showQuotedHeadline = false,
       showLivePlayable = false,
-      imageSlideshowReplace = false)
+      imageSlideshowReplace = false,
+      videoReplace = false
+    )
 
   "should return 'Missing Headline' when the headline is None in a Snaps" in {
     val snap = LatestSnap("myId",

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -50,7 +50,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     properties = emptyProperties,
     byline = None,
     kicker = None,
-    brandingByEdition = Map.empty
+    brandingByEdition = Map.empty,
+    atomId = None
   )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
@@ -70,7 +71,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     embedType = None,
     embedUri = None,
     embedCss = None,
-    brandingByEdition = Map.empty
+    brandingByEdition = Map.empty,
+    atomId = None
   )
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
@@ -85,7 +87,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     image = None,
     properties = emptyProperties,
     byline = None,
-    kicker = None)
+    kicker = None,
+    atomId = None)
 
   "webPublicationDateOption" - {
     "should return a None for a LinkSnap" in {

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -27,7 +27,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     ContentProperties.fromResolvedMetaData(ResolvedMetaData.Default),
     byline = None,
     kicker = None,
-    brandingByEdition = Map.empty
+    brandingByEdition = Map.empty,
+    mediaAtomData = None
   )
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
@@ -51,7 +52,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     brandingByEdition = Map.empty,
-    atomId = None
+    atomId = None,
+    mediaAtomData = None
   )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
@@ -72,7 +74,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     embedUri = None,
     embedCss = None,
     brandingByEdition = Map.empty,
-    atomId = None
+    atomId = None,
+    mediaAtomData = None
   )
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
@@ -88,7 +91,9 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     properties = emptyProperties,
     byline = None,
     kicker = None,
-    atomId = None)
+    atomId = None,
+    mediaAtomData = None
+  )
 
   "webPublicationDateOption" - {
     "should return a None for a LinkSnap" in {


### PR DESCRIPTION
## What does this change?
Adds a `videoReplace` attribute to the properties object on FaciaContent. It also adds support for enriching FaciaContent with `atomId` and `mediaAtomData`.

### Details
Introduces an enrichment step during content retrieval to extract and attach the relevant media atom.

- If the content has `showMainVideo`, the main media atom is retrieved directly from the content and filtered out if expired.
- If the content has `videoReplace` set to true, the replacement video atom is retrieved via a CAPI query and also filtered if expired.
- Both approaches return `Atom.Media Data` if valid.

Since this step introduces a CAPI query, the return type of the content retrieval function has been updated to Response[Option[FaciaContent]].

`atomId` is a pre-existing field used to enrich Interactive Atoms. We have repurposed it to store an ID for a replacement Media (i.e. Video) Atom. In practice there should be no overlap between the two - video enrichment should only happen if the `videoReplace` field is set to true, and this should only be set if the atom is a Media atom.

If an atom cannot be found or is expired, the error is logged but swallowed, returning a None wrapped in a successful future. This ensured fronts still renderer if an atom cannot be retrieved. 

NB: The logic to filter out expired atoms was already present on both platforms. It may be preferable to always pass the atom to the platforms—regardless of expiration—and let them handle filtering during rendering. This would require input from Editorial and has been excluded from this PR to avoid scope creep.

This PR contains file formatting so it is advised to review with whitespace hidden to help reduce noise.


## How to test

Use a preview version of this release in MAPI or Frontend and validate that a replacement video is piped through to the end response.
