### PR TITLE
Refactor main media atom extraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,6 @@ def fapiClient(playJsonVersion: PlayJsonVersion) =  playJsonSpecificProject("fap
       commercialShared,
       scalaTestMockito,
       mockito,
-      jSoup
     ),
     artifactProducingSettings(supportScala3 = false) // currently blocked by contentApi & commercialShared clients
   )

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -1,7 +1,7 @@
 package com.gu.facia.api.models
 
 import com.gu.contentapi.client.ContentApiClient
-import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.v1.{Block, BlockElement, Blocks, Content, ContentAtomElementFields}
 import com.gu.contentatom.thrift.{Atom, AtomData}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import com.gu.facia.api.contentapi.{LatestSnapsRequest, LinkSnapsRequest}
@@ -10,7 +10,6 @@ import org.joda.time.{DateTime, DateTimeZone}
 import com.gu.facia.api.utils.BoostLevel
 import com.gu.facia.api.Response
 import com.typesafe.scalalogging.StrictLogging
-import org.jsoup.Jsoup
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -140,9 +139,8 @@ object Collection extends StrictLogging {
           }
 
         case faciaContent: CuratedContent if faciaContent.properties.showMainVideo =>
-          val mainField = faciaContent.content.fields.flatMap(_.main).get
           val mainAtom = for {
-            atomId <- extractMainMediaAtomIdFromHtml(mainField)
+            atomId <- getMainMediaAtomId(faciaContent)
             atoms <- faciaContent.content.atoms
             mediaAtoms <- atoms.media
             validMediaAtom <- mediaAtoms.find(atom => atom.id == atomId && isValidMediaAtom(atom))
@@ -154,16 +152,13 @@ object Collection extends StrictLogging {
       Response.Async.Right(futureMaybeAtomData)
     }
 
-    //
-    // We need to make sure that we only select the main media atom rather than another embedded atom. This follows the same pattern implemented in Frontend.
-    //
-    def extractMainMediaAtomIdFromHtml(html: String): Option[String] = {
+    def getMainMediaAtomId(faciaContent: CuratedContent): Option[String] = {
       for {
-        document <- Some(Jsoup.parse(html))
-        atomContainer <- Option(document.getElementsByClass("element-atom").first())
-        bodyElement <- Some(atomContainer.getElementsByTag("gu-atom"))
-        atomId <- Some(bodyElement.attr("data-atom-id"))
-      } yield atomId
+        block       <- faciaContent.content.blocks
+        main        <- block.main
+        element     <- main.elements.find(_.contentAtomTypeData.isDefined)
+        atomData    <- element.contentAtomTypeData
+      } yield atomData.atomId
     }
 
     def isValidMediaAtom(atom: Atom): Boolean = {

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.2.18" % Test
   val scalaLogging = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
   val commercialShared = "com.gu" %% "commercial-shared" % "6.1.8"
-  val jSoup = "org.jsoup" % "jsoup" % "1.21.1"
 
   case class PlayJsonVersion(
     majorMinorVersion: String,


### PR DESCRIPTION
## What does this change?
@davidfurey noted that we can access the main media atom id directly from the content rather than having to parse the html. 

This refactor does just that.

In doing so, we can remove the dependency on Jsoup which was required for HTML parsing. 

This has been tested on a front with the following video variants - all pull through as expected to the front.

- main media video (one video in content)
- main media video (multiple video in content)
- video page 
- replacement video

## How to test
- test a preview version of this branch in frontend/mapi
- ensure the mediaAtom in the json still contains the correct main media atom rather than another atom in the content. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
