### PR TITLE
Remove hardcoded canonical container ids

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/front.scala
@@ -68,15 +68,7 @@ object Front {
    * We should never have a front with no containers so final fallback is a placeholder.
    */
   private def canonicalCollection(id: String, frontJson: FrontJson): String = {
-    val frontHeadlineCollections = id match {
-      //                PROD                             CODE
-      case "uk" => List("uk-alpha/news/regular-stories", "f3d7d2bc-e667-4a86-974f-fe27daeaebcc")
-      case "us" => List("us-alpha/news/regular-stories")
-      case "au" => List("au-alpha/news/regular-stories")
-      case _ => Nil
-    }
-    frontHeadlineCollections.find(frontJson.collections.contains)
-      .orElse(frontJson.canonical.filter(frontJson.collections.contains))
+    frontJson.canonical.filter(frontJson.collections.contains)
       .orElse(frontJson.collections.headOption)
       .getOrElse("no collections")
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FrontTest.scala
@@ -23,27 +23,12 @@ class FrontTest extends AnyFreeSpec with Matchers with MockitoSugar with OneInst
         Front.fromFrontJson("frontId", frontJson).canonicalCollection should equal("collection1")
       }
 
-      "on the uk front, takes the editorially-chosen PROD uk headlines collection if it is present" in {
-        val ukFrontJson = frontJson.copy(collections = frontJson.collections :+ "uk-alpha/news/regular-stories")
-        Front.fromFrontJson("uk", ukFrontJson).canonicalCollection should equal("uk-alpha/news/regular-stories")
-      }
-
       "on the uk front, takes the first collection if the editorially-chosen uk headlines collection is not present" in {
         Front.fromFrontJson("uk", frontJson).canonicalCollection should equal("collection1")
       }
 
-      "on the us front, takes the editorially-chosen PROD us headlines collection if it is present" in {
-        val usFrontJson = frontJson.copy(collections = frontJson.collections :+ "us-alpha/news/regular-stories")
-        Front.fromFrontJson("us", usFrontJson).canonicalCollection should equal("us-alpha/news/regular-stories")
-      }
-
       "on the us front, takes the first collection if the editorially-chosen us headlines collection is not present" in {
         Front.fromFrontJson("us", frontJson).canonicalCollection should equal("collection1")
-      }
-
-      "on the au front, takes the editorially-chosen PROD au headlines collection if it is present" in {
-        val auFrontJson = frontJson.copy(collections = frontJson.collections :+ "au-alpha/news/regular-stories")
-        Front.fromFrontJson("au", auFrontJson).canonicalCollection should equal("au-alpha/news/regular-stories")
       }
 
       "on the au front, takes the first collection if the editorially-chosen au headlines collection is not present" in {


### PR DESCRIPTION
## What does this change?

According to https://github.com/guardian/facia-scala-client/commit/b242fde63d69be22807dfc56d71e23585e312a63 these were only added while we waited for tooling support. We've had that tooling support for quite a while, and these hard coded canonical IDs are about to become invalid.
