### PR TITLE
Bump content-api-scala-client version to bring in Product Element

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "38.0.0-PREVIEW.filterbump-cpai-version.2025-10-17T1452.d9337833"
+  val capiVersion = "38.0.0"
   val eTagCachingVersion = "7.0.0"
 
   val awsS3SdkV1 = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.765"


### PR DESCRIPTION
## What does this change?
Bumps the version of content-api-scala-client to bring in the changes from [this PR](https://github.com/guardian/content-api-scala-client/pull/446), which updates the version of content-api-models to include the Product Element.
