### PR TITLE
Introduce Editorial AB test model

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -75,20 +75,6 @@ object SupportingItemMetaData {
 
 case class SupportingItemMetaData(json: Map[String, JsValue]) extends MetaDataCommonFields
 
-object SupportingItem {
-  implicit val jsonFormat: OFormat[SupportingItem] = Json.format[SupportingItem]
-}
-
-case class SupportingItem(
-  id: String,
-  frontPublicationDate: Option[Long],
-  publishedBy: Option[String],
-  meta: Option[SupportingItemMetaData]
-) {
-  val isSnap: Boolean = id.startsWith("snap/")
-  lazy val safeMeta = meta.getOrElse(TrailMetaData.empty)
-}
-
 object TrailMetaData {
   implicit val flatReads: Reads[TrailMetaData] = new Reads[TrailMetaData] {
     override def reads(j: JsValue): JsResult[TrailMetaData] = {
@@ -110,6 +96,59 @@ case class TrailMetaData(json: Map[String, JsValue]) extends MetaDataCommonField
   lazy val supporting: Option[List[SupportingItem]] = json.get("supporting").flatMap(_.asOpt[List[SupportingItem]])
 }
 
+sealed trait VariantId
+object VariantId {
+  case object A extends VariantId
+  case object B extends VariantId
+
+  implicit val format: Format[VariantId] = new Format[VariantId] {
+    override def reads(json: JsValue): JsResult[VariantId] = json.validate[String].flatMap {
+      case "A" => JsSuccess(A)
+      case "B" => JsSuccess(B)
+      case other => JsError(s"Unknown VariantId: $other")
+    }
+    override def writes(o: VariantId): JsValue = o match {
+      case A => JsString("A")
+      case B => JsString("B")
+    }
+  }
+}
+
+case class VariantMeta(id: VariantId, meta: TrailMetaData)
+object VariantMeta {
+  implicit val jsonFormat: OFormat[VariantMeta] = Json.format[VariantMeta]
+}
+
+case class Test(
+  testUuid: String,
+  variantMeta: List[VariantMeta],
+  startDate: Option[DateTime],
+  expiryDate: Option[DateTime],
+  createdByName: String,
+  createdByEmail: String,
+  hasManuallyEndedOnThisTrail: Boolean,
+  manuallyEndedOnThisTrailByName: Option[String],
+  manuallyEndedOnThisTrailByEmail: Option[String]
+)
+object Test {
+  implicit val jsonFormat: OFormat[Test] = Json.format[Test]
+}
+
+object SupportingItem {
+  implicit val jsonFormat: OFormat[SupportingItem] = Json.format[SupportingItem]
+}
+
+case class SupportingItem(
+  id: String,
+  frontPublicationDate: Option[Long],
+  publishedBy: Option[String],
+  meta: Option[SupportingItemMetaData],
+  tests: Option[List[Test]]
+) {
+  val isSnap: Boolean = id.startsWith("snap/")
+  lazy val safeMeta = meta.getOrElse(TrailMetaData.empty)
+}
+
 object Trail {
   implicit val jsonFormat: OFormat[Trail] = Json.format[Trail]
 }
@@ -118,7 +157,8 @@ case class Trail(
   id: String,
   frontPublicationDate: Long,
   publishedBy: Option[String],
-  meta: Option[TrailMetaData]
+  meta: Option[TrailMetaData],
+  tests: Option[List[Test]]
 ) {
   val isSnap: Boolean = id.startsWith("snap/")
   lazy val safeMeta = meta.getOrElse(TrailMetaData.empty)

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -120,12 +120,13 @@ object VariantMeta {
 }
 
 case class Test(
-  testUuid: String,
+  testUuid: String, // A static referrer, which will help if the card moves from container to container. The same testUuid can be shared across multiple Tests
   variantMeta: List[VariantMeta],
   startDate: Option[DateTime],
   expiryDate: Option[DateTime],
   createdByName: String,
   createdByEmail: String,
+  frontsThisTestCanRunOn: List[String],
   hasManuallyEndedOnThisTrail: Boolean,
   manuallyEndedOnThisTrailByName: Option[String],
   manuallyEndedOnThisTrailByEmail: Option[String]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -119,17 +119,31 @@ object VariantMeta {
   implicit val jsonFormat: OFormat[VariantMeta] = Json.format[VariantMeta]
 }
 
+/**
+ * Represents an A/B test running on a trail within a collection.
+ *
+ * @param testUuid a static reference that persists if the card moves between containers, and can be shared across multiple Test instances on multiple cards.
+ * @param variantMeta the list of variants for this test, each with its own metadata
+ * @param startDate the start date of the test, in milliseconds since epoch
+ * @param expiryDate the expiry date of the test, in milliseconds since epoch. If the test has expired, it will not be shown to users.
+ * @param createdByName the name of the person who created the test
+ * @param createdByEmail the email of the person who created the test
+ * @param frontsThisTestCanRunOn the list of fronts that this test can run on.
+ * @param hasManuallyEndedOnThisTrail whether this test has been manually ended on this trail. If true, the test will not be shown to users on this trail, nor will it report to Ophan, even if it is still active on other trails.
+ * @param manuallyEndedOnThisTrailByName the name of the person who manually ended this test on this trail, if applicable
+ * @param manuallyEndedOnThisTrailByEmail the email of the person who manually ended this test on this trail, if applicable
+ */
 case class Test(
-  testUuid: String, // a static reference that persists if the card moves between containers, and can be shared across multiple Test instances on multiple cards.
-  variantMeta: List[VariantMeta], // the list of variants for this test, each with its own metadata
-  startDate: Option[Long], // the start date of the test, in milliseconds since epoch
-  expiryDate: Option[Long], // the expiry date of the test, in milliseconds since epoch. If the test has expired, it will not be shown to users.
-  createdByName: String, // the name of the person who created the test
-  createdByEmail: String, // the email of the person who created the test
-  frontsThisTestCanRunOn: List[String], // the list of fronts that this test can run on.
-  hasManuallyEndedOnThisTrail: Boolean, // whether this test has been manually ended on this trail. If true, the test will not be shown to users on this trail, nor will it report to Ophan, even if it is still active on other trails.
-  manuallyEndedOnThisTrailByName: Option[String], // the name of the person who manually ended this test on this trail, if applicable
-  manuallyEndedOnThisTrailByEmail: Option[String] // the email of the person who manually ended this test on this trail, if applicable
+  testUuid: String,
+  variantMeta: List[VariantMeta],
+  startDate: Option[Long],
+  expiryDate: Option[Long],
+  createdByName: String,
+  createdByEmail: String,
+  frontsThisTestCanRunOn: List[String],
+  hasManuallyEndedOnThisTrail: Boolean,
+  manuallyEndedOnThisTrailByName: Option[String],
+  manuallyEndedOnThisTrailByEmail: Option[String]
 )
 object Test {
   implicit val jsonFormat: OFormat[Test] = Json.format[Test]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -114,6 +114,11 @@ object VariantId {
   }
 }
 
+/**
+ * @param meta only contains the fields that are actually being tested, i.e. the fields that differ
+ *             per variant. Any field not being tested will not be present here, and consumers should
+ *             fall back to the trail's own [[TrailMetaData]] for those.
+ */
 case class VariantMeta(id: VariantId, meta: TrailMetaData)
 object VariantMeta {
   implicit val jsonFormat: OFormat[VariantMeta] = Json.format[VariantMeta]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -120,16 +120,16 @@ object VariantMeta {
 }
 
 case class Test(
-  testUuid: String, // A static referrer, which will help if the card moves from container to container. The same testUuid can be shared across multiple Tests
-  variantMeta: List[VariantMeta],
-  startDate: Option[Long],
-  expiryDate: Option[Long],
-  createdByName: String,
-  createdByEmail: String,
-  frontsThisTestCanRunOn: List[String],
-  hasManuallyEndedOnThisTrail: Boolean,
-  manuallyEndedOnThisTrailByName: Option[String],
-  manuallyEndedOnThisTrailByEmail: Option[String]
+  testUuid: String, // a static reference that persists if the card moves between containers, and can be shared across multiple Test instances on multiple cards.
+  variantMeta: List[VariantMeta], // the list of variants for this test, each with its own metadata
+  startDate: Option[Long], // the start date of the test, in milliseconds since epoch
+  expiryDate: Option[Long], // the expiry date of the test, in milliseconds since epoch. If the test has expired, it will not be shown to users.
+  createdByName: String, // the name of the person who created the test
+  createdByEmail: String, // the email of the person who created the test
+  frontsThisTestCanRunOn: List[String], // the list of fronts that this test can run on.
+  hasManuallyEndedOnThisTrail: Boolean, // whether this test has been manually ended on this trail. If true, the test will not be shown to users on this trail, nor will it report to Ophan, even if it is still active on other trails.
+  manuallyEndedOnThisTrailByName: Option[String], // the name of the person who manually ended this test on this trail, if applicable
+  manuallyEndedOnThisTrailByEmail: Option[String] // the email of the person who manually ended this test on this trail, if applicable
 )
 object Test {
   implicit val jsonFormat: OFormat[Test] = Json.format[Test]

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -122,8 +122,8 @@ object VariantMeta {
 case class Test(
   testUuid: String, // A static referrer, which will help if the card moves from container to container. The same testUuid can be shared across multiple Tests
   variantMeta: List[VariantMeta],
-  startDate: Option[DateTime],
-  expiryDate: Option[DateTime],
+  startDate: Option[Long],
+  expiryDate: Option[Long],
   createdByName: String,
   createdByEmail: String,
   frontsThisTestCanRunOn: List[String],

--- a/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/Collection.scala
@@ -153,6 +153,11 @@ object SupportingItem {
   implicit val jsonFormat: OFormat[SupportingItem] = Json.format[SupportingItem]
 }
 
+/**
+ * @param tests the list of A/B tests configured on this supporting item. Note that expired tests
+ *              and tests which have been manually ended aren't removed from this list. Consumers
+ *              must check a test's expiry/manually-ended status themselves.
+ */
 case class SupportingItem(
   id: String,
   frontPublicationDate: Option[Long],
@@ -168,6 +173,11 @@ object Trail {
   implicit val jsonFormat: OFormat[Trail] = Json.format[Trail]
 }
 
+/**
+ * @param tests the list of A/B tests configured on this trail. Note that expired tests
+ *              and tests which have been manually ended aren't removed from this list. Consumers
+ *              must check a test's expiry/manually-ended status themselves.
+ */
 case class Trail(
   id: String,
   frontPublicationDate: Long,

--- a/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/models/CollectionSpec.scala
@@ -89,7 +89,7 @@ class CollectionSpec extends AnyFlatSpec with Matchers with OptionValues with Re
     
   it should "be able to serialize and deserialize the same object" in {
     val collectionJson = CollectionJson(
-      live = List(Trail("id-123", DateTime.now.getMillis, None, None)),
+      live = List(Trail("id-123", DateTime.now.getMillis, None, None, None)),
       draft = None,
       treats = None,
       lastUpdated = DateTime.now(),

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/collection.scala
@@ -88,8 +88,16 @@ object Collection extends StrictLogging {
         .map { content =>
           trail.safeMeta.supporting
             .map(_.flatMap(resolveSupportingContent))
-            .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(content, trail.safeMeta, Option(trail.frontPublicationDate), supportingItems.take(maxItems), collection.collectionConfig))
-            .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, Option(trail.frontPublicationDate), collection.collectionConfig))
+            .map(supportingItems => CuratedContent.fromTrailAndContentWithSupporting(
+              content,
+              trail.safeMeta,
+              Option(trail.frontPublicationDate),
+              supportingItems.take(maxItems),
+              collection.collectionConfig,
+              trail.tests
+            )
+            )
+            .getOrElse(CuratedContent.fromTrailAndContent(content, trail.safeMeta, Option(trail.frontPublicationDate), collection.collectionConfig, trail.tests))
         }
         .orElse {
           snapContent
@@ -113,7 +121,7 @@ object Collection extends StrictLogging {
       content.find { c =>
         supportingItem.id.endsWith("/" + c.fields.flatMap(_.internalPageCode).getOrElse(throw new RuntimeException("No internal page code")))
       }
-        .map { content => SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, supportingItem.frontPublicationDate, collection.collectionConfig) }
+        .map { content => SupportingCuratedContent.fromTrailAndContent(content, supportingItem.safeMeta, supportingItem.frontPublicationDate, collection.collectionConfig, supportingItem.tests) }
         .orElse {
           snapContent
             .find { case (id, _) => supportingItem.id == id }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -8,6 +8,7 @@ import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.api.utils._
 import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Test, Trail, TrailMetaData}
 
+
 sealed trait FaciaImage
 
 case class Cutout(imageSrc: String, imageSrcWidth: Option[String], imageSrcHeight: Option[String]) extends FaciaImage
@@ -95,8 +96,6 @@ sealed trait FaciaContent {
   def kicker: Option[ItemKicker]
 
   def atomId: Option[String]
-
-  def tests: Option[List[Test]]
 }
 
 // This needs to be kept aligned with Frontend until it's pushed all the way upstream to Thrift
@@ -151,7 +150,6 @@ object Snap {
           trail.safeMeta.byline,
           ItemKicker.fromTrailMetaData(trail.safeMeta),
           brandingByEdition,
-          None,
           None
         ))
       case _ => None
@@ -179,7 +177,6 @@ object Snap {
         supportingItem.safeMeta.byline,
         ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
         Map.empty,
-        None,
         None
       ))
     case _ => None
@@ -204,8 +201,7 @@ case class LinkSnap(
                      byline: Option[String],
                      kicker: Option[ItemKicker],
                      override val brandingByEdition: BrandingByEdition,
-                     mediaAtom: Option[Atom],
-                     tests: Option[List[Test]]
+                     mediaAtom: Option[Atom]
                    ) extends Snap
 
 case class LatestSnap(
@@ -226,8 +222,7 @@ case class LatestSnap(
                        kicker: Option[ItemKicker],
                        override val brandingByEdition: BrandingByEdition,
                        atomId: Option[String],
-                       mediaAtom: Option[Atom],
-                       tests: Option[List[Test]]
+                       mediaAtom: Option[Atom]
                      ) extends Snap
 
 object LatestSnap {
@@ -255,7 +250,6 @@ object LatestSnap {
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData),
       brandingByEdition,
       trail.safeMeta.atomId,
-      None,
       None
     )
   }
@@ -284,7 +278,6 @@ object LatestSnap {
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData),
       brandingByEdition,
       supportingItem.safeMeta.atomId,
-      None,
       None
     )
   }

--- a/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/models/curatedcontent.scala
@@ -6,7 +6,7 @@ import com.gu.contentapi.client.utils.format._
 import com.gu.contentatom.thrift.Atom
 import com.gu.facia.api.utils.ContentApiUtils._
 import com.gu.facia.api.utils._
-import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Trail, TrailMetaData}
+import com.gu.facia.client.models.{MetaDataCommonFields, SupportingItem, Test, Trail, TrailMetaData}
 
 sealed trait FaciaImage
 
@@ -95,6 +95,8 @@ sealed trait FaciaContent {
   def kicker: Option[ItemKicker]
 
   def atomId: Option[String]
+
+  def tests: Option[List[Test]]
 }
 
 // This needs to be kept aligned with Frontend until it's pushed all the way upstream to Thrift
@@ -149,6 +151,7 @@ object Snap {
           trail.safeMeta.byline,
           ItemKicker.fromTrailMetaData(trail.safeMeta),
           brandingByEdition,
+          None,
           None
         ))
       case _ => None
@@ -176,6 +179,7 @@ object Snap {
         supportingItem.safeMeta.byline,
         ItemKicker.fromTrailMetaData(supportingItem.safeMeta),
         Map.empty,
+        None,
         None
       ))
     case _ => None
@@ -200,7 +204,8 @@ case class LinkSnap(
                      byline: Option[String],
                      kicker: Option[ItemKicker],
                      override val brandingByEdition: BrandingByEdition,
-                     mediaAtom: Option[Atom]
+                     mediaAtom: Option[Atom],
+                     tests: Option[List[Test]]
                    ) extends Snap
 
 case class LatestSnap(
@@ -221,8 +226,8 @@ case class LatestSnap(
                        kicker: Option[ItemKicker],
                        override val brandingByEdition: BrandingByEdition,
                        atomId: Option[String],
-                       mediaAtom: Option[Atom]
-
+                       mediaAtom: Option[Atom],
+                       tests: Option[List[Test]]
                      ) extends Snap
 
 object LatestSnap {
@@ -250,6 +255,7 @@ object LatestSnap {
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, trail.safeMeta, resolvedMetaData),
       brandingByEdition,
       trail.safeMeta.atomId,
+      None,
       None
     )
   }
@@ -278,6 +284,7 @@ object LatestSnap {
       ItemKicker.fromMaybeContentTrailMetaAndResolvedMetaData(maybeContent, supportingItem.safeMeta, resolvedMetaData),
       brandingByEdition,
       supportingItem.safeMeta.atomId,
+      None,
       None
     )
   }
@@ -302,7 +309,8 @@ case class CuratedContent(
                            embedCss: Option[String],
                            override val brandingByEdition: BrandingByEdition,
                            atomId: Option[String],
-                           mediaAtom: Option[Atom]
+                           mediaAtom: Option[Atom],
+                           tests: Option[List[Test]]
                          ) extends FaciaContent
 
 case class SupportingCuratedContent(
@@ -319,7 +327,8 @@ case class SupportingCuratedContent(
                                      byline: Option[String],
                                      kicker: Option[ItemKicker],
                                      atomId: Option[String],
-                                     mediaAtom: Option[Atom]
+                                     mediaAtom: Option[Atom],
+                                     tests: Option[List[Test]]
                                    ) extends FaciaContent
 
 object CuratedContent {
@@ -328,7 +337,8 @@ object CuratedContent {
                                         trailMetaData: TrailMetaData,
                                         maybeFrontPublicationDate: Option[Long],
                                         supportingContent: List[FaciaContent],
-                                        collectionConfig: CollectionConfig) = {
+                                        collectionConfig: CollectionConfig,
+                                        tests: Option[List[Test]] ) = {
     val cardStyle = CardStyle(content, trailMetaData)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
@@ -351,14 +361,16 @@ object CuratedContent {
       embedCss = trailMetaData.snapCss,
       brandingByEdition = content.brandingByEdition,
       trailMetaData.atomId,
-      None
+      None,
+      tests
     )
   }
 
   def fromTrailAndContent(content: Content,
                           trailMetaData: MetaDataCommonFields,
                           maybeFrontPublicationDate: Option[Long],
-                          collectionConfig: CollectionConfig): CuratedContent = {
+                          collectionConfig: CollectionConfig,
+                          tests: Option[List[Test]] ): CuratedContent = {
 
     val cardStyle = CardStyle(content, trailMetaData)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
@@ -383,7 +395,8 @@ object CuratedContent {
       embedCss = trailMetaData.snapCss,
       brandingByEdition = content.brandingByEdition,
       trailMetaData.atomId,
-      None
+      None,
+      tests
     )
   }
 }
@@ -392,7 +405,8 @@ object SupportingCuratedContent {
   def fromTrailAndContent(content: Content,
                           trailMetaData: MetaDataCommonFields,
                           maybeFrontPublicationDate: Option[Long],
-                          collectionConfig: CollectionConfig): SupportingCuratedContent = {
+                          collectionConfig: CollectionConfig,
+                          tests: Option[List[Test]] ): SupportingCuratedContent = {
     val cardStyle = CardStyle(content, trailMetaData)
     val resolvedMetaData = ResolvedMetaData.fromContentAndTrailMetaData(content, trailMetaData, cardStyle)
 
@@ -410,7 +424,8 @@ object SupportingCuratedContent {
       trailMetaData.byline.orElse(content.fields.flatMap(_.byline)),
       ItemKicker.fromContentAndTrail(Option(content), trailMetaData, resolvedMetaData, None),
       trailMetaData.atomId,
-      None
+      None,
+      tests
     )
   }
 }

--- a/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
+++ b/fapi-client/src/main/scala/com/gu/facia/api/utils/Backfill.scala
@@ -38,7 +38,7 @@ object BackfillResolver {
         for {
           backfillContent <- ContentApi.backfillContentFromResponse(backfillResponse)
         } yield {
-          backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig))
+          backfillContent.map(CuratedContent.fromTrailAndContent(_, TrailMetaData.empty, None, collectionConfig, None))
         }
       case CollectionBackfill(parentCollectionId) =>
         val collectionBackfillResult =

--- a/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/integration/IntegrationTest.scala
@@ -33,9 +33,9 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
   )
 
   def makeLatestTrailFor(id: String, uri: String) =
-    Trail(id, 0, None, Some(TrailMetaData(Map("snapUri" -> JsString(uri), "snapType" -> JsString("latest")))))
+    Trail(id, 0, None, Some(TrailMetaData(Map("snapUri" -> JsString(uri), "snapType" -> JsString("latest")))), None)
   def makeLinkSnapFor(id: String, uri: String) =
-    Trail(id, 0, None, Some(TrailMetaData(Map("snapUri" -> JsString(uri), "snapType" -> JsString("link")))))
+    Trail(id, 0, None, Some(TrailMetaData(Map("snapUri" -> JsString(uri), "snapType" -> JsString("link")))), None)
 
   "getFronts" - {
     "should return a set of Front instances from the fronts JSON" in {
@@ -110,7 +110,7 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
 
       val plainSnapOne = makeLinkSnapFor("snap/347234723", "doesnotmatter")
 
-      val normalTrail = Trail("internal-code/page/2144828", 0, None, None)
+      val normalTrail = Trail("internal-code/page/2144828", 0, None, None, None)
 
       val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
 
@@ -364,9 +364,9 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
 
   "Supporting Items" - {
     def makeTrail(id: String) =
-      Trail(id, 0, None, None)
+      Trail(id, 0, None, None, None)
     def makeTrailWithSupporting(id: String, supporting: Trail*) =
-      Trail(id, 0, None, Some(TrailMetaData(Map("supporting" -> JsArray(supporting.map(Json.toJson(_)))))))
+      Trail(id, 0, None, Some(TrailMetaData(Map("supporting" -> JsArray(supporting.map(Json.toJson(_)))))), None)
 
     val supportingTrailOne = makeTrail("internal-code/page/2144828")
     val supportingTrailTwo = makeTrail("internal-code/page/2383149")
@@ -467,8 +467,8 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
       targetedTerritory = None
     )
 
-    val normalTrail = Trail("internal-code/page/2144828", 0, None, None)
-    val normalTrailTwo = Trail("internal-code/page/2383149", 0, None, None)
+    val normalTrail = Trail("internal-code/page/2144828", 0, None, None, None)
+    val normalTrailTwo = Trail("internal-code/page/2383149", 0, None, None, None)
     val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
 
     "should request normal item treats" ignore {
@@ -536,8 +536,8 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
       targetedTerritory = None
     )
 
-    val normalTrail = Trail("internal-code/page/2144828", 0, None, None)
-    val normalTrailTwo = Trail("internal-code/page/2383149", 0, None, None)
+    val normalTrail = Trail("internal-code/page/2144828", 0, None, None, None)
+    val normalTrailTwo = Trail("internal-code/page/2383149", 0, None, None, None)
     val collectionConfig = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults())
 
     "should request draft items" ignore {
@@ -615,7 +615,7 @@ class IntegrationTest extends AnyFreeSpec with Matchers with ScalaFutures with O
     }
 
     "Should request a mix of both" - {
-      val normalTrailThree = Trail("internal-code/page/2379309", 0, None, None)
+      val normalTrailThree = Trail("internal-code/page/2379309", 0, None, None, None)
       val latestSnapOne = makeLatestTrailFor("snap/1281727", "uk/culture")
       val latestSnapTwo = makeLatestTrailFor("snap/2372382", "technology")
       val collectionJson = makeCollectionJsonWithDraft(List(latestSnapOne, normalTrail, latestSnapTwo, normalTrailTwo), normalTrailThree)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -17,7 +17,7 @@ import com.gu.contentapi.client.ContentApiClient
 
 class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with OneInstancePerTest {
   val trailMetadata = spy(TrailMetaData.empty)
-  val trail = Trail("internal-code/page/123", 1, None, Some(trailMetadata))
+  val trail = Trail("internal-code/page/123", 1, None, Some(trailMetadata), None)
   val collectionJson = CollectionJson(
     live = List(trail),
     draft = None,
@@ -186,7 +186,7 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
     }
 
     "excludes trails where no corresponding content is found" in {
-      val trail2 = Trail("content-id-2", 2, None, Some(trailMetadata))
+      val trail2 = Trail("content-id-2", 2, None, Some(trailMetadata), None)
 
       Collection.liveContent(collection, contents)(capiClient, global).map{ curatedContent =>
         val curatedIds = curatedContent.collect {
@@ -197,10 +197,10 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
     }
 
     "Successfully retrieve snaps from snapContent for latest snaps" in {
-      val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))))
-      val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))))
-      val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))))
-      val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))))
+      val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))), None)
+      val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))), None)
+      val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))), None)
+      val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))), None)
 
       val snapContentOne = Content(
         id = "content-id-one",
@@ -272,11 +272,11 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
   }
 
   "liveIdsWithoutSnaps" - {
-    val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata))
-    val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata))
-    val trailThree = Trail("artanddesign/gallery/2014/feb/28/beyond-basquiat-black-artists", 1, None, Some(trailMetadata))
-    val snapOne = Trail("snap/1415985080061", 1, None, Some(trailMetadata))
-    val snapTwo = Trail("snap/5345345215342", 1, None, Some(trailMetadata))
+    val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata), None)
+    val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata), None)
+    val trailThree = Trail("artanddesign/gallery/2014/feb/28/beyond-basquiat-black-artists", 1, None, Some(trailMetadata), None)
+    val snapOne = Trail("snap/1415985080061", 1, None, Some(trailMetadata), None)
+    val snapTwo = Trail("snap/5345345215342", 1, None, Some(trailMetadata), None)
 
     val collectionJsonTwo = collectionJson.copy(live = List(trailOne, snapOne, snapTwo, trailTwo, trailThree))
 
@@ -303,12 +303,12 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
 
   "Collection" - {
     "filter out the snaps in live" in {
-        val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata))
-        val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata))
-        val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))))
-        val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))))
-        val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))))
-        val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))))
+        val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata), None)
+        val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata), None)
+        val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))), None)
+        val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))), None)
+        val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))), None)
+        val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))), None)
 
         val snapContentOne = Content(
           id = "content-id-one",
@@ -362,12 +362,12 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       }
 
     "filter out the snaps in draft" in {
-      val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata))
-      val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata))
-      val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))))
-      val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))))
-      val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))))
-      val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))))
+      val trailOne = Trail("internal-code/page/1", 1, None, Some(trailMetadata), None)
+      val trailTwo = Trail("internal-code/page/2", 1, None, Some(trailMetadata), None)
+      val snapOne = Trail("snap/1415985080061", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapUri" -> JsString("abc")))), None)
+      val snapTwo = Trail("snap/5345345215342", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("link"), "snapCss" -> JsString("css")))), None)
+      val snapLatestOne = Trail("snap/8474745745660", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("uk")))), None)
+      val snapLatestTwo = Trail("snap/4324234234234", 1, None, Some(TrailMetaData(Map("snapType" -> JsString("latest"), "href" -> JsString("culture")))), None)
 
       val snapContentOne = Content(
         id = "content-id-one",
@@ -451,11 +451,11 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
     )
 
     def makeTrail(id: String) =
-      Trail(id, 0, None, None)
+      Trail(id, 0, None, None, None)
     def makeTrailWithSupporting(id: String, supporting: Trail*) =
-      Trail(id, 0, None, Some(TrailMetaData(Map("supporting" -> JsArray(supporting.map(Json.toJson(_)))))))
+      Trail(id, 0, None, Some(TrailMetaData(Map("supporting" -> JsArray(supporting.map(Json.toJson(_)))))), None)
     "trails with internalPageCode" in {
-      val trail = Trail("internal-code/page/2", 1, None, Some(trailMetadata))
+      val trail = Trail("internal-code/page/2", 1, None, Some(trailMetadata), None)
       val collectionJsonWithPageCode = collectionJson.copy(live = List(trail))
       val collection = Collection.fromCollectionJsonConfigAndContent("id", Some(collectionJsonWithPageCode), collectionConfig)
       Collection.liveContent(collection, contents)(capiClient, global).map{ content =>
@@ -549,7 +549,7 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       val collectionType = "flexible/general"
       val splashGroup = "3"
       val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(splashGroup))))
-      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData, None)
       val trailIndex = 0
       val collectionHasSnap = false;
       Collection.isSplashCard(trail, trailIndex, collectionType, collectionHasSnap) should be (true)
@@ -558,7 +558,7 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       val collectionType = "flexible/general"
       val bigGroup = "1"
       val trailMetaData = Some(TrailMetaData(Map("group" -> JsString(bigGroup))))
-      val trail = Trail("internal-code/page/1", 1, None, trailMetaData)
+      val trail = Trail("internal-code/page/1", 1, None, trailMetaData, None)
       val trailIndex = 0
       val collectionHasSnap = false;
       Collection.isSplashCard(trail, trailIndex, collectionType, collectionHasSnap) should be (false)

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -93,6 +93,7 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       latestContent map (_.brandingByEdition) getOrElse Map.empty,
       atomId = None,
       None,
+      None
     )
 
   def makeLinkSnap(
@@ -126,6 +127,7 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       byline,
       kicker,
       Map.empty,
+      None,
       None
     )
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CollectionTest.scala
@@ -92,7 +92,6 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       kicker,
       latestContent map (_.brandingByEdition) getOrElse Map.empty,
       atomId = None,
-      None,
       None
     )
 
@@ -127,7 +126,6 @@ class CollectionTest extends AnyFreeSpec with Matchers with MockitoSugar with On
       byline,
       kicker,
       Map.empty,
-      None,
       None
     )
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/CuratedContentTest.scala
@@ -22,16 +22,16 @@ class CuratedContentTest extends AnyFreeSpec with Matchers with TestContent {
     val trailMetaDataWithoutHeadline = TrailMetaData(Map.empty)
 
     "should resolve the headline from TrailMetaData" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithHeadline, None, collectionConfig, None)
       curatedContent.headline should be ("trailMetaDataHeadline")
     }
 
     "should resolve the headline from Content fields.headline" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig, None)
       curatedContent.headline should be ("Content headline")
     }
     "should resolve the headline from Content webTitle" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithoutFieldHeadline, trailMetaDataWithoutHeadline, None, collectionConfig, None)
       curatedContent.headline should be ("contentWithoutFieldHeadlineHeadline")
     }
   }
@@ -48,30 +48,30 @@ class CuratedContentTest extends AnyFreeSpec with Matchers with TestContent {
     val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
 
     "should resolve to None" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig, None)
       curatedContent.kicker should be (None)
     }
 
     "should resolve to SectionKicker with config showSections true" in {
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections, None)
       curatedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to TagKicker with config showTags true" in {
       //This test requires content to have tags
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags, None)
       curatedContent.kicker.value shouldBe a [TagKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
       val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags, None)
       curatedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
       val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
-      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags)
+      val curatedContent = CuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags, None)
       curatedContent.kicker.value shouldBe a [TagKicker]
     }
   }
@@ -93,29 +93,29 @@ class CuratedContentTest extends AnyFreeSpec with Matchers with TestContent {
     val collectionConfigShowTags = CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults(showTags = Option(true)))
 
     "should resolve to None" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfig, None)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to None with config showSections true" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowSections, None)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to None with config showTags true" in {
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, emptyTrailMetaData, None, collectionConfigShowTags, None)
       supportingCuratedContent.kicker should be (None)
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerSection true" in {
       val trailMetaDataShowKickerSection = TrailMetaData(Map("showKickerSection" -> JsBoolean(value = true)))
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerSection, None, collectionConfigShowTags, None)
       supportingCuratedContent.kicker.value shouldBe a [SectionKicker]
     }
 
     "should resolve to SectionKicker for trailMetaData showKickerTag true" in {
       val trailMetaDataShowKickerTag = TrailMetaData(Map("showKickerTag" -> JsBoolean(value = true)))
-      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags)
+      val supportingCuratedContent = SupportingCuratedContent.fromTrailAndContent(emptyContent, trailMetaDataShowKickerTag, None, collectionConfigShowTags, None)
       supportingCuratedContent.kicker.value shouldBe a [TagKicker]
     }
   }
@@ -136,7 +136,7 @@ class CuratedContentTest extends AnyFreeSpec with Matchers with TestContent {
         "imageCutoutSrcWidth" -> JsString(cutoutDimensions),
         "imageCutoutSrcHeight" -> JsString(cutoutDimensions)
       ))
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig, None)
 
       val expectedImage = Some(Cutout(
         cutoutSrc,
@@ -157,7 +157,7 @@ class CuratedContentTest extends AnyFreeSpec with Matchers with TestContent {
         "imageCutoutSrcWidth" -> JsString(cutoutDimensions),
         "imageCutoutSrcHeight" -> JsString(cutoutDimensions)
       ))
-      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig)
+      val curatedContent = CuratedContent.fromTrailAndContent(contentWithCommentTone, trailMetadata, None, collectionConfig, None)
 
       val expectedImage = Some(Replace(
         replaceSrc,

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.JsString
 
 class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent {
 
-  val emptyTrail: Trail = Trail("no-id", 0, None, Option(TrailMetaData.empty))
+  val emptyTrail: Trail = Trail("no-id", 0, None, Option(TrailMetaData.empty), None)
 
   val emptyContentProperties =
     ContentProperties(

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -48,6 +48,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       Map.empty,
       None,
+      None,
       None
     )
     FaciaContentUtils.headlineOption(snap) should equal(None)
@@ -55,19 +56,19 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
 
   "should return the headline for a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None, None)
     FaciaContentUtils.headlineOption(cc) should equal(Some("The headline"))
   }
 
   "should return 'Missing href' when the href is None in a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("Content byline"))))
-    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None)
+    val cc = CuratedContent(content, None, Nil, DefaultCardstyle, ContentFormat.defaultContentFormat, "The headline", None, None, "myGroup", None, emptyContentProperties, None, None, None, None, None, Map.empty, None, None, None)
     FaciaContentUtils.href(cc) should equal(None)
   }
 
   "should return default boost level for a CuratedContent if the boostLevel is not present in meta data" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("myByline"))))
-    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData.empty, None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData.empty, None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()), None)
     FaciaContentUtils.boostLevel(cc) should equal(BoostLevel.Default)
   }
 
@@ -94,6 +95,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       None,
       Map.empty,
+      None,
       None,
       None
     )
@@ -123,6 +125,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       None,
       Map.empty,
+      None,
       None
     )
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -48,7 +48,6 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       Map.empty,
       None,
-      None,
       None
     )
     FaciaContentUtils.headlineOption(snap) should equal(None)
@@ -96,7 +95,6 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       Map.empty,
       None,
-      None,
       None
     )
     FaciaContentUtils.href(snap) should equal(Some("The href"))
@@ -125,7 +123,6 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
       None,
       None,
       Map.empty,
-      None,
       None
     )
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/models/FaciaContentHelperTest.scala
@@ -74,7 +74,7 @@ class FaciaContentHelperTest extends AnyFreeSpec with Matchers with TestContent 
 
   "should return boost level for a CuratedContent" in {
     val content = baseContent.copy(fields = Some(ContentFields(headline = Some("myTitle"), trailText = Some("Content trailtext"), byline = Some("myByline"))))
-    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData(Map("boostLevel" -> JsString("gigaboost"))), None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()))
+    val cc = CuratedContent.fromTrailAndContent(content, TrailMetaData(Map("boostLevel" -> JsString("gigaboost"))), None, CollectionConfig.fromCollectionJson(CollectionConfigJson.withDefaults()), None)
     FaciaContentUtils.boostLevel(cc) should equal(BoostLevel.GigaBoost)
   }  
 

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -28,8 +28,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     brandingByEdition = Map.empty,
-    mediaAtom = None,
-    tests = None
+    mediaAtom = None
   )
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
@@ -54,8 +53,7 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     kicker = None,
     brandingByEdition = Map.empty,
     atomId = None,
-    mediaAtom = None,
-    tests = None
+    mediaAtom = None
   )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(

--- a/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
+++ b/fapi-client/src/test/scala/com/gu/facia/api/utils/FaciaContentUtilsTest.scala
@@ -28,7 +28,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     brandingByEdition = Map.empty,
-    mediaAtom = None
+    mediaAtom = None,
+    tests = None
   )
 
   val staticDateTime = new DateTime().withYear(2015).withMonthOfYear(4).withDayOfMonth(22)
@@ -53,7 +54,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     kicker = None,
     brandingByEdition = Map.empty,
     atomId = None,
-    mediaAtom = None
+    mediaAtom = None,
+    tests = None
   )
 
   def makeCuratedContent(curatedContentId: String, content: Content = content) = CuratedContent(
@@ -75,7 +77,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     embedCss = None,
     brandingByEdition = Map.empty,
     atomId = None,
-    mediaAtom = None
+    mediaAtom = None,
+    tests = None
   )
 
   def makeSupportingCuratedContent(curatedContentId: String, content: Content = content) = SupportingCuratedContent(
@@ -92,7 +95,8 @@ class FaciaContentUtilsTest extends AnyFreeSpec with Matchers with TestContent {
     byline = None,
     kicker = None,
     atomId = None,
-    mediaAtom = None
+    mediaAtom = None,
+    tests = None
   )
 
   "webPublicationDateOption" - {


### PR DESCRIPTION
## What does this change?
Introduces a Test model for editorially-led content tests (A/B tests) on fronts. This adds several new types to com.gu.facia.client.models:
- **VariantId**: a sealed trait enum with two variants, A and B.
- **VariantMeta**:  pairs a VariantId with its associated TrailMetaData, allowing each variant to carry its own card metadata overrides.
- **Test**: describes a single content test, including:
  - **testUuid**: a static reference that persists if the card moves between containers, and can be shared across multiple Test instances on multiple cards.
  - **variantMeta**: the list of variants in the test.
  - **startDate** & **expiryDate**: scheduling boundaries. This field is optional as they will be defined when the test starts, not when the test is created.
  - **createdByName** & **createdByEmail** : audit fields for user who created the test
  - **frontsThisTestCanRunOn**: restricts where the test is allowed to run.
  - **hasManuallyEndedOnThisTrail** & **manuallyEndedOnThisTrailByName** & **manuallyEndedOnThisTrailByEmail**: track manual termination of a test on a given trail.
    

**tests**: Option[List[Test]] has been added as an optional field to both Trail and SupportingItem (sublinks) to support cards with tests moving between trails and sublinks 

## How to test
Include a preview release in a downstream dependent (eg fronts tool) and make sure that the build compiles, deploys and runs successfully. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
This is a model/library change with no behavioural runtime impact on its own. Success is measured by downstream consumers (facia-tool, frontend) being able to read and write the new tests field, enabling the editorial content-testing feature to be built on top.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This is a low risk change as tests is optional on both Trail and SupportingItem, so this change is backwards compatible

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment

- [x] Updated facia-tool to use latest version <- https://github.com/guardian/facia-tool/pull/2013
- [x] Updated frontend to use latest version <- https://github.com/guardian/frontend/pull/28992
- [x] Updated MAPI to use latest version <- https://github.com/guardian/mobile-apps-api/pull/4305
- [ ] Updated Ophan to use latest version
- [ ] Updated story-packages to use latest version
- [x] Updated apple-news to use latest version <- https://github.com/guardian/apple-news/pull/730
- [ ] Checked for other downstream dependencies (perhaps via snyk or github search)
