### PR TITLE
Update `gha-scala-library-release-workflow` to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.11.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")
-
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")


### PR DESCRIPTION
Updating `gha-scala-library-release-workflow` to v2:

* https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0