### PR TITLE
Add .carabiner/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ target/
 .bloop/
 .metals/
 metals.sbt
+
+# Build tools & caches
+.carabiner/


### PR DESCRIPTION
## What does this change?

The `sbtrelease` plugin's `initialVcsChecks` step requires a clean Git working directory with no untracked files before publishing. This change allows the VCS checks to pass by excluding the temporary verification cache.

./carabiner is a transient cache directory that is automatically generated by sbt/setup-sbt during the workflow. It contains only temporary verification artifacts and binaries downloaded at runtime and is not intended for version control

## How to test?
- test the release workflow by releasing a replica of main (which does not have ./carabiner in .gitignore). Observe that the release fails due to untracked changes (https://github.com/guardian/facia-scala-client/actions/runs/31378239759)

- test the release workflow by releasing this branch (which does have ./carabiner in .gitignore). Observe that the release workflow runs successfully (https://github.com/guardian/facia-scala-client/actions/runs/31377995476)