### PR TITLE
Declare CustomSubnav types

### DIFF
--- a/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
@@ -88,6 +88,14 @@ object Palette {
   implicit val paletteFormat: OFormat[Palette] = Json.format[Palette]
 }
 
+case class Palettes(
+  light: Palette,
+  dark: Palette
+)
+object Palettes {
+  implicit val palettesFormat: OFormat[Palettes] = Json.format[Palettes]
+}
+
 sealed trait CustomSubnavFormat
 object CustomSubnavFormat {
   case object Large extends CustomSubnavFormat
@@ -112,7 +120,7 @@ case class CustomSubnav(
   links: List[SubnavLink],
   pages: List[TargetedPage],
   images: Option[List[SubnavImage]],
-  palette: Option[Palette],
+  palette: Option[Palettes],
   lastUpdated: DateTime,
   updatedBy: String,
   updatedEmail: String,

--- a/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
@@ -1,0 +1,68 @@
+package com.gu.facia.client.models
+
+import org.joda.time.DateTime
+
+case class SubnavLink(
+  linkText: String,
+  dotcomPath: String
+)
+
+sealed trait TargetedPageType
+object TargetedPageType {
+  case object Front extends TargetedPageType
+  case object Article extends TargetedPageType
+  case object HasTag extends TargetedPageType
+}
+
+case class TargetedPage(
+  `type`: TargetedPageType,
+  path: String
+)
+
+sealed trait ImageBreakpoint
+object ImageBreakpoint {
+  case object Mobile extends ImageBreakpoint
+  case object Tablet extends ImageBreakpoint
+  case object Web extends ImageBreakpoint
+}
+
+case class Image(
+  imageSrc: String,
+  breakpoint: ImageBreakpoint
+)
+
+case class CustomSubnavHeader(
+  headerText: String,
+  dotcomPath: Option[String],
+  copy: String
+)
+
+case class Palette(
+  text: Option[String],
+  header: Option[String],
+  link: Option[String]
+)
+
+sealed trait CustomSubnavFormat
+object CustomSubnavFormat {
+  case object Large extends CustomSubnavFormat
+  case object Compact extends CustomSubnavFormat
+}
+
+case class CustomSubnav(
+  id: String,
+  header: CustomSubnavHeader,
+  format: CustomSubnavFormat,
+  links: List[SubnavLink],
+  pages: List[TargetedPage],
+  images: List[Image],
+  palette: Palette,
+  lastUpdated: DateTime,
+  updatedBy: String,
+  updatedEmail: String,
+)
+
+case class CustomSubnavConfig(
+  live: List[CustomSubnav],
+  draft: List[CustomSubnav]
+)

--- a/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
@@ -62,12 +62,12 @@ object ImageBreakpoint {
   }
 }
 
-case class Image(
+case class SubnavImage(
   imageSrc: String,
   breakpoint: ImageBreakpoint
 )
-object Image {
-  implicit val imageFormat: OFormat[Image] = Json.format[Image]
+object SubnavImage {
+  implicit val subnavImageFormat: OFormat[SubnavImage] = Json.format[SubnavImage]
 }
 
 case class CustomSubnavHeader(
@@ -111,7 +111,7 @@ case class CustomSubnav(
   format: CustomSubnavFormat,
   links: List[SubnavLink],
   pages: List[TargetedPage],
-  images: Option[List[Image]],
+  images: Option[List[SubnavImage]],
   palette: Option[Palette],
   lastUpdated: DateTime,
   updatedBy: String,

--- a/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
+++ b/facia-json/src/main/scala/com/gu/facia/client/models/CustomSubnav.scala
@@ -1,52 +1,108 @@
 package com.gu.facia.client.models
 
 import org.joda.time.DateTime
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue, Json, OFormat}
 
 case class SubnavLink(
   linkText: String,
   dotcomPath: String
 )
+object SubnavLink {
+  implicit val subnavLinkFormat: OFormat[SubnavLink] = Json.format[SubnavLink]
+}
 
 sealed trait TargetedPageType
 object TargetedPageType {
   case object Front extends TargetedPageType
   case object Article extends TargetedPageType
   case object HasTag extends TargetedPageType
+  implicit val targetedPageTypeFormat: Format[TargetedPageType] = new Format[TargetedPageType] {
+    override def reads(json: JsValue): JsResult[TargetedPageType] = json match {
+      case JsString("front") => JsSuccess(Front)
+      case JsString("article") => JsSuccess(Article)
+      case JsString("hasTag") => JsSuccess(HasTag)
+      case _ => JsError("Invalid TargetedPageType")
+    }
+
+    override def writes(o: TargetedPageType): JsValue = o match {
+      case Front => JsString("front")
+      case Article => JsString("article")
+      case HasTag => JsString("hasTag")
+    }
+  }
 }
 
 case class TargetedPage(
   `type`: TargetedPageType,
   path: String
 )
+object TargetedPage {
+  implicit val targetedPageFormat: OFormat[TargetedPage] = Json.format[TargetedPage]
+}
 
 sealed trait ImageBreakpoint
 object ImageBreakpoint {
   case object Mobile extends ImageBreakpoint
   case object Tablet extends ImageBreakpoint
   case object Web extends ImageBreakpoint
+
+  implicit val imageBreakpointFormat: Format[ImageBreakpoint] = new Format[ImageBreakpoint] {
+    override def reads(json: JsValue): JsResult[ImageBreakpoint] = json match {
+      case JsString("mobile") => JsSuccess(Mobile)
+      case JsString("tablet") => JsSuccess(Tablet)
+      case JsString("web") => JsSuccess(Web)
+      case _ => JsError("Invalid ImageBreakpoint")
+    }
+
+    override def writes(o: ImageBreakpoint): JsValue = o match {
+      case Mobile => JsString("mobile")
+      case Tablet => JsString("tablet")
+      case Web => JsString("web")
+    }
+  }
 }
 
 case class Image(
   imageSrc: String,
   breakpoint: ImageBreakpoint
 )
+object Image {
+  implicit val imageFormat: OFormat[Image] = Json.format[Image]
+}
 
 case class CustomSubnavHeader(
   headerText: String,
   dotcomPath: Option[String],
   copy: String
 )
+object CustomSubnavHeader {
+  implicit val customSubnavHeaderFormat: OFormat[CustomSubnavHeader] = Json.format[CustomSubnavHeader]
+}
 
 case class Palette(
   text: Option[String],
   header: Option[String],
   link: Option[String]
 )
+object Palette {
+  implicit val paletteFormat: OFormat[Palette] = Json.format[Palette]
+}
 
 sealed trait CustomSubnavFormat
 object CustomSubnavFormat {
   case object Large extends CustomSubnavFormat
   case object Compact extends CustomSubnavFormat
+  implicit val customSubnavFormatFormat: Format[CustomSubnavFormat] = new Format[CustomSubnavFormat] {
+    override def reads(json: JsValue): JsResult[CustomSubnavFormat] = json match {
+      case JsString("large") => JsSuccess(Large)
+      case JsString("compact") => JsSuccess(Compact)
+      case _ => JsError("Invalid CustomSubnavFormat")
+    }
+    override def writes(o: CustomSubnavFormat): JsValue = o match {
+      case Large => JsString("large")
+      case Compact => JsString("compact")
+    }
+  }
 }
 
 case class CustomSubnav(
@@ -55,14 +111,23 @@ case class CustomSubnav(
   format: CustomSubnavFormat,
   links: List[SubnavLink],
   pages: List[TargetedPage],
-  images: List[Image],
-  palette: Palette,
+  images: Option[List[Image]],
+  palette: Option[Palette],
   lastUpdated: DateTime,
   updatedBy: String,
   updatedEmail: String,
 )
 
+object CustomSubnav {
+  import com.gu.facia.client.json.JodaFormat._
+  implicit val customSubnavFormat: OFormat[CustomSubnav] = Json.format[CustomSubnav]
+}
+
 case class CustomSubnavConfig(
   live: List[CustomSubnav],
   draft: List[CustomSubnav]
 )
+
+object CustomSubnavConfig {
+  implicit val customSubnavConfigFormat: OFormat[CustomSubnavConfig] = Json.format[CustomSubnavConfig]
+}


### PR DESCRIPTION
## What does this change?
In this PR I introduce the CustomSubnav types. Context: https://github.com/guardian/eventkit-mission/issues/65

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
None of these are relevant at this stage
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
None of these are relevant at this stage
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
None of these are relevant at this stage
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)

## Deployment
None of these are relevant at this stage
- ~~[ ] Updated facia-tool to use latest version~~
- ~~[ ] Updated frontend to use latest version~~
- ~~[ ] Updated MAPI to use latest version~~
- ~~[ ] Updated Ophan to use latest version~~
- ~~[ ] Updated story-packages to use latest version~~
- ~~[ ] Updated apple-news to use latest version~~
- ~~[ ] Checked for other downstream dependencies (perhaps via snyk or github search)~~
