### PR TITLE
Correctly identify splash card in a flexible/special container

### DIFF
--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -45,10 +45,10 @@ object Collection extends StrictLogging {
   }
 
 
-  private def isSplashCard(trail: Trail, index: Int, collectionType: String): Boolean = {
+  private[models] def isSplashCard(trail: Trail, index: Int, collectionType: String): Boolean = {
     (collectionType, trail.safeMeta.group, index) match {
       case ("flexible/general", Some("3"), _) => true
-      case ("flexible/special", Some("1"), 0) => true
+      case ("flexible/special", None, 0) => true
       case _ => false
     }
   }

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -544,5 +544,49 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       Collection.maxSupportingItems(isSplashCard, collectionType, boostLevel) shouldBe 4
     }
   }
+  "isSplashCard" - {
+    "should return true for any card in a splash group of a flexible general" in {
+      val collectionType = "flexible/general"
+      val splashGroup = "3"
+      val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(splashGroup))))
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (true)
+    }
+    "should return false for any card not in the splash group of a flexible general" in {
+      val collectionType = "flexible/general"
+      val bigGroup = "1"
+      val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(bigGroup))))
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (false)
+    }
+    "should return true for the first card in the standard group of a flexible special" in {
+      val collectionType = "flexible/special"
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (true)
+    }
+    "should return false for the card in the snap group of a flexible special" in {
+      val collectionType = "flexible/special"
+      val snapGroup = "1"
+      val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(snapGroup))))
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (false)
+    }
+    "should return false for the second card in the standard group of a flexible special" in {
+      val collectionType = "flexible/special"
+      val snapGroup = "1"
+      val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(snapGroup))))
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (false)
+    }
+    "should return false if the container is not flexible general or flexible special" in {
+      val collectionType = "scollable/medium"
+      val trailIndex = 0
+      Collection.isSplashCard(trail, trailIndex, collectionType) should be (false)
+    }
+  }
 
 }


### PR DESCRIPTION
Groups in the fronts tool descend rather than ascend so Some(1) is the snap group and None is the standard group. As a consequence of this mixup, the splash card was not being correctly identified as card 0 of group standard.

## What does this change?
Updates the conditions for identifying a splash card in a flexible/special container.

Groups in the fronts tool descend rather than ascend so Some(1) is the snap group and None is the standard group. As a consequence of this mixup, the splash card was not being correctly identified as card 0 of group standard.

As a consequence of incorrectly assigning the splash card in flex special, flexible specials were not having the correct sublinks capping and were being capped at 2 sublinks instead of 4. This change will resolve this bug.

To be confident in this change, this PR adds test coverage for this function to validate when a card should / should not be considered a splash card.

## How to test

- construct a front with a flexible special container with a card with 5 sublinks in position 0 of standard group.
- use the preview version of this in Frontend or MAPI and deploy to CODE
- check the json of the front and validate that the flexible special splash card has 4 sublinks
