### PR TITLE
Bump CAPI client to latest

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "35.0.0"
+  val capiVersion = "37.0.0"
   val eTagCachingVersion = "7.0.0"
 
   val awsS3SdkV1 = "com.amazonaws" % "aws-java-sdk-s3" % "1.12.765"


### PR DESCRIPTION
## What does this change?

Bumps CAPI client from v35.0.0 (https://github.com/guardian/content-api-scala-client/releases/tag/v35.0.0) to v37.0.0 (https://github.com/guardian/content-api-scala-client/releases/tag/v37.0.0).