### PR TITLE
Bump CAPI version to allow rolling out change to CAPI model

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "34.0.0"
+  val capiVersion = "35.0.0"
   val eTagCachingVersion = "7.0.0"
 
   val awsS3SdkV1 = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.765"


### PR DESCRIPTION
## What does this change?

Only bumps CAPI, to allow us to roll out a binary compatible version of CAPI client, CAPI model and Facia client to apple news