### PR TITLE
Main media selection bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,8 @@ def fapiClient(playJsonVersion: PlayJsonVersion) =  playJsonSpecificProject("fap
       contentApiDefault,
       commercialShared,
       scalaTestMockito,
-      mockito
+      mockito,
+      jSoup
     ),
     artifactProducingSettings(supportScala3 = false) // currently blocked by contentApi & commercialShared clients
   )

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -1,14 +1,14 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.ContentApiClient
-import com.gu.contentapi.client.model.v1.{Content, ItemResponse}
+import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentatom.thrift.{Atom, AtomData}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
-import com.gu.facia.api.contentapi.{ LatestSnapsRequest, LinkSnapsRequest}
+import com.gu.facia.api.contentapi.{LatestSnapsRequest, LinkSnapsRequest}
 import com.gu.facia.client.models.{CollectionJson, SupportingItem, TargetedTerritory, Trail}
 import org.joda.time.{DateTime, DateTimeZone}
 import com.gu.facia.api.utils.BoostLevel
-import com.gu.facia.api.{CapiError, Response}
+import com.gu.facia.api.Response
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.18" % Test
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.8"
+  val jSoup = "org.jsoup" % "jsoup" % "1.21.1"
 
   case class PlayJsonVersion(
     majorMinorVersion: String,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "20.0.0"
+ThisBuild / version := "20.0.1-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Adjusts the process for selecting a main media video atom by validating the atom ID against main media atom id.

This follows the pattern implemented in Frontend and resolves a bug where, if content has multiple atoms, the main media atom is not necessarily selected https://github.com/guardian/frontend/blob/7ac77e8bb7026b61f9712701c22db4e55e21919f/common/app/model/PressedStory.scala#L32

**before** 
![Screenshot 2025-06-23 at 10 14 21](https://github.com/user-attachments/assets/2884b068-f293-4e61-ad4d-60f37335dd2d)

**after**
![Screenshot 2025-06-23 at 10 14 05](https://github.com/user-attachments/assets/2956eb70-3097-47e3-bd6f-1755f6d058f1)


## How to test
- Press a front on main with [this article](https://m.code.dev-theguardian.com/world/live/2025/jun/22/israel-iran-war-live-trump-says-us-has-attacked-nuclear-sites-in-iran-including-fordow). Check the DCR json and validate that the mediaAtom is *not* the main media. 
- Use the preview version of this branch in frontend and run locally. Validate that the mediaAtom *is now* the main media. 

## How can we measure success?
Main media videos are being correctly attributed to the mainAtom field.

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
