### PR TITLE
Update `etag-caching` (fix unwanted `ExecutionContext`s on `Fetching`)

### DIFF
--- a/facia-json/src/test/scala/com/gu/facia/client/ApiClientSpec.scala
+++ b/facia-json/src/test/scala/com/gu/facia/client/ApiClientSpec.scala
@@ -18,13 +18,15 @@ import scala.util.hashing.MurmurHash3
 object FakeS3Fetching extends S3ByteArrayFetching with ResourcesHelper {
   private def pretendETagFor(bytes: Array[Byte]): String = MurmurHash3.bytesHash(bytes).toHexString
 
-  override def fetch(objectId: ObjectId)(implicit ec: ExecutionContext): Future[MissingOrETagged[Array[Byte]]] = Future {
+  override def fetch(objectId: ObjectId): Future[MissingOrETagged[Array[Byte]]] = Future.successful {
     slurpBytes(objectId.key).fold(Missing: MissingOrETagged[Array[Byte]]) { bytes =>
       ETaggedData(pretendETagFor(bytes), bytes)
     }
   }
 
-  override def fetchOnlyIfETagChanged(objectId: ObjectId, oldETag: String)(implicit ec: ExecutionContext): Future[Option[MissingOrETagged[Array[Byte]]]] = {
+  override def fetchOnlyIfETagChanged(objectId: ObjectId, oldETag: String): Future[Option[MissingOrETagged[Array[Byte]]]] = {
+    implicit val ec: ExecutionContext = ExecutionContext.parasitic
+
     fetch(objectId).map {
       case taggedData: ETaggedData[_] =>
         Option.unless(oldETag == taggedData.eTag)(taggedData) // simulate a Not-Modified response, if there's no change in ETag

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.14

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val capiVersion = "47.0.0"
-  val eTagCachingVersion = "7.0.0"
+  val eTagCachingVersion = "18.0.0"
 
   val eTagCachingS3Base = "com.gu.etag-caching" %% "aws-s3-base" % eTagCachingVersion
   val eTagCachingS3SupportForTesting = "com.gu.etag-caching" %% "aws-s3-sdk-v2" % eTagCachingVersion % Test


### PR DESCRIPTION
This unblocks facia-scala-client from using the latest versions of etag-caching- it was blocked because of the changes to the etag-caching `Fetching` interface in this PR:

* https://github.com/guardian/etag-caching/pull/111

Tested against `apple-news` with this PR:

* https://github.com/guardian/apple-news/pull/733

...you can see that only dep versions needed to be changed, there were no further code changes there.