### PR TITLE
Bump CAPI to v42.0.1

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "41.0.0"
+  val capiVersion = "42.0.1"
   val eTagCachingVersion = "7.0.0"
 
   val eTagCachingS3Base = "com.gu.etag-caching" %% "aws-s3-base" % eTagCachingVersion


### PR DESCRIPTION
## What does this change?

Bump CAPI to v42.0.1 for the latest capi-models version to support new media atom fields.

This reflects the changes made in https://github.com/guardian/content-api-scala-client/pull/479

## How to test
This can be tested in Frontend or MAPI by deploying the following branches to CODE


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [ ] Updated facia-tool to use latest version
- [ ] Updated frontend to use latest version
- [ ] Updated MAPI to use latest version
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [ ] Updated apple-news to use latest version
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)



## Relevant PRs

- [content-atom](https://github.com/guardian/content-atom/pull/208)
- [atom-maker](https://github.com/guardian/atom-maker/pull/141)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3335)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3336)
- [content-api-models](https://github.com/guardian/content-api-models/pull/297)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3337) 
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/479) 
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/392) <- you are here



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214231129787221