### PR TITLE
Refactor mediaAtomData to mediaAtom on the facia content collection model

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -131,7 +131,7 @@ object Collection extends StrictLogging {
         case faciaContent@AtomId(atomId) if faciaContent.properties.videoReplace =>
           capiClient.getResponse(ContentApiClient.item(atomId)).map { response =>
             response.media.flatMap(atom =>
-              if (isValidMediaAtom(atom, atomId)) Some(atom) else None
+              Option.when(isValidMediaAtom(atom, atomId))(atom)
             )
           }.recover {
             case e =>

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -3,7 +3,7 @@ package com.gu.facia.api.models
 import com.gu.contentapi.client.model.v1.{Content, TagType}
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RenderingFormat
 import com.gu.contentapi.client.utils.format._
-import com.gu.contentatom.thrift.AtomData.{ Media => MediaAtomData}
+import com.gu.contentatom.thrift.Atom
 import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Trail, TrailMetaData}
@@ -71,6 +71,8 @@ object AtomId {
     content.atomId
   }
 }
+
+
 
 
 sealed trait FaciaContent {
@@ -198,7 +200,7 @@ case class LinkSnap(
                      byline: Option[String],
                      kicker: Option[ItemKicker],
                      override val brandingByEdition: BrandingByEdition,
-                     mediaAtomData: Option[MediaAtomData]
+                     mediaAtom: Option[Atom]
                    ) extends Snap
 
 case class LatestSnap(
@@ -219,7 +221,7 @@ case class LatestSnap(
                        kicker: Option[ItemKicker],
                        override val brandingByEdition: BrandingByEdition,
                        atomId: Option[String],
-                       mediaAtomData: Option[MediaAtomData]
+                       mediaAtom: Option[Atom]
 
                      ) extends Snap
 
@@ -300,7 +302,7 @@ case class CuratedContent(
                            embedCss: Option[String],
                            override val brandingByEdition: BrandingByEdition,
                            atomId: Option[String],
-                           mediaAtomData: Option[MediaAtomData]
+                           mediaAtom: Option[Atom]
                          ) extends FaciaContent
 
 case class SupportingCuratedContent(
@@ -317,7 +319,7 @@ case class SupportingCuratedContent(
                                      byline: Option[String],
                                      kicker: Option[ItemKicker],
                                      atomId: Option[String],
-                                     mediaAtomData: Option[MediaAtomData]
+                                     mediaAtom: Option[Atom]
                                    ) extends FaciaContent
 
 object CuratedContent {

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -28,7 +28,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     brandingByEdition = Map.empty,
-    mediaAtomData = None
+    mediaAtom = None
   )
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
@@ -53,7 +53,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     kicker = None,
     brandingByEdition = Map.empty,
     atomId = None,
-    mediaAtomData = None
+    mediaAtom = None
   )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
@@ -75,7 +75,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     embedCss = None,
     brandingByEdition = Map.empty,
     atomId = None,
-    mediaAtomData = None
+    mediaAtom = None
   )
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
@@ -92,7 +92,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     atomId = None,
-    mediaAtomData = None
+    mediaAtom = None
   )
 
   "webPublicationDateOption" - {


### PR DESCRIPTION
## What does this change?
Refactor mediaAtomData to mediaAtom on the facia content curation collection model

This is so that we have access to the whole atom, rather than just the media atom data. The whole atom is required downsteam as the atom id is nested at the top of the model, not on the media atom. Without the ID, the media atom cannot be modeled by Frontend and passed to the rendering layer, DCR

This revision means we now validate in the consumer that the atom is of type media.   

This PR addresses some formatting so it is advised to review without whitespace changes to help reduce noise.

## How to test
Use the preview version of this branch and use it in Frontend. Validate that facia-press correctly adds a mediaAtom to any article that has either a main media or replacement video. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
