### PR TITLE
Product ID: bump capi version

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val capiVersion = "43.0.0"
+  val capiVersion = "44.0.0"
   val eTagCachingVersion = "7.0.0"
 
   val eTagCachingS3Base = "com.gu.etag-caching" %% "aws-s3-base" % eTagCachingVersion


### PR DESCRIPTION
## What does this change?

Bumps the CAPI version to bring in the product element ID field

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Testing with preview versions and in Frontend

## Deployment chain

- [flexible-model](https://github.com/guardian/flexible-model/pull/93) [includes release] 
- [flexible-content](https://github.com/guardian/flexible-content/pull/6533)
- [content-api-models](https://github.com/guardian/content-api-models/pull/302) [includes release]
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3341)
- [content-api (ES mappings](https://github.com/guardian/content-api/pull/3342)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3344)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/484) [includes release]
- [content-api-firehose-client](https://github.com/guardian/content-api-firehose-client/pull/) [includes release] 
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/394) [includes release]  ← ← ← We are here
- [frontend](https://github.com/guardian/frontend/pull/28766)
- [dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/15780)
- [apple-news](https://github.com/guardian/apple-news/pull/) N/A
